### PR TITLE
feat: create Badge component, tests and stories

### DIFF
--- a/packages/osc-ui/src/components/Badge/Badge.spec.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.spec.tsx
@@ -9,10 +9,6 @@ describe('Badge component', () => {
             <Badge badgeName={badgeName} className={className} color={color} variant={variant} />
         );
 
-    test('renders a Span element for the Badge component', () => {
-        setup({ badgeName: 'Default' });
-        expect(screen.getByText('Default').nodeName).toBe('SPAN');
-    });
     test('renders a Badge with the correct name', () => {
         setup({ badgeName: 'Default' });
         expect(screen.getByText('Default')).toHaveTextContent('Default');

--- a/packages/osc-ui/src/components/Badge/Badge.spec.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.spec.tsx
@@ -15,7 +15,7 @@ describe('Badge component', () => {
     });
     test('renders a Badge with correct default classNames', () => {
         setup({ badgeName: 'Default' });
-        expect(screen.getByText('Default')).toHaveClass('chakra-badge o-badge');
+        expect(screen.getByText('Default')).toHaveClass('chakra-badge');
     });
     test('passes className to the Badge component', () => {
         setup({ badgeName: 'Default', className: 'test-class' });

--- a/packages/osc-ui/src/components/Badge/Badge.spec.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Badge } from './Badge';
+import { screen, render } from '@testing-library/react';
+import type { Props } from './Badge';
+
+describe('Badge component', () => {
+    const setup = ({ badgeName, className, color, variant }: Props) =>
+        render(
+            <Badge badgeName={badgeName} className={className} color={color} variant={variant} />
+        );
+
+    test('renders a Span element for the Badge component', () => {
+        setup({ badgeName: 'Default' });
+        expect(screen.getByText('Default').nodeName).toBe('SPAN');
+    });
+    test('renders a Badge with the correct name', () => {
+        setup({ badgeName: 'Default' });
+        expect(screen.getByText('Default')).toHaveTextContent('Default');
+    });
+    test('renders a Badge with correct default classNames', () => {
+        setup({ badgeName: 'Default' });
+        expect(screen.getByText('Default')).toHaveClass('chakra-badge o-badge');
+    });
+    test('passes className to the Badge component', () => {
+        setup({ badgeName: 'Default', className: 'test-class' });
+        expect(screen.getByText('Default')).toHaveClass('test-class');
+    });
+});

--- a/packages/osc-ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.stories.tsx
@@ -21,17 +21,22 @@ export default {
 
 const Template: Story<Props> = (args) => <Badge {...args} />;
 
+export const Primary = Template.bind({});
 export const Colour = Template.bind({});
 export const Variant = Template.bind({});
 
-Colour.args = {
-    color: 'blue',
+Primary.args = {
     badgeName: 'default',
+    color: 'blue',
     variant: 'subtle'
 };
 
+Colour.args = {
+    color: 'red',
+    ...Primary.args
+};
+
 Variant.args = {
-    variant: 'subtle',
-    badgeName: 'default',
-    color: 'blue'
+    variant: 'outline',
+    ...Primary.args
 };

--- a/packages/osc-ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+
+import type { Props } from './Badge';
+import { Badge } from './Badge';
+
+export default {
+    title: 'Badge',
+    component: Badge,
+    argTypes: {
+        color: {
+            options: ['green', 'red', 'blue'],
+            control: { type: 'inline-radio' }
+        },
+        variant: {
+            options: ['subtle', 'solid', 'outline'],
+            control: { type: 'inline-radio' }
+        }
+    }
+} as Meta;
+
+const Template: Story<Props> = (args) => <Badge {...args} />;
+
+export const Colour = Template.bind({});
+export const Variant = Template.bind({});
+
+Colour.args = {
+    color: 'blue',
+    badgeName: 'default',
+    variant: 'subtle'
+};
+
+Variant.args = {
+    variant: 'subtle',
+    badgeName: 'default',
+    color: 'blue'
+};

--- a/packages/osc-ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.stories.tsx
@@ -1,42 +1,85 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 
-import type { Props } from './Badge';
 import { Badge } from './Badge';
 
 export default {
     title: 'Badge',
-    component: Badge,
-    argTypes: {
-        color: {
-            options: ['green', 'red', 'blue'],
-            control: { type: 'inline-radio' }
-        },
-        variant: {
-            options: ['subtle', 'solid', 'outline'],
-            control: { type: 'inline-radio' }
-        }
-    }
+    component: Badge
 } as Meta;
 
-const Template: Story<Props> = (args) => <Badge {...args} />;
+const BadgeTemplate: Story = ({ items }) => {
+    return (
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+            {items.map((item, i) => (
+                <div key={i} style={{ margin: '1em' }}>
+                    <Badge {...item} />
+                </div>
+            ))}
+        </div>
+    );
+};
 
-export const Primary = Template.bind({});
-export const Colour = Template.bind({});
-export const Variant = Template.bind({});
+export const Primary = BadgeTemplate.bind({});
+export const SubtleBadge = BadgeTemplate.bind({});
+export const SolidBadge = BadgeTemplate.bind({});
+export const OutlineBadge = BadgeTemplate.bind({});
 
 Primary.args = {
-    badgeName: 'default',
-    color: 'blue',
-    variant: 'subtle'
+    items: [{ badgeName: 'Badge', color: 'blue', variant: 'subtle' }]
 };
 
-Colour.args = {
-    color: 'red',
-    ...Primary.args
+SubtleBadge.args = {
+    items: [
+        {
+            ...Primary.args.items[0],
+            color: 'red'
+        },
+        {
+            ...Primary.args.items[0],
+            color: 'blue'
+        },
+        {
+            ...Primary.args.items[0],
+            color: 'green'
+        }
+    ]
 };
-
-Variant.args = {
-    variant: 'outline',
-    ...Primary.args
+SolidBadge.args = {
+    items: [
+        {
+            ...Primary.args.items[0],
+            color: 'red',
+            variant: 'solid'
+        },
+        {
+            ...Primary.args.items[0],
+            color: 'blue',
+            variant: 'solid'
+        },
+        {
+            ...Primary.args.items[0],
+            color: 'green',
+            variant: 'solid'
+        }
+    ]
+};
+OutlineBadge.args = {
+    items: [
+        {
+            ...Primary.args.items[0],
+            color: 'red',
+            variant: 'outline'
+        },
+        {
+            ...Primary.args.items[0],
+            color: 'blue',
+            variant: 'outline'
+        },
+        {
+            ...Primary.args.items[0],
+            color: 'green',
+            variant: 'outline'
+        }
+    ]
 };

--- a/packages/osc-ui/src/components/Badge/Badge.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.tsx
@@ -2,8 +2,6 @@ import type { FC } from 'react';
 import React from 'react';
 import { Badge as ChakraBadge } from '@chakra-ui/react';
 
-import './badge.css';
-
 export interface Props {
     color?: string;
     variant?: string;

--- a/packages/osc-ui/src/components/Badge/Badge.tsx
+++ b/packages/osc-ui/src/components/Badge/Badge.tsx
@@ -1,0 +1,28 @@
+import type { FC } from 'react';
+import React from 'react';
+import { Badge as ChakraBadge } from '@chakra-ui/react';
+
+import './badge.css';
+
+export interface Props {
+    color?: string;
+    variant?: string;
+    fontSize?: string;
+    className?: string;
+    badgeName: string;
+}
+
+export const Badge: FC<Props> = (props: Props) => {
+    const { color, variant, fontSize, className, badgeName } = props;
+
+    return (
+        <ChakraBadge
+            className={className ? className : ''}
+            colorScheme={color}
+            variant={variant}
+            fontSize={`${fontSize}em`}
+        >
+            {badgeName}
+        </ChakraBadge>
+    );
+};

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -3,4 +3,5 @@ import './styles/dest/main.css';
 export { Header } from './components/Header/Header';
 export { Footer } from './components/Footer/Footer';
 export { Tabs } from './components/Tabs/Tabs';
+export { Badge } from './components/Badge/Badge';
 export { Trustpilot } from './components/Trustpilot/Trustpilot';


### PR DESCRIPTION
Closes #270 

## 📝 Description

Add Chakra Badge component along with Stories and tests to OSC UI.

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

New Badge component

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Unsure how to test the additional props such as `variant` and `colorScheme` as these just create a new random CSS class so can't really test this. 

I think one test may be to at least see if it's pulling the props in correctly - using something like `hasBeenCalledWith` - but there doesn't seem to be any easy way of doing this in terms of actually spying on a component. 

There is a thread here that shows how to do it with Jest but this doesn't seem to work with Vitest:
https://stackoverflow.com/questions/58623666/how-to-test-if-a-component-is-rendered-with-the-right-props-when-using-react-tes
Aware this isn't the recommended way anyway as it's not testing something actually rendered to the screen, but in this case I don't think it's possible. 
