### PR TITLE
Feature/sitemap

### DIFF
--- a/packages/osc-ecommerce/app/queries/sanity/allPageSlugs.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/allPageSlugs.ts
@@ -1,0 +1,10 @@
+import groq from 'groq';
+
+export const ALL_PAGE_SLUGS = groq`
+    *[slug != null || store.slug != null] {
+        _id,
+        _type,
+        _updatedAt,
+        "slug": coalesce(slug.current, store.slug.current)
+    }
+`;

--- a/packages/osc-ecommerce/app/routes/robots[.]txt.ts
+++ b/packages/osc-ecommerce/app/routes/robots[.]txt.ts
@@ -1,0 +1,20 @@
+import type { LoaderFunction } from '@remix-run/node';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const url = new URL(request?.url);
+
+    // The alignment looks a bit funky as indenting it here causes the indentation to be included in the returned file.
+    // Which makes the robots.txt invalid.
+    const robots = `
+User-agent: *
+
+Sitemap: ${url.origin}/sitemap.xml
+    `.trim();
+
+    return new Response(robots, {
+        status: 200,
+        headers: {
+            'Content-Type': 'text/plain; charset=utf-8'
+        }
+    });
+};

--- a/packages/osc-ecommerce/app/routes/robots[.]txt.ts
+++ b/packages/osc-ecommerce/app/routes/robots[.]txt.ts
@@ -2,13 +2,16 @@ import type { LoaderFunction } from '@remix-run/node';
 
 export const loader: LoaderFunction = async ({ request }) => {
     const url = new URL(request?.url);
+    // The request on Fly seems to return http as the protocol so we're forcing it into https
+    const protocol = url.protocol === 'http:' ? 'https:' : url.protocol;
+    const host = url.host;
 
     // The alignment looks a bit funky as indenting it here causes the indentation to be included in the returned file.
     // Which makes the robots.txt invalid.
     const robots = `
 User-agent: *
 
-Sitemap: ${url.origin}/sitemap.xml
+Sitemap: ${protocol}//${host}/sitemap.xml
     `.trim();
 
     return new Response(robots, {

--- a/packages/osc-ecommerce/app/routes/sitemap[.]xml.ts
+++ b/packages/osc-ecommerce/app/routes/sitemap[.]xml.ts
@@ -1,0 +1,61 @@
+import type { LoaderFunction } from '@remix-run/node';
+import { getClient } from '~/lib/sanity/getClient.server';
+import { buildUrlPath, excludeDrafts } from '~/models/sanity.server';
+import { ALL_PAGE_SLUGS } from '~/queries/sanity/allPageSlugs';
+
+interface SanityEntry {
+    _id: string;
+    _type: string;
+    _updatedAt: string;
+    slug: string;
+}
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const url = new URL(request?.url);
+    // Query all of the documents in Sanity that have a slug (indicating that it is a page)
+    const querySanityDataset: SanityEntry[] = await getClient()
+        .fetch(ALL_PAGE_SLUGS)
+        .catch((error) => {
+            throw new Response(error, {
+                status: 500
+            });
+        });
+
+    // Template out the markup for each individual entry
+    const sitemapEntry = (path: SanityEntry['slug'], lastmod: SanityEntry['_updatedAt']) => {
+        return `
+            <url>
+                <loc>${url.origin}${path}</loc>
+                <lastmod>${lastmod}</lastmod>
+            </url>
+        `.trim();
+    };
+
+    const filterMapEntries = querySanityDataset
+        .filter((entry: SanityEntry) => excludeDrafts(entry))
+        .map((entry: SanityEntry) => {
+            const path = buildUrlPath({
+                type: entry._type,
+                url,
+                slug: entry.slug
+            });
+
+            return sitemapEntry(path, entry._updatedAt);
+        })
+        .join('');
+
+    // Template out the markup for the doctype and urlset
+    const sitemap = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            ${filterMapEntries}
+        </urlset>
+    `.trim();
+
+    return new Response(sitemap, {
+        status: 200,
+        headers: {
+            'Content-Type': 'application/xml'
+        }
+    });
+};

--- a/packages/osc-ecommerce/app/routes/sitemap[.]xml.ts
+++ b/packages/osc-ecommerce/app/routes/sitemap[.]xml.ts
@@ -12,6 +12,10 @@ interface SanityEntry {
 
 export const loader: LoaderFunction = async ({ request }) => {
     const url = new URL(request?.url);
+    // The request on Fly seems to return http as the protocol so we're forcing it into https
+    const protocol = url.protocol === 'http:' ? 'https:' : url.protocol;
+    const host = url.host;
+
     // Query all of the documents in Sanity that have a slug (indicating that it is a page)
     const querySanityDataset: SanityEntry[] = await getClient()
         .fetch(ALL_PAGE_SLUGS)
@@ -25,7 +29,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     const sitemapEntry = (path: SanityEntry['slug'], lastmod: SanityEntry['_updatedAt']) => {
         return `
             <url>
-                <loc>${url.origin}${path}</loc>
+                <loc>${protocol}//${host}${path}</loc>
                 <lastmod>${lastmod}</lastmod>
             </url>
         `.trim();


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #154 

## 📝 Description

I've added a `sitemap[.]xml.ts` and `robots[.]txt.ts` file to the routes directory in `osc-ecommerce`. Unlike normal routes these are "resource routes" so they won't export a default function and have a different headers response. See: https://remix.run/docs/en/v1/guides/resource-routes

You'll see in that link there are a couple of examples on how to escape urls to include the suffix (.xml for example). I've chosen the `[.]something.ts` route as we already have a file `routes/resources/manifest[.]webmanifest.ts` using that convention.

The sitemap.xml essentially queries Sanity for everything that has a `slug` field, filters out any drafts and maps over the array creating an entry for each one.

The robots.txt is simply just some text

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

Adds a /sitemap.xml and /robots.txt route to `osc-ecommerce`

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information