### PR TITLE
Feature/tag component

### DIFF
--- a/packages/osc-ui/src/components/Tag/Tag.spec.tsx
+++ b/packages/osc-ui/src/components/Tag/Tag.spec.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { Tag } from './Tag';
+import { screen, render } from '@testing-library/react';
+import type { Props } from './Tag';
+
+import { SmallAddIcon } from '@chakra-ui/icons';
+import { Avatar as ChakraAvatar } from '@chakra-ui/react';
+
+// Get children nodes from span
+const getChildrenNodes = (container) => container.querySelectorAll('span')[0].childNodes;
+
+describe('Tag component', () => {
+    const setup = ({
+        tagName,
+        className,
+        customElement,
+        icon,
+        iconPosition,
+        theme: { backgroundColor, color }
+    }: Props) =>
+        render(
+            <Tag
+                tagName={tagName}
+                className={className}
+                customElement={customElement}
+                icon={icon}
+                iconPosition={iconPosition}
+                theme={{ backgroundColor: backgroundColor, color: color }}
+            />
+        );
+    test('renders a tag with the correct name', () => {
+        setup({ tagName: 'Default', theme: { backgroundColor: 'primary', color: 'secondary' } });
+        expect(screen.getByText('Default')).toHaveTextContent('Default');
+    });
+    test('passes correct classNames to Tag component', () => {
+        setup({
+            tagName: 'Default',
+            theme: { backgroundColor: 'primary', color: 'secondary' },
+            className: 'test-class-1 test-class-2'
+        });
+        expect(screen.getByText('Default').closest('div > span')).toHaveClass(
+            'test-class-1 test-class-2'
+        );
+    });
+    test('renders an svg when passed an icon and icon position', () => {
+        const { container } = setup({
+            tagName: 'Default',
+            iconPosition: 'left',
+            icon: SmallAddIcon,
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+        expect(container.querySelectorAll('svg').length).toBe(1);
+    });
+    test('renders an svg to the left of the text when icon position is set to "left"', () => {
+        const { container } = setup({
+            tagName: 'Default',
+            iconPosition: 'left',
+            icon: SmallAddIcon,
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+
+        const result = getChildrenNodes(container);
+        // Check whether first child is an SVG
+        expect(result[0].nodeName).toBe('SVG');
+    });
+    test('renders an svg to the right of the text when icon position is set to "right"', () => {
+        const { container } = setup({
+            tagName: 'Default',
+            iconPosition: 'right',
+            icon: SmallAddIcon,
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+        const result = getChildrenNodes(container);
+        // Check whether second child is an SVG
+        expect(result[1].nodeName).toBe('SVG');
+    });
+    test('renders an svg to the left of the text as default when icon position is not set', () => {
+        const { container } = setup({
+            tagName: 'Default',
+            icon: SmallAddIcon,
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+        const result = getChildrenNodes(container);
+        expect(result[0].nodeName).toBe('SVG');
+    });
+    test('renders an svg to left position as default if "icon" prop is passed in without an "iconPosition" prop', () => {
+        const { container } = setup({
+            tagName: 'Default',
+            icon: SmallAddIcon,
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+        const result = getChildrenNodes(container);
+        expect(result[0].nodeName).toBe('SVG');
+    });
+    test('fails to render an svg if "icon" prop is not passed in', () => {
+        const { container } = setup({
+            tagName: 'Default',
+            iconPosition: 'right',
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+        expect(container.querySelectorAll('svg').length).toBe(0);
+    });
+    test('renders an Avatar component when passed in as a custom element', async () => {
+        const { container } = setup({
+            tagName: 'Default',
+            customElement: <ChakraAvatar src="randomSource.com" name="Segun Adebayo" />,
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+        const result = container.querySelectorAll('span')[1];
+        expect(result).toHaveClass('chakra-avatar');
+    });
+    test('returns an empty DOM Element if "custom element" and an "icon" are both passed in', () => {
+        const { container } = setup({
+            tagName: 'Default',
+            icon: SmallAddIcon,
+            customElement: 'some custom element',
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        });
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/packages/osc-ui/src/components/Tag/Tag.stories.tsx
+++ b/packages/osc-ui/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+import { SmallAddIcon } from '@chakra-ui/icons';
+import { Avatar as ChakraAvatar } from '@chakra-ui/react';
+
+import { Tag } from './Tag';
+
+export default {
+    title: 'Tag',
+    component: Tag
+} as Meta;
+
+const TagTemplate: Story = ({ items }) => {
+    return (
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+            {items.map((item, i) => (
+                <div key={i} style={{ margin: '1em' }}>
+                    <Tag {...item} />
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export const Primary = TagTemplate.bind({});
+export const WithLeftIcon = TagTemplate.bind({});
+export const WithRightIcon = TagTemplate.bind({});
+export const WithCustomElement = TagTemplate.bind({});
+
+Primary.args = {
+    items: [{ tagName: 'Tag', theme: { backgroundColor: 'primary', color: 'secondary' } }]
+};
+WithLeftIcon.args = {
+    items: [
+        {
+            icon: SmallAddIcon,
+            iconPosition: 'left',
+            tagName: 'Tag with Left Icon',
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        }
+    ]
+};
+WithRightIcon.args = {
+    items: [
+        {
+            icon: SmallAddIcon,
+            iconPosition: 'right',
+            tagName: 'Tag with Right Icon',
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        }
+    ]
+};
+
+WithCustomElement.args = {
+    items: [
+        {
+            className: 'u-p-15',
+            tagName: 'Tag with Custom Element',
+            iconPosition: 'left',
+            customElement: <ChakraAvatar src="https://bit.ly/sage-adebayo" name="Segun Adebayo" />,
+            theme: { backgroundColor: 'primary', color: 'secondary' }
+        }
+    ]
+};

--- a/packages/osc-ui/src/components/Tag/Tag.tsx
+++ b/packages/osc-ui/src/components/Tag/Tag.tsx
@@ -1,0 +1,57 @@
+import type { FC } from 'react';
+import React from 'react';
+import {
+    Tag as ChakraTag,
+    TagLabel as ChakraTagLabel,
+    TagLeftIcon as ChakraTagLeftIcon,
+    TagRightIcon as ChakraTagRightIcon
+} from '@chakra-ui/react';
+
+import { themeOptions } from '../../constants';
+import type { ThemeProps } from '../../interfaces';
+
+export interface Props {
+    theme: ThemeProps;
+    className?: string;
+    customElement?: any;
+    icon?: any;
+    iconPosition?: 'left' | 'right';
+    tagName: string;
+}
+
+export const Tag: FC<Props> = (props: Props) => {
+    const {
+        className,
+        customElement,
+        icon,
+        iconPosition = 'left',
+        tagName,
+        theme: { backgroundColor = themeOptions.PRIMARY, color = themeOptions.SECONDARY }
+    } = props;
+
+    if (icon && customElement) {
+        console.error(
+            'ERROR RENDERING TAG - Can not render icon and custom element together, please choose one'
+        );
+        return;
+    }
+
+    let leftIcon,
+        rightIcon = null;
+
+    if (icon) {
+        if (iconPosition === 'left') leftIcon = <ChakraTagLeftIcon as={icon} />;
+        if (iconPosition === 'right') rightIcon = <ChakraTagRightIcon as={icon} />;
+    } else if (customElement) {
+        if (iconPosition === 'left') leftIcon = customElement;
+        if (iconPosition === 'right') rightIcon = customElement;
+    }
+
+    return (
+        <ChakraTag backgroundColor={backgroundColor} className={className ? className : ''}>
+            {leftIcon}
+            <ChakraTagLabel color={color}>{tagName}</ChakraTagLabel>
+            {rightIcon}
+        </ChakraTag>
+    );
+};

--- a/packages/osc-ui/src/constants.js
+++ b/packages/osc-ui/src/constants.js
@@ -1,0 +1,6 @@
+export const themeOptions = {
+    PRIMARY: 'primary',
+    SECONDARY: 'secondary',
+    TERTIARY: 'tertiary',
+    QUATERNARY: 'quaternary'
+};

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -5,3 +5,4 @@ export { Tabs } from './components/Tabs/Tabs';
 export { Badge } from './components/Badge/Badge';
 export { Trustpilot } from './components/Trustpilot/Trustpilot';
 export { Carousel } from './components/Carousel/Carousel';
+export { Tag } from './components/Tag/Tag';

--- a/packages/osc-ui/src/interfaces.ts
+++ b/packages/osc-ui/src/interfaces.ts
@@ -1,0 +1,4 @@
+export interface ThemeProps {
+    backgroundColor?: 'primary' | 'secondary' | 'tertiary' | 'quaternary';
+    color?: 'primary' | 'secondary' | 'tertiary' | 'quaternary';
+}


### PR DESCRIPTION
* Closes #273 
* Closes #274 
* Closes #275 

## 📝 Description

Create Chakra Tag component, tests and stories. 

The Tag enables the usage of an Icon or a custom element that can be positioned to the left or right.

Basic:
<img width="58" alt="Screenshot 2022-10-25 at 15 52 42" src="https://user-images.githubusercontent.com/36510083/197807699-2890d336-43c6-4af6-9fbe-e4f6eead56af.png">

Icon to the left:
<img width="176" alt="Screenshot 2022-10-25 at 15 52 46" src="https://user-images.githubusercontent.com/36510083/197807742-5f0df5fd-8edf-4a9b-9665-251fe5df2fa9.png">

Icon to the right:
<img width="175" alt="Screenshot 2022-10-25 at 15 52 50" src="https://user-images.githubusercontent.com/36510083/197807797-38b310f8-2e86-466a-a407-7088f076ab1a.png">

Custom Element (Chakra Avatar component):
<img width="258" alt="Screenshot 2022-10-25 at 15 52 56" src="https://user-images.githubusercontent.com/36510083/197807888-3b095e9f-0cf4-438c-bfe6-f81507847f1e.png">


## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

Adds Tag Component to the OSC-UI library

## 📝 Additional Information

