### PR TITLE
Fix/remove npm init test scripts

### DIFF
--- a/packages/osc-api-auth/package.json
+++ b/packages/osc-api-auth/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"There is no spoon\" && exit 0",
     "dev": "nodemon './src/index.ts' --exec 'ts-node' ./src/index.ts -e ts,graphql"
   },
   "keywords": [],

--- a/packages/osc-api-gateway/package.json
+++ b/packages/osc-api-gateway/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"There is no spoon\" && exit 0",
     "dev": "nodemon './src/index.ts' --exec 'ts-node' ./src/index.ts -e ts,graphql"
   },
   "keywords": [],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
Removed error caused by `npm init` default test script (`exit 1`)

## ⛳️ Current behavior (updates)
Vitest catches an error - just npm init default test script

## 🚀 New behavior

`npm run test` will no longer `exit 1`

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
