### PR TITLE
fix: fixed pre-commit error message if unstaged files contain linting…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "stylelint": "npx stylelint \"**/*.scss\" --allow-empty-input --formatter verbose",
     "stylelint-and-fix": "npx stylelint \"**/*.scss\" --allow-empty-input --fix ",
     "lint": "DEBUG=eslint:cli-engine eslint --cache --cache-location ./node_modules/.cache/eslint  -c ./.eslintrc.js --max-warnings 0 --ext .ts,.tsx,.js,.jsx --no-error-on-unmatched-pattern .",
-    "lint-and-fix": "eslint -c ./.eslintrc.js --cache --cache-location ./node_modules/.cache/eslint  --max-warnings 0 --ext .ts,.tsx,.js,.jsx --fix --no-error-on-unmatched-pattern .",
+    "lint-and-fix": "eslint -c ./.eslintrc.js --cache --cache-location ./node_modules/.cache/eslint  --max-warnings 0 --ext .ts,.tsx,.js,.jsx --fix --no-error-on-unmatched-pattern",
     "prettier-format": "prettier --config .prettierrc.json '*.{js,jsx,ts,tsx,json,scss}' '**/*.{js,jsx,ts,tsx,json,scss}' --write",
     "build-storybook": "cross-env NODE_ENV=production lerna run build:css && build-storybook",
     "storybook": "concurrently \"npm run dev:osc-ui --parallel\" \"start-storybook -p 6006\"",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Allows comitting of stages files if unstaged files have linting errors (as long as staged files pass)

## ⛳️ Current behavior (updates)

Regardless of selected stage files, if ANY changes contain linting errors, such as unused vars, pre-commit will fail.

## 🚀 New behavior

`lint-and-fix` script will only check staged files, and not unstaged changes. Your half finished functions are now safe.

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
`lint-staged` automatically appends staged files to the command run. We were manually telling the `eslint` to check all files via `.`.

See [https://github.com/okonet/lint-staged/issues/869](url) for details
