### PR TITLE
Feature/breadcrumbs component

### DIFF
--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Breadcrumb } from './Breadcrumb';
+import { screen, render } from '@testing-library/react';
+import type { Props } from './Breadcrumb';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom/extend-expect';
+import { ArrowRightIcon } from '@chakra-ui/icons';
+
+describe('Breadcrumb component', () => {
+    const setup = ({ className, matches, separator }: Props) =>
+        render(<Breadcrumb className={className} matches={matches} separator={separator} />, {
+            wrapper: MemoryRouter
+        });
+
+    const links = [
+        { pathname: '/courses', title: 'courses' },
+        { pathname: '/courses/biology', title: 'biology' },
+        { pathname: '/courses/biology/module-1', title: 'module 1' }
+    ];
+
+    test('renders breadcrumbs with the correct titles', () => {
+        setup({
+            matches: links,
+            separator: '/'
+        });
+        links.forEach((link) => {
+            expect(screen.getByText(`${link.title}`)).toHaveTextContent(`${link.title}`);
+        });
+    });
+    test('renders breadcrumbs with anchor tag and correct pathnames', () => {
+        setup({
+            matches: links,
+            separator: '/'
+        });
+        expect(screen.getByRole('link', { name: `${links[0].title}` })).toHaveAttribute(
+            'href',
+            `${links[0].pathname}`
+        );
+        expect(screen.getByRole('link', { name: `${links[0].title}` }).nodeName).toBe('A');
+    });
+    test('renders a breadcrumb without an anchor tag or pathname when it is the last breadcrumb', () => {
+        setup({
+            matches: links,
+            separator: '/'
+        });
+        expect(screen.getByText(`${links[2].title}`)).not.toHaveAttribute(
+            'href',
+            `${links[2].pathname}`
+        );
+        expect(screen.getByText(`${links[2].title}`).nodeName).not.toBe('A');
+    });
+    test('renders a string separator that is passed in', () => {
+        setup({
+            matches: links,
+            separator: '/'
+        });
+        expect(screen.getAllByRole('presentation')[0]).toHaveTextContent('/');
+        expect(screen.getAllByRole('presentation')[1]).toHaveTextContent('/');
+    });
+    test('renders an icon separator that is passed in', () => {
+        setup({
+            matches: links,
+            separator: <ArrowRightIcon />
+        });
+        expect(screen.getAllByRole('presentation')[0].childNodes[0].nodeName).toBe('SVG');
+        expect(screen.getAllByRole('presentation')[1].childNodes[0].nodeName).toBe('SVG');
+    });
+});

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+import { ChevronRightIcon } from '@chakra-ui/icons';
+
+import { Breadcrumb } from './Breadcrumb';
+import type { Props } from './Breadcrumb';
+
+export default {
+    title: 'Breadcrumb',
+    component: Breadcrumb
+} as Meta;
+
+const Template: Story<Props> = (args) => <Breadcrumb {...args} />;
+
+export const Primary = Template.bind({});
+export const CustomIcon = Template.bind({});
+
+Primary.args = {
+    matches: [
+        { pathname: '/courses', title: 'courses' },
+        { pathname: '/courses/biology', title: 'biology' },
+        { pathname: '/courses/biology/module-1', title: 'module 1' }
+    ],
+    separator: '/'
+};
+
+CustomIcon.args = {
+    matches: [
+        { pathname: '/qualifications', title: 'qualifications' },
+        { pathname: '/qualifications/a-levels', title: 'a-levels' },
+        { pathname: '/qualifications/biology/web-development', title: 'web development' },
+        {
+            pathname: '/qualifications/biology/web-development/course-content',
+            title: 'course content'
+        }
+    ],
+    separator: <ChevronRightIcon />
+};

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { FC } from 'react';
+import {
+    Breadcrumb as ChakraBreadcrumb,
+    BreadcrumbItem as ChakraBreadcrumbItem,
+    BreadcrumbLink as ChakraBreadcrumbLink
+} from '@chakra-ui/react';
+import { Link } from '@remix-run/react';
+
+interface Match {
+    pathname: string;
+    title: string;
+}
+
+export interface Props {
+    className?: string;
+    matches: Match[];
+    separator: any;
+}
+
+export const Breadcrumb: FC<Props> = (props: Props) => {
+    const { className, matches, separator } = props;
+
+    return (
+        <ChakraBreadcrumb className={className ? className : ''} separator={separator}>
+            {matches.map((match, idx) => {
+                return (
+                    <ChakraBreadcrumbItem
+                        key={idx}
+                        isCurrentPage={matches.length === idx + 1 ? true : false}
+                    >
+                        <ChakraBreadcrumbLink as={Link} to={match.pathname}>
+                            {match.title}
+                        </ChakraBreadcrumbLink>
+                    </ChakraBreadcrumbItem>
+                );
+            })}
+        </ChakraBreadcrumb>
+    );
+};

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { FC } from 'react';
-import './breadcrumb.css';
+import './breadcrumb.scss';
 
 import {
     Breadcrumb as ChakraBreadcrumb,

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
@@ -23,18 +23,18 @@ export interface Props {
 export const Breadcrumb: FC<Props> = (props: Props) => {
     const { className, matches, separator } = props;
 
-    const shouldRenderALinkOrNot = (matches, match, idx) => {
+    const shouldRenderALinkOrNot = (matches, match, index) => {
         let breadCrumb;
-        if (matches.length === idx + 1) {
+        if (matches.length === index + 1) {
             // If it is the current page then don't add Link, and set to 'isCurrentPage'
             breadCrumb = (
-                <ChakraBreadcrumbItem key={idx} isCurrentPage className="c-breadcrumb__item">
+                <ChakraBreadcrumbItem key={index} isCurrentPage className="c-breadcrumb__item">
                     <ChakraBreadcrumbLink>{match.title}</ChakraBreadcrumbLink>
                 </ChakraBreadcrumbItem>
             );
         } else {
             breadCrumb = (
-                <ChakraBreadcrumbItem key={idx} className="c-breadcrumb__item">
+                <ChakraBreadcrumbItem key={index} className="c-breadcrumb__item">
                     <ChakraBreadcrumbLink as={Link} to={match.pathname}>
                         {match.title}
                     </ChakraBreadcrumbLink>
@@ -49,8 +49,8 @@ export const Breadcrumb: FC<Props> = (props: Props) => {
             className={`c-breadcrumb ${className ? className : ''}`}
             separator={separator}
         >
-            {matches.map((match, idx) => {
-                let chakraBreadCrumb = shouldRenderALinkOrNot(matches, match, idx);
+            {matches.map((match, index) => {
+                let chakraBreadCrumb = shouldRenderALinkOrNot(matches, match, index);
                 return chakraBreadCrumb;
             })}
         </ChakraBreadcrumb>

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import type { FC } from 'react';
+import './breadcrumb.css';
+
 import {
     Breadcrumb as ChakraBreadcrumb,
     BreadcrumbItem as ChakraBreadcrumbItem,
@@ -21,19 +23,35 @@ export interface Props {
 export const Breadcrumb: FC<Props> = (props: Props) => {
     const { className, matches, separator } = props;
 
+    const shouldRenderALinkOrNot = (matches, match, idx) => {
+        let breadCrumb;
+        if (matches.length === idx + 1) {
+            // If it is the current page then don't add Link, and set to 'isCurrentPage'
+            breadCrumb = (
+                <ChakraBreadcrumbItem key={idx} isCurrentPage className="c-breadcrumb__item">
+                    <ChakraBreadcrumbLink>{match.title}</ChakraBreadcrumbLink>
+                </ChakraBreadcrumbItem>
+            );
+        } else {
+            breadCrumb = (
+                <ChakraBreadcrumbItem key={idx} className="c-breadcrumb__item">
+                    <ChakraBreadcrumbLink as={Link} to={match.pathname}>
+                        {match.title}
+                    </ChakraBreadcrumbLink>
+                </ChakraBreadcrumbItem>
+            );
+        }
+        return breadCrumb;
+    };
+
     return (
-        <ChakraBreadcrumb className={className ? className : ''} separator={separator}>
+        <ChakraBreadcrumb
+            className={`c-breadcrumb ${className ? className : ''}`}
+            separator={separator}
+        >
             {matches.map((match, idx) => {
-                return (
-                    <ChakraBreadcrumbItem
-                        key={idx}
-                        isCurrentPage={matches.length === idx + 1 ? true : false}
-                    >
-                        <ChakraBreadcrumbLink as={Link} to={match.pathname}>
-                            {match.title}
-                        </ChakraBreadcrumbLink>
-                    </ChakraBreadcrumbItem>
-                );
+                let chakraBreadCrumb = shouldRenderALinkOrNot(matches, match, idx);
+                return chakraBreadCrumb;
             })}
         </ChakraBreadcrumb>
     );

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.tsx
@@ -24,16 +24,16 @@ export const Breadcrumb: FC<Props> = (props: Props) => {
     const { className, matches, separator } = props;
 
     const shouldRenderALinkOrNot = (matches, match, index) => {
-        let breadCrumb;
+        let breadcrumbItem;
         if (matches.length === index + 1) {
             // If it is the current page then don't add Link, and set to 'isCurrentPage'
-            breadCrumb = (
+            breadcrumbItem = (
                 <ChakraBreadcrumbItem key={index} isCurrentPage className="c-breadcrumb__item">
                     <ChakraBreadcrumbLink>{match.title}</ChakraBreadcrumbLink>
                 </ChakraBreadcrumbItem>
             );
         } else {
-            breadCrumb = (
+            breadcrumbItem = (
                 <ChakraBreadcrumbItem key={index} className="c-breadcrumb__item">
                     <ChakraBreadcrumbLink as={Link} to={match.pathname}>
                         {match.title}
@@ -41,7 +41,7 @@ export const Breadcrumb: FC<Props> = (props: Props) => {
                 </ChakraBreadcrumbItem>
             );
         }
-        return breadCrumb;
+        return breadcrumbItem;
     };
 
     return (
@@ -50,8 +50,8 @@ export const Breadcrumb: FC<Props> = (props: Props) => {
             separator={separator}
         >
             {matches.map((match, index) => {
-                let chakraBreadCrumb = shouldRenderALinkOrNot(matches, match, index);
-                return chakraBreadCrumb;
+                const chakraBreadcrumbItem = shouldRenderALinkOrNot(matches, match, index);
+                return chakraBreadcrumbItem;
             })}
         </ChakraBreadcrumb>
     );

--- a/packages/osc-ui/src/components/Breadcrumb/breadcrumb.scss
+++ b/packages/osc-ui/src/components/Breadcrumb/breadcrumb.scss
@@ -1,0 +1,12 @@
+.c-breadcrumb {
+    &__item {
+        &:hover {
+            // standard link hover styles
+            [aria-current="page"] {
+                // non-standard link hover styles
+                text-decoration: none;
+                cursor: text;
+            }
+        }
+    }
+}

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -6,3 +6,4 @@ export { Badge } from './components/Badge/Badge';
 export { Trustpilot } from './components/Trustpilot/Trustpilot';
 export { Carousel } from './components/Carousel/Carousel';
 export { Tag } from './components/Tag/Tag';
+export { Breadcrumb } from './components/Breadcrumb/Breadcrumb';


### PR DESCRIPTION
* Closes #449 
* Closes #450 

## 📝 Description

Create Chakra Tag component, tests and stories. 

## ⛳️ Current behaviour (updates)

N/A

## 🚀 New behaviour

Adds Breadcrumb Component to the OSC-UI library

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

The implementation relies on receiving a match `pathname` and `title` as part of a `matches` props. The Remix docs give an example of how to use breadcrumbs with the `useMatches` hook and `handle` function.
(See 'useMatches' section https://remix.run/docs/en/v1/api/remix)
I've attached a small screen recording demonstrating how this could be achieved. It's slightly different than they suggest - which is to pass the link in directly to the handle function. This approach just passes a title to the handle function which can then get picked up in the `root.tsx`. 
I believe the point of this approach is that it gives flexibility on whether or not to have breadcrumbs on any given route. 
To work it will require this `handle` function to be exported on any route where we would want breadcrumbs.

The screen recording will hopefully make more sense of this explanation..! 


https://user-images.githubusercontent.com/36510083/199284395-566c175d-03a9-4ba0-9f2a-cbb62a4d3575.mp4

