### PR TITLE
Feature/redirects(restored)

### DIFF
--- a/packages/osc-ecommerce/__test__/setup-test-env.ts
+++ b/packages/osc-ecommerce/__test__/setup-test-env.ts
@@ -2,3 +2,22 @@ import { installGlobals } from '@remix-run/node';
 import '@testing-library/jest-dom/extend-expect';
 
 installGlobals();
+
+expect.extend({
+    arrayIncludesSome: (received: any[], expected: any[]) => {
+        const someExist = expected.some((value: any) => {
+            return received.includes(value);
+        });
+
+        if (!someExist) {
+            return {
+                message: () => `expected ${received} to include ${expected}`,
+                pass: false
+            };
+        }
+
+        return {
+            pass: true
+        };
+    }
+});

--- a/packages/osc-ecommerce/app/models/sanity-server.spec.ts
+++ b/packages/osc-ecommerce/app/models/sanity-server.spec.ts
@@ -1,131 +1,176 @@
-import getPageData from './sanity.server';
+import getPageData, { buildUrlPath, shouldRedirect } from './sanity.server';
 // eslint-disable-next-line jest/no-mocks-import -- no clear way to intercept a request form remix so we want to use this as a function rather than a true mock -- perhaps this could be done better?
 import { mockHomeRequest } from '../../__mocks__/requests';
 import { HOME_QUERY } from '~/queries/sanity/home';
 import { COLLECTION_QUERY } from '~/queries/sanity/collection';
 import { PRODUCT_QUERY } from '~/queries/sanity/product';
 
-test('returns data from a query to the homepage', async () => {
-    const data = await getPageData({
-        request: mockHomeRequest('http://localhost/'),
-        query: HOME_QUERY
+describe("Tests that getPageData doesn't hang", () => {
+    test('returns data from a query to the homepage', async () => {
+        const data = await getPageData({
+            request: mockHomeRequest('http://localhost/'),
+            query: HOME_QUERY
+        });
+
+        if (!data) throw Error('Request failed');
+        const { page, isPreview } = data;
+
+        expect(page?._id).toBe('home');
+        expect(isPreview).toBe(false);
     });
 
-    if (!data) throw Error('Request failed');
-    const { page, isPreview } = data;
+    test('returns store data from a query to a collection', async () => {
+        const data = await getPageData({
+            request: mockHomeRequest('http://localhost/collections/accounting'),
+            params: { slug: 'accounting' },
+            query: COLLECTION_QUERY
+        });
 
-    expect(page?._id).toBe('home');
-    expect(isPreview).toBe(false);
+        if (!data) throw Error('Request failed');
+        const { page } = data;
+
+        expect(page?._type).toBe('collection');
+
+        // Expect these key properties
+        expect(page.store).toEqual(
+            expect.objectContaining({
+                descriptionHtml: expect.any(String),
+                gid: expect.any(String),
+                id: expect.any(Number),
+                isDeleted: expect.any(Boolean),
+                slug: {
+                    _type: 'slug',
+                    current: 'accounting'
+                },
+                title: expect.any(String)
+            })
+        );
+    });
+
+    test('returns store data from a query to a product', async () => {
+        const data = await getPageData({
+            request: mockHomeRequest('http://localhost/products/a-level-maths'),
+            params: { slug: 'a-level-maths' },
+            query: PRODUCT_QUERY
+        });
+
+        if (!data) throw Error('Request failed');
+        const { page } = data;
+
+        expect(page?._type).toBe('product');
+
+        // Expect these key properties
+        expect(page.store).toEqual(
+            expect.objectContaining({
+                descriptionHtml: expect.any(String),
+                gid: expect.any(String),
+                id: expect.any(Number),
+                isDeleted: expect.any(Boolean),
+                options: expect.arrayContaining([
+                    expect.objectContaining({
+                        _key: expect.any(String),
+                        _type: 'option',
+                        name: expect.any(String),
+                        // We expect the returned array to include at least some of these values
+                        values: expect.arrayIncludesSome([
+                            'Course Material',
+                            'Course Material + Exams',
+                            'Online',
+                            'Study Pack'
+                        ])
+                    })
+                ]),
+                priceRange: {
+                    maxVariantPrice: expect.any(Number),
+                    minVariantPrice: expect.any(Number)
+                },
+                slug: {
+                    _type: 'slug',
+                    current: 'a-level-maths'
+                },
+                status: expect.any(String),
+                title: expect.any(String),
+                variants: expect.arrayContaining([
+                    expect.objectContaining({
+                        _key: expect.any(String),
+                        _ref: expect.any(String),
+                        _type: 'reference'
+                    })
+                ])
+            })
+        );
+    });
 });
 
-test('returns store data from a query to a collection', async () => {
-    const data = await getPageData({
-        request: mockHomeRequest('http://localhost/collections/accounting'),
-        params: { slug: 'accounting' },
-        query: COLLECTION_QUERY
+describe('buildUrlPath()', () => {
+    const url = new URL('http://localhost/');
+
+    test('builds the homepage path', () => {
+        const urlPath = buildUrlPath({
+            type: 'home',
+            url,
+            slug: '/'
+        });
+
+        expect(urlPath).toBe('/');
     });
 
-    if (!data) throw Error('Request failed');
-    const { page } = data;
+    test('builds the deafult path', () => {
+        const urlPath = buildUrlPath({
+            type: 'page',
+            url,
+            slug: 'test-page'
+        });
 
-    expect(page?._type).toBe('collection');
-    // Should match _all_ of the store data
-    expect(page?.store).toMatchObject({
-        createdAt: '2022-09-30T10:19:56.409Z',
-        descriptionHtml: '',
-        disjunctive: false,
-        gid: 'gid://shopify/Collection/387079045375',
-        id: 387079045375,
-        isDeleted: false,
-        rules: [
-            {
-                _key: '18c07fa0-e97e-54a7-af3f-76d1135f72bb',
-                _type: 'object',
-                column: 'TAG',
-                condition: 'Accounting',
-                relation: 'EQUALS'
-            }
-        ],
-        slug: {
-            _type: 'slug',
-            current: 'accounting'
-        },
-        sortOrder: 'BEST_SELLING',
-        title: 'Accounting'
+        expect(urlPath).toBe('/test-page');
+    });
+
+    test('builds the blog path', () => {
+        const urlPath = buildUrlPath({
+            type: 'post',
+            url,
+            slug: 'test-post'
+        });
+
+        expect(urlPath).toBe('/blog/test-post');
+    });
+
+    test('builds the collection path', () => {
+        const urlPath = buildUrlPath({
+            type: 'collection',
+            url,
+            slug: 'test-collection'
+        });
+
+        expect(urlPath).toBe('/collections/test-collection');
+    });
+
+    test('builds the product path', () => {
+        const urlPath = buildUrlPath({
+            type: 'product',
+            url,
+            slug: 'test-product'
+        });
+
+        expect(urlPath).toBe('/products/test-product');
     });
 });
 
-test('returns store data from a query to a product', async () => {
-    const data = await getPageData({
-        request: mockHomeRequest('http://localhost/products/a-level-maths'),
-        params: { slug: 'a-level-maths' },
-        query: PRODUCT_QUERY
+describe('shouldRedirect()', () => {
+    test('returns a redirect object', async () => {
+        // Mock a fake page, make sure the slug is an redirect in Sanity
+        const request = mockHomeRequest('http://localhost/what-page');
+
+        const redirect = await shouldRedirect(request);
+
+        expect(redirect?.status).toBe(301);
     });
 
-    if (!data) throw Error('Request failed');
-    const { page } = data;
+    test("returns undefined if redirect doesn't exist", async () => {
+        const request = mockHomeRequest('http://localhost/');
 
-    expect(page?._type).toBe('product');
-    expect(page?.store).toMatchObject({
-        createdAt: '2021-11-09T00:00:40Z',
-        descriptionHtml: '',
-        gid: 'gid://shopify/Product/7438715551999',
-        id: 7438715551999,
-        isDeleted: false,
-        options: [
-            {
-                _key: 'Format',
-                _type: 'option',
-                name: 'Format',
-                values: ['Course Material', 'Course Material + Exams']
-            },
-            {
-                _key: 'Study-method',
-                _type: 'option',
-                name: 'Study-method',
-                values: ['Online', 'Study Pack']
-            }
-        ],
-        previewImageUrl:
-            'https://cdn.shopify.com/s/files/1/0609/0519/3727/products/OSC1289-category-image-e1599048301547.jpg?v=1636416440',
-        priceRange: {
-            maxVariantPrice: 899,
-            minVariantPrice: 469
-        },
-        productType: '',
-        slug: {
-            _type: 'slug',
-            current: 'a-level-maths'
-        },
-        status: 'active',
-        tags: 'import_2021_11_08_234706, Mathematics & Economics',
-        title: 'A Level Maths',
-        variants: [
-            {
-                _key: '89187a13-264d-5b62-9946-e366ca57aa51',
-                _ref: 'shopifyProductVariant-42016931414271',
-                _type: 'reference',
-                _weak: true
-            },
-            {
-                _key: 'd89e2615-e478-5827-a6c3-bc60e06fc999',
-                _ref: 'shopifyProductVariant-42016931447039',
-                _type: 'reference',
-                _weak: true
-            },
-            {
-                _key: 'fb900d42-b9a8-52fa-b4d7-20bf3e51c76a',
-                _ref: 'shopifyProductVariant-42016931479807',
-                _type: 'reference',
-                _weak: true
-            },
-            {
-                _key: 'c342a5c0-0353-51fd-9983-6a30913bef08',
-                _ref: 'shopifyProductVariant-42016931512575',
-                _type: 'reference',
-                _weak: true
-            }
-        ],
-        vendor: 'openstudydev'
+        const redirect = await shouldRedirect(request);
+
+        expect(redirect).toBe(undefined);
     });
 });

--- a/packages/osc-ecommerce/app/models/sanity.server.ts
+++ b/packages/osc-ecommerce/app/models/sanity.server.ts
@@ -1,6 +1,8 @@
 import type { Params } from 'react-router-dom';
 import type { SanityPage, SanitySiteSetting, SanityRedirect } from '~/types/sanity';
 import { getClient } from '~/lib/sanity/getClient.server';
+import { REDIRECT } from '~/queries/sanity/redirects';
+import { redirect } from '@remix-run/server-runtime';
 
 /**
  * Exclude items that contain "drafts" in the _id
@@ -83,6 +85,28 @@ export async function getSettingsData({ query }: { query: string }) {
         )[0];
 
         return liveSettings;
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+export async function shouldRedirect(request: Request) {
+    if (!request) throw new Error('Request must be passed');
+
+    try {
+        const url = new URL(request.url);
+        const getRedirect = await getClient().fetch(REDIRECT, { slug: url.pathname });
+        const redirectObject = getRedirect.filter((item: SanityRedirect) => excludeDrafts(item))[0];
+
+        if (!redirectObject) return;
+
+        const destination = buildUrlPath({
+            type: redirectObject.destination._type,
+            url,
+            slug: redirectObject.destination.slug
+        });
+
+        return redirect(destination, redirectObject.statusCode);
     } catch (err) {
         console.error(err);
     }

--- a/packages/osc-ecommerce/app/models/sanity.server.ts
+++ b/packages/osc-ecommerce/app/models/sanity.server.ts
@@ -1,6 +1,46 @@
 import type { Params } from 'react-router-dom';
-import type { SanityPage, SanitySiteSetting } from '~/types/sanity';
+import type { SanityPage, SanitySiteSetting, SanityRedirect } from '~/types/sanity';
 import { getClient } from '~/lib/sanity/getClient.server';
+
+/**
+ * Exclude items that contain "drafts" in the _id
+ */
+export const excludeDrafts = (item: { _id: string }) => !item._id.includes('drafts');
+
+/**
+ * Create the url pathname so we can handle subfolders
+ */
+interface BuildUrlArgs {
+    type: SanityRedirect['destination']['_type'];
+    url: URL;
+    slug: SanityRedirect['destination']['slug'];
+}
+
+export const buildUrlPath = ({ type, url, slug }: BuildUrlArgs) => {
+    switch (type) {
+        case 'home':
+            url.pathname = `/`;
+            break;
+
+        case 'post':
+            url.pathname = `blog/${slug}`;
+            break;
+
+        case 'collection':
+            url.pathname = `collections/${slug}`;
+            break;
+
+        case 'product':
+            url.pathname = `products/${slug}`;
+            break;
+
+        default:
+            url.pathname = slug;
+            break;
+    }
+
+    return url.pathname;
+};
 
 interface Args {
     request: Request;
@@ -38,8 +78,8 @@ export async function getSettingsData({ query }: { query: string }) {
 
     try {
         const siteSettings = await getClient().fetch(query);
-        const liveSettings = siteSettings.filter(
-            (setting: SanitySiteSetting) => !setting._id.includes('drafts')
+        const liveSettings = siteSettings.filter((setting: SanitySiteSetting) =>
+            excludeDrafts(setting)
         )[0];
 
         return liveSettings;

--- a/packages/osc-ecommerce/app/queries/sanity/redirects.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/redirects.ts
@@ -1,0 +1,13 @@
+import groq from 'groq';
+
+export const REDIRECT = groq`
+    *[_type == 'redirect' && source == $slug] {
+        _id,
+        source,
+        statusCode,
+        "destination": destination->{
+            _type,
+            "slug": coalesce(slug.current, store.slug.current)
+        },
+    }
+`;

--- a/packages/osc-ecommerce/app/routes/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/$slug.tsx
@@ -5,7 +5,7 @@ import { json } from '@remix-run/node';
 import { useState } from 'react';
 
 import Preview from '~/components/Preview';
-import getPageData from '~/models/sanity.server';
+import getPageData, { shouldRedirect } from '~/models/sanity.server';
 import { PAGE_QUERY } from '~/queries/sanity/page';
 import type { SanityPage } from '~/types/sanity';
 import Module from '~/components/Module';
@@ -28,8 +28,14 @@ export const loader: LoaderFunction = async ({ request, params }) => {
         query: PAGE_QUERY
     });
 
-    if (!data) {
-        throw new Response('`data` is not defined', { status: 500 });
+    if (!data?.page) {
+        const redirect = await shouldRedirect(request);
+
+        if (redirect) {
+            return redirect;
+        } else {
+            throw new Response('Not found', { status: 404 });
+        }
     }
 
     const { page, isPreview }: PageData = data;

--- a/packages/osc-ecommerce/app/routes/blog/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/blog/$slug.tsx
@@ -5,7 +5,7 @@ import { json } from '@remix-run/node';
 import { useState } from 'react';
 
 import Preview from '~/components/Preview';
-import getPageData from '~/models/sanity.server';
+import getPageData, { shouldRedirect } from '~/models/sanity.server';
 import { POST_QUERY } from '~/queries/sanity/post';
 import type { SanityPage } from '~/types/sanity';
 import Module from '~/components/Module';
@@ -28,8 +28,14 @@ export const loader: LoaderFunction = async ({ request, params }) => {
         query: POST_QUERY
     });
 
-    if (!data) {
-        throw new Response('`data` is not defined', { status: 500 });
+    if (!data?.page) {
+        const redirect = await shouldRedirect(request);
+
+        if (redirect) {
+            return redirect;
+        } else {
+            throw new Response('Not found', { status: 404 });
+        }
     }
 
     const { page: post, isPreview }: PageData = data;

--- a/packages/osc-ecommerce/app/routes/blog/index.tsx
+++ b/packages/osc-ecommerce/app/routes/blog/index.tsx
@@ -5,7 +5,7 @@ import { json } from '@remix-run/node';
 import { useState } from 'react';
 
 import Preview from '~/components/Preview';
-import getPageData from '~/models/sanity.server';
+import getPageData, { shouldRedirect } from '~/models/sanity.server';
 import { BLOG_QUERY } from '~/queries/sanity/blog';
 import type { SanityPage } from '~/types/sanity';
 import Module from '~/components/Module';
@@ -25,8 +25,14 @@ export const loader: LoaderFunction = async ({ request }) => {
         query: BLOG_QUERY
     });
 
-    if (!data) {
-        throw new Response('`data` is not defined', { status: 500 });
+    if (!data?.page) {
+        const redirect = await shouldRedirect(request);
+
+        if (redirect) {
+            return redirect;
+        } else {
+            throw new Response('Not found', { status: 404 });
+        }
     }
 
     const { page: blog, isPreview }: PageData = data;

--- a/packages/osc-ecommerce/app/routes/collections/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/collections/$slug.tsx
@@ -5,7 +5,7 @@ import { json } from '@remix-run/node';
 import { useState } from 'react';
 
 import Preview from '~/components/Preview';
-import getPageData from '~/models/sanity.server';
+import getPageData, { shouldRedirect } from '~/models/sanity.server';
 import { COLLECTION_QUERY } from '~/queries/sanity/collection';
 import type { SanityPage } from '~/types/sanity';
 import Module from '~/components/Module';
@@ -28,8 +28,14 @@ export const loader: LoaderFunction = async ({ request, params }) => {
         query: COLLECTION_QUERY
     });
 
-    if (!data) {
-        throw new Response('`data` is not defined', { status: 500 });
+    if (!data?.page) {
+        const redirect = await shouldRedirect(request);
+
+        if (redirect) {
+            return redirect;
+        } else {
+            throw new Response('Not found', { status: 404 });
+        }
     }
 
     const { page: collection, isPreview }: PageData = data;

--- a/packages/osc-ecommerce/app/routes/index.tsx
+++ b/packages/osc-ecommerce/app/routes/index.tsx
@@ -31,8 +31,8 @@ export const loader: LoaderFunction = async ({ request }) => {
         query: HOME_QUERY
     });
 
-    if (!data) {
-        throw new Response('`data` is not defined', { status: 500 });
+    if (!data?.page) {
+        throw new Response('Not found', { status: 404 });
     }
 
     const { page: home, isPreview }: PageData = data;

--- a/packages/osc-ecommerce/app/routes/products/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/products/$slug.tsx
@@ -5,7 +5,7 @@ import { json } from '@remix-run/node';
 import { useState } from 'react';
 
 import Preview from '~/components/Preview';
-import getPageData from '~/models/sanity.server';
+import getPageData, { shouldRedirect } from '~/models/sanity.server';
 import { PRODUCT_QUERY } from '~/queries/sanity/product';
 import type { SanityPage } from '~/types/sanity';
 import Module from '~/components/Module';
@@ -28,8 +28,14 @@ export const loader: LoaderFunction = async ({ request, params }) => {
         query: PRODUCT_QUERY
     });
 
-    if (!data) {
-        throw new Response('`data` is not defined', { status: 500 });
+    if (!data?.page) {
+        const redirect = await shouldRedirect(request);
+
+        if (redirect) {
+            return redirect;
+        } else {
+            throw new Response('Not found', { status: 404 });
+        }
     }
 
     const { page: product, isPreview }: PageData = data;

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -148,3 +148,13 @@ export interface SanitySiteSetting {
     };
     seo: SanitySEO;
 }
+
+export interface SanityRedirect {
+    _id: string;
+    source: string;
+    statusCode: 301 | 302;
+    destination: {
+        _type: string;
+        slug: string;
+    };
+}

--- a/packages/osc-ecommerce/tsconfig.json
+++ b/packages/osc-ecommerce/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["remix.env.d.ts", "vitest.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2019"],
     "types": ["vitest/globals"],

--- a/packages/osc-ecommerce/vitest.d.ts
+++ b/packages/osc-ecommerce/vitest.d.ts
@@ -1,0 +1,10 @@
+interface CustomMatchers<R = unknown> {
+    arrayIncludes(): R;
+}
+
+declare global {
+    namespace Vi {
+        interface Assertion extends CustomMatchers {}
+        interface AsymmetricMatchersContaining extends CustomMatchers {}
+    }
+}

--- a/packages/osc-studio/desk/redirects.ts
+++ b/packages/osc-studio/desk/redirects.ts
@@ -1,0 +1,9 @@
+import S from '@sanity/desk-tool/structure-builder';
+import { ArrowRightIcon } from '@sanity/icons';
+
+// prettier-ignore
+export const redirects = S.listItem()
+    .title('Redirects')
+    .icon(ArrowRightIcon)
+    .schemaType('redirect')
+    .child(S.documentTypeList('redirect'));

--- a/packages/osc-studio/deskStructure.js
+++ b/packages/osc-studio/deskStructure.js
@@ -30,6 +30,7 @@ import { products } from './desk/products';
 import { settings } from './desk/settings';
 import { blog } from './desk/blog';
 import { posts } from './desk/posts';
+import { redirects } from './desk/redirects';
 
 // If you add document types to desk structure manually, you can add them to this array to prevent duplicates in the root pane
 const DOCUMENT_TYPES_IN_STRUCTURE = [
@@ -41,7 +42,8 @@ const DOCUMENT_TYPES_IN_STRUCTURE = [
     'productVariant',
     'settings',
     'blog',
-    'post'
+    'post',
+    'redirect'
 ];
 
 /**
@@ -52,6 +54,11 @@ const DOCUMENT_TYPES_IN_STRUCTURE = [
  * into the document file.
  */
 export const getDefaultDocumentNode = ({ schemaType }) => {
+    // Don't add the preview or seo pane to the redirect
+    if (schemaType === 'redirect') {
+        return;
+    }
+
     return S.document().views([
         S.view.form(),
         // Including the iframe pane, with a function to create the url
@@ -80,23 +87,24 @@ export const getDefaultDocumentNode = ({ schemaType }) => {
 // Then we export the default list of menu items
 export default () => {
     // prettier-ignore
-    return (
-    S.list()
-      .title('Content')
-      .items([
-        home,
-        pages,
-        S.divider(),
-        blog,
-        posts,
-        S.divider(),
-        collections,
-        products,
-        S.divider(),
-        settings,
-        S.divider(),
-        // Automatically add new document types to the root pane
-        ...S.documentTypeListItems().filter(listItem => !DOCUMENT_TYPES_IN_STRUCTURE.includes(listItem.getId()))
-      ])
-  )
+    return S.list()
+        .title('Content')
+        .items([
+            home,
+            pages,
+            S.divider(),
+            blog,
+            posts,
+            S.divider(),
+            collections,
+            products,
+            S.divider(),
+            settings,
+            redirects,
+            S.divider(),
+            // Automatically add new document types to the root pane
+            ...S.documentTypeListItems().filter(
+                (listItem) => !DOCUMENT_TYPES_IN_STRUCTURE.includes(listItem.getId())
+            )
+        ]);
 };

--- a/packages/osc-studio/schemas/documents/redirects.tsx
+++ b/packages/osc-studio/schemas/documents/redirects.tsx
@@ -1,0 +1,66 @@
+import { ArrowRightIcon } from '@sanity/icons';
+import { PAGE_REFERENCES } from '../../constants.js';
+
+export default {
+    name: 'redirect',
+    title: 'Redirect',
+    type: 'document',
+    icon: ArrowRightIcon,
+    fields: [
+        {
+            name: 'source',
+            title: 'From',
+            type: 'string',
+            description:
+                'The page you want to redirect from. Must be a relative url e.g. /blog/post or /page',
+            validation: (Rule) =>
+                Rule.required().custom((context) => {
+                    const startsWithSlash = /(^\/\w+)/g;
+
+                    if (!startsWithSlash.test(context)) {
+                        return 'The slug be relative (starts with "/")';
+                    }
+
+                    return true;
+                })
+        },
+        {
+            name: 'destination',
+            title: 'To',
+            type: 'reference',
+            to: PAGE_REFERENCES,
+            description: 'The page you want to redirect to',
+            options: {
+                disableNew: true // Stop ability to create new pages from this screen
+            },
+            validation: (Rule) => Rule.required()
+        },
+        {
+            name: 'statusCode',
+            title: 'Status Code',
+            type: 'number',
+            initialValue: 301,
+            description: '301 = permanent redirect | 302 = temporary redirect',
+            options: {
+                list: [301, 302],
+                layout: 'dropdown'
+            },
+            validation: (Rule) => Rule.required()
+        }
+    ],
+    preview: {
+        select: {
+            title: 'source',
+            subtitle: 'destination.title',
+            storeSubTitle: 'destination.store.title'
+        },
+        prepare(selection) {
+            const { title, subtitle, storeSubTitle } = selection;
+
+            return {
+                title,
+                subtitle: `Redirected to ${subtitle ? subtitle : storeSubTitle}`
+            };
+        }
+    }
+};

--- a/packages/osc-studio/schemas/schema.ts
+++ b/packages/osc-studio/schemas/schema.ts
@@ -15,6 +15,7 @@ import page from './documents/page';
 import post from './documents/post';
 import product from './documents/product';
 import productVariant from './documents/productVariant';
+import redirects from './documents/redirects';
 
 // Singleton document types
 import home from './singletons/home';
@@ -62,6 +63,7 @@ export default createSchema({
         post,
         product,
         productVariant,
+        redirects,
         // Singleton document types
         home,
         blog,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

**This is a new branch -- originally approved as #454**

- Closes #153 

## 📝 Description

I've added a new document to Sanity called redirects which will allow us to create a redirect on a page by page basis. In Sanity it works a bit like adding new pages. I've done it this way rather than another tab in settings as it makes it easier to search and also gives editors a quick way to add them here:

https://user-images.githubusercontent.com/23461173/197565218-04d47206-2ca7-472e-81b6-e8545297d7f9.mov

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

A new document type (redirects) has been added to `osc-studio` along with appropriate validation.

Within `osc-ecommerce/sanity.server` I've added a utility function to create the url paths. Which is used by a new function called `shouldRedirect()`.

`shouldRedirect()` is then used on each of the `routes`. 

If no page data is found we'll check if we shouldRedirect it. If `shouldRedirect` returns something then we run it, otherwise it'll return undefined and we throw a 404.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information

You should be able to see the redirects in action by opening your network tab and navigating to https://pr-454-osc-ecommerce.fly.dev/what-page or https://pr-454-osc-ecommerce.fly.dev/blog/page-2.

https://user-images.githubusercontent.com/23461173/198242112-b639feb8-b2ae-418d-b799-45d6a359d373.mov


The Studio should be at https://pr-454-osc-studio.fly.dev
