### PR TITLE
fix(gh-actions) fixing issues with the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.CHANGELOG_RELEASE }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+
+      - name: Install
+        run: npm install conventional-changelog-conventionalcommits@^5.0.0
 
       - name: conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@v3.7.1
         with:
-          git-user-name: "OSC Dev"
-          git-user-email: "si@hi-im-si.com"
+          git-user-name: "OSC CI"
+          git-user-email: "simon.shahriveri@openstudycollege.com"
           github-token: ${{ secrets.CHANGELOG_RELEASE }}
-          git-message: "RELEASE: {version}"
-          version-file: "./package.json,./package-lock.json"
+          git-message: 'RELEASE: {version}'
+          version-file: './package.json,./package-lock.json'
+          config-file-path: './changelog.config.js'
 
       - name: create release
         uses: actions/create-release@v1

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -1,0 +1,15 @@
+'use strict'
+const config = require('conventional-changelog-conventionalcommits');
+
+module.exports = config({
+    "types": [
+        { type: 'feat', section: '✨ Features' },
+        { type: 'fix', section: '🐛 Bugs' },
+        { type: 'ci', section: '⚙️ CI/CD Updates' },
+        { type: 'docs', section: '📝 Documentation' },
+        { type: 'perf', section: '⚡️ Performance' },
+        { type: 'test', section: '🧪 Tests' },
+        { type: 'refactor', section: '♻️ Refactors' },
+        { type: 'chore', section: '📦 General Housekeeping / Package Updates' },
+    ]
+})


### PR DESCRIPTION
## 📝 Description

Adds a conventional commit config and fixes to release workflow

## ⛳️ Current behavior (updates)

release workflow currently does not create release

## 🚀 New behavior

updated workflow will now create a release in github

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The conventional commit config file now allows your define your own sections to format the changelog for the release
