### PR TITLE
Refactor/update vitest environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17687,6 +17687,8 @@
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
       "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -17787,6 +17789,8 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -21123,7 +21127,9 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ccount": {
       "version": "1.1.0",
@@ -28267,6 +28273,8 @@
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-3.2.2.tgz",
       "integrity": "sha512-NgRLzVYeTs5Y12LwpD6C2qbn7FCaKVb1BewLQOuvxS9WOxfL/dy122jDwEFluGyzZbip/ogf9MLsN+ZBlit1aA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "css.escape": "^1.5.1",
         "he": "^1.2.0",
@@ -28942,6 +28950,8 @@
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
       "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "caseless": "^0.12.0",
         "concat-stream": "^1.6.2",
@@ -28956,7 +28966,9 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/http-basic/node_modules/concat-stream": {
       "version": "1.6.2",
@@ -28966,6 +28978,8 @@
       "engines": [
         "node >= 0.8"
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -28977,13 +28991,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/http-basic/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -28999,6 +29017,8 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -29041,6 +29061,8 @@
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "^10.0.3"
       }
@@ -29049,7 +29071,9 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -37533,7 +37557,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/parse-conflict-json": {
       "version": "2.0.2",
@@ -39071,6 +39097,8 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
       "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "asap": "~2.0.6"
       }
@@ -43825,6 +43853,8 @@
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
       "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "http-response-object": "^3.0.1",
         "sync-rpc": "^1.2.1",
@@ -43839,6 +43869,8 @@
       "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
       "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "get-port": "^3.1.0"
       }
@@ -43848,6 +43880,8 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
       "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -44357,6 +44391,8 @@
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
       "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/concat-stream": "^1.6.0",
         "@types/form-data": "0.0.33",
@@ -44378,13 +44414,17 @@
       "version": "8.10.66",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
       "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/then-request/node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/then-request/node_modules/concat-stream": {
       "version": "1.6.2",
@@ -44394,6 +44434,8 @@
       "engines": [
         "node >= 0.8"
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -44406,6 +44448,8 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
       "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -44419,13 +44463,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/then-request/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -44441,6 +44489,8 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -47792,7 +47842,6 @@
         "cssnano": "^5.1.12",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
-        "happy-dom": "^3.2.2",
         "husky": "^8.0.1",
         "lerna": "^5.0.0",
         "lint-staged": "^13.0.1",
@@ -48038,7 +48087,6 @@
         "cssnano": "^5.1.12",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
-        "happy-dom": "^3.2.2",
         "husky": "^8.0.1",
         "lerna": "^5.0.0",
         "lint-staged": "^13.0.1",
@@ -48175,7 +48223,6 @@
         "cssnano": "^5.1.12",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
-        "happy-dom": "^3.2.2",
         "husky": "^8.0.1",
         "lerna": "^5.0.0",
         "lint-staged": "^13.0.1",
@@ -61526,6 +61573,8 @@
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
       "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -61626,6 +61675,8 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -64294,7 +64345,9 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "ccount": {
       "version": "1.1.0",
@@ -69768,6 +69821,8 @@
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-3.2.2.tgz",
       "integrity": "sha512-NgRLzVYeTs5Y12LwpD6C2qbn7FCaKVb1BewLQOuvxS9WOxfL/dy122jDwEFluGyzZbip/ogf9MLsN+ZBlit1aA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "css.escape": "^1.5.1",
         "he": "^1.2.0",
@@ -70280,6 +70335,8 @@
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
       "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "caseless": "^0.12.0",
         "concat-stream": "^1.6.2",
@@ -70291,13 +70348,17 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "concat-stream": {
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -70309,13 +70370,17 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -70331,6 +70396,8 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -70369,6 +70436,8 @@
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/node": "^10.0.3"
       },
@@ -70377,7 +70446,9 @@
           "version": "10.17.60",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
           "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -76099,7 +76170,6 @@
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
         "framer-motion": "^6.5.1",
-        "happy-dom": "^3.2.2",
         "husky": "^8.0.1",
         "isomorphic-dompurify": "^0.19.0",
         "lerna": "^5.0.0",
@@ -76322,7 +76392,6 @@
         "eslint-config-prettier": "^8.5.0",
         "framer-motion": "^6.5.1",
         "groq": "^2.33.2",
-        "happy-dom": "^3.2.2",
         "husky": "^8.0.1",
         "isomorphic-dompurify": "^0.19.0",
         "lerna": "^5.0.0",
@@ -76426,7 +76495,6 @@
         "embla-carousel-react": "^7.0.3",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
-        "happy-dom": "^3.2.2",
         "husky": "^8.0.1",
         "lerna": "^5.0.0",
         "lint-staged": "^13.0.1",
@@ -77124,7 +77192,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "parse-conflict-json": {
       "version": "2.0.2",
@@ -78216,6 +78286,8 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
       "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "asap": "~2.0.6"
       }
@@ -81898,6 +81970,8 @@
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
       "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "http-response-object": "^3.0.1",
         "sync-rpc": "^1.2.1",
@@ -81909,6 +81983,8 @@
       "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
       "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "get-port": "^3.1.0"
       },
@@ -81917,7 +81993,9 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
           "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -82309,6 +82387,8 @@
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
       "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/concat-stream": "^1.6.0",
         "@types/form-data": "0.0.33",
@@ -82327,19 +82407,25 @@
           "version": "8.10.66",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
           "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "buffer-from": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
           "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "concat-stream": {
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -82352,6 +82438,8 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
           "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -82362,13 +82450,17 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -82384,6 +82476,8 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }

--- a/packages/osc-academic-hub/package.json
+++ b/packages/osc-academic-hub/package.json
@@ -87,7 +87,6 @@
     "cssnano": "^5.1.12",
     "eslint": "^8.16.0",
     "eslint-config-prettier": "^8.5.0",
-    "happy-dom": "^3.2.2",
     "husky": "^8.0.1",
     "lerna": "^5.0.0",
     "lint-staged": "^13.0.1",

--- a/packages/osc-academic-hub/vitest.config.ts
+++ b/packages/osc-academic-hub/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     plugins: [react(), tsconfigPaths()],
     test: {
         globals: true,
-        environment: 'happy-dom',
+        environment: 'jsdom',
         setupFiles: ['./__test__/setup-test-env.ts'],
         exclude: ['./e2e/**/*']
     }

--- a/packages/osc-ecommerce/package.json
+++ b/packages/osc-ecommerce/package.json
@@ -91,7 +91,6 @@
     "cssnano": "^5.1.12",
     "eslint": "^8.16.0",
     "eslint-config-prettier": "^8.5.0",
-    "happy-dom": "^3.2.2",
     "husky": "^8.0.1",
     "lerna": "^5.0.0",
     "lint-staged": "^13.0.1",

--- a/packages/osc-ecommerce/vitest.config.ts
+++ b/packages/osc-ecommerce/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => {
         plugins: [react(), tsconfigPaths()],
         test: {
             globals: true,
-            environment: 'happy-dom',
+            environment: 'jsdom',
             setupFiles: ['./__test__/setup-test-env.ts'],
             exclude: ['./e2e/**/*']
         }

--- a/packages/osc-ui/package.json
+++ b/packages/osc-ui/package.json
@@ -84,7 +84,6 @@
     "cssnano": "^5.1.12",
     "eslint": "^8.16.0",
     "eslint-config-prettier": "^8.5.0",
-    "happy-dom": "^3.2.2",
     "husky": "^8.0.1",
     "lerna": "^5.0.0",
     "lint-staged": "^13.0.1",

--- a/packages/osc-ui/src/__mocks__/matchMedia.ts
+++ b/packages/osc-ui/src/__mocks__/matchMedia.ts
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import { vi } from 'vitest';
 
 // Mocks the matchMedia method which is not defined in JSDOM

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -66,6 +66,6 @@ describe('Breadcrumb component', () => {
             separator: <ChevronRightIcon />
         });
 
-        expect(screen.getAllByRole('listitem')[0].childNodes[1].childNodes[0].nodeName).toBe('SVG');
+        expect(screen.getAllByRole('listitem')[0].childNodes[1].childNodes[0].nodeName).toBe('svg');
     });
 });

--- a/packages/osc-ui/src/components/Carousel/Carousel.spec.tsx
+++ b/packages/osc-ui/src/components/Carousel/Carousel.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import React from 'react';
 import { Carousel } from './Carousel';
 import { render } from '@testing-library/react';

--- a/packages/osc-ui/src/components/Content/Content.spec.tsx
+++ b/packages/osc-ui/src/components/Content/Content.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { Content } from './Content';

--- a/packages/osc-ui/src/components/Footer/Footer.spec.tsx
+++ b/packages/osc-ui/src/components/Footer/Footer.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Footer } from './Footer';

--- a/packages/osc-ui/src/components/Header/Header.spec.tsx
+++ b/packages/osc-ui/src/components/Header/Header.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Header } from './Header';

--- a/packages/osc-ui/src/components/Image/Image.spec.tsx
+++ b/packages/osc-ui/src/components/Image/Image.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import React from 'react';
 import { Image } from './Image';
 import { imageData, largeImageData, noImageWidthData, imageDataNoTransforms } from './imageData';

--- a/packages/osc-ui/src/components/List/List.spec.tsx
+++ b/packages/osc-ui/src/components/List/List.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import type { ListItemProps } from './List';

--- a/packages/osc-ui/src/components/Modal/Modal.spec.tsx
+++ b/packages/osc-ui/src/components/Modal/Modal.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';

--- a/packages/osc-ui/src/components/Tabs/Tabs.spec.tsx
+++ b/packages/osc-ui/src/components/Tabs/Tabs.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Tabs } from './Tabs';

--- a/packages/osc-ui/src/components/Tag/Tag.spec.tsx
+++ b/packages/osc-ui/src/components/Tag/Tag.spec.tsx
@@ -54,7 +54,7 @@ describe('Tag component', () => {
 
         const result = getChildrenNodes(container);
         // Check whether first child is an SVG
-        expect(result[0].nodeName).toBe('SVG');
+        expect(result[0].nodeName).toBe('svg');
     });
     test('renders an svg to the right of the text when icon position is set to "right"', () => {
         const { container } = setup({
@@ -65,7 +65,7 @@ describe('Tag component', () => {
         });
         const result = getChildrenNodes(container);
         // Check whether second child is an SVG
-        expect(result[1].nodeName).toBe('SVG');
+        expect(result[1].nodeName).toBe('svg');
     });
     test('renders an svg to the left of the text as default when icon position is not set', () => {
         const { container } = setup({
@@ -74,7 +74,7 @@ describe('Tag component', () => {
             theme: 'primary'
         });
         const result = getChildrenNodes(container);
-        expect(result[0].nodeName).toBe('SVG');
+        expect(result[0].nodeName).toBe('svg');
     });
     test('renders an svg to left position as default if "icon" prop is passed in without an "iconPosition" prop', () => {
         const { container } = setup({
@@ -83,7 +83,7 @@ describe('Tag component', () => {
             theme: 'primary'
         });
         const result = getChildrenNodes(container);
-        expect(result[0].nodeName).toBe('SVG');
+        expect(result[0].nodeName).toBe('svg');
     });
     test('fails to render an svg if "icon" prop is not passed in', () => {
         const { container } = setup({

--- a/packages/osc-ui/src/components/Trustpilot/Trustpilot.spec.tsx
+++ b/packages/osc-ui/src/components/Trustpilot/Trustpilot.spec.tsx
@@ -1,7 +1,3 @@
-/**
- * @vitest-environment jsdom
- */
-
 import React from 'react';
 
 // eslint-disable-next-line jest/no-mocks-import -- This is how the jest docs suggest to do this https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom

--- a/packages/osc-ui/vite.config.ts
+++ b/packages/osc-ui/vite.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
         css: true,
         reporters: ['verbose'],
         globals: true,
-        environment: 'happy-dom',
+        environment: 'jsdom',
         setupFiles: ['./__test__/setup-test-env.ts'],
         include: ['./src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx,css}']
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #547 

## 📝 Description

Replaces happy-dom in the Vite environment with jsdom

## ⛳️ Current behavior (updates)

Vite currently uses happy-dom as the default testing environment. This means that to use things just as `userEvent` from react testing library we have to manually add 
```ts
/**
 * @vitest-environment jsdom
 */
```
at the top of the file to test in jsdom

## 🚀 New behavior

I have updated the vite/vitest config files to use jsdom by default so we don't have to remember to manually add the environment setter. I've also uninstalled happy-dom as we're no longer using it.

## 💣 Is this a breaking change (Yes/No): Yes

You no longer need to add the vitest environment at the top of your test files.

## 📝 Additional Information
