### PR TITLE
Feature/popover component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3492,6 +3492,32 @@
         "npm": ">=6.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.4.tgz",
+      "integrity": "sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==",
+      "dependencies": {
+        "@floating-ui/core": "^0.7.3"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-0.7.2.tgz",
+      "integrity": "sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==",
+      "dependencies": {
+        "@floating-ui/dom": "^0.5.3",
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@fullhuman/postcss-purgecss": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.1.3.tgz",
@@ -10492,6 +10518,19 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.1.tgz",
+      "integrity": "sha512-1yientwXqXcErDHEv8av9ZVNEBldH8L9scVR3is20lL+jOCfcJyMFZFEY5cgIrgexsq1qggSXqiEL/d/4f+QXA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.0.1.tgz",
@@ -10644,6 +10683,54 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.0.2.tgz",
+      "integrity": "sha512-4tqZEl9w95R5mlZ/sFdgBnfhCBOEPepLIurBA5kt/qaAhldJ1tNQd0ngr0ET0AHbPotT4mwxMPr7a+MA/wbK0g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.2",
+        "@radix-ui/react-focus-guards": "1.0.0",
+        "@radix-ui/react-focus-scope": "1.0.1",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-popper": "1.0.1",
+        "@radix-ui/react-portal": "1.0.1",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-slot": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.0.1.tgz",
+      "integrity": "sha512-J4Vj7k3k+EHNWgcKrE+BLlQfpewxA7Zd76h5I0bIa+/EqaIZ3DuwrbPj49O3wqN+STnXsBuxiHLiF0iU3yfovw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "0.7.2",
+        "@radix-ui/react-arrow": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.0",
+        "@radix-ui/react-use-rect": "1.0.0",
+        "@radix-ui/react-use-size": "1.0.0",
+        "@radix-ui/rect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
     "node_modules/@radix-ui/react-portal": {
@@ -10815,6 +10902,18 @@
         "react": "^16.8 || ^17.0 || ^18.0"
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.0.tgz",
+      "integrity": "sha512-TB7pID8NRMEHxb/qQJpvSt3hQU4sqNPM1VCTjTRjEOa7cEop/QMuq8S6fb/5Tsz64kqSvB9WnwsDHtjnrM9qew==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz",
@@ -10838,6 +10937,14 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.0.tgz",
+      "integrity": "sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@remix-run/dev": {
@@ -45561,6 +45668,19 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
@@ -48162,6 +48282,7 @@
         "@radix-ui/react-avatar": "^1.0.1",
         "@radix-ui/react-dialog": "^1.0.2",
         "@radix-ui/react-icons": "^1.1.1",
+        "@radix-ui/react-popover": "^1.0.2",
         "@radix-ui/react-slot": "^1.0.1",
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
@@ -50749,6 +50870,28 @@
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
       "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==",
       "dev": true
+    },
+    "@floating-ui/core": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg=="
+    },
+    "@floating-ui/dom": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.4.tgz",
+      "integrity": "sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==",
+      "requires": {
+        "@floating-ui/core": "^0.7.3"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-0.7.2.tgz",
+      "integrity": "sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==",
+      "requires": {
+        "@floating-ui/dom": "^0.5.3",
+        "use-isomorphic-layout-effect": "^1.1.1"
+      }
     },
     "@fullhuman/postcss-purgecss": {
       "version": "4.1.3",
@@ -56108,6 +56251,15 @@
         "@radix-ui/react-visually-hidden": "1.0.1"
       }
     },
+    "@radix-ui/react-arrow": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.1.tgz",
+      "integrity": "sha512-1yientwXqXcErDHEv8av9ZVNEBldH8L9scVR3is20lL+jOCfcJyMFZFEY5cgIrgexsq1qggSXqiEL/d/4f+QXA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.1"
+      }
+    },
     "@radix-ui/react-avatar": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.0.1.tgz",
@@ -56223,6 +56375,46 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-layout-effect": "1.0.0"
+      }
+    },
+    "@radix-ui/react-popover": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.0.2.tgz",
+      "integrity": "sha512-4tqZEl9w95R5mlZ/sFdgBnfhCBOEPepLIurBA5kt/qaAhldJ1tNQd0ngr0ET0AHbPotT4mwxMPr7a+MA/wbK0g==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.2",
+        "@radix-ui/react-focus-guards": "1.0.0",
+        "@radix-ui/react-focus-scope": "1.0.1",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-popper": "1.0.1",
+        "@radix-ui/react-portal": "1.0.1",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-slot": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      }
+    },
+    "@radix-ui/react-popper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.0.1.tgz",
+      "integrity": "sha512-J4Vj7k3k+EHNWgcKrE+BLlQfpewxA7Zd76h5I0bIa+/EqaIZ3DuwrbPj49O3wqN+STnXsBuxiHLiF0iU3yfovw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "0.7.2",
+        "@radix-ui/react-arrow": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.0",
+        "@radix-ui/react-use-rect": "1.0.0",
+        "@radix-ui/react-use-size": "1.0.0",
+        "@radix-ui/rect": "1.0.0"
       }
     },
     "@radix-ui/react-portal": {
@@ -56352,6 +56544,15 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "@radix-ui/react-use-rect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.0.tgz",
+      "integrity": "sha512-TB7pID8NRMEHxb/qQJpvSt3hQU4sqNPM1VCTjTRjEOa7cEop/QMuq8S6fb/5Tsz64kqSvB9WnwsDHtjnrM9qew==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "1.0.0"
+      }
+    },
     "@radix-ui/react-use-size": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz",
@@ -56368,6 +56569,14 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.1"
+      }
+    },
+    "@radix-ui/rect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.0.tgz",
+      "integrity": "sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
       }
     },
     "@remix-run/dev": {
@@ -76456,6 +76665,7 @@
         "@radix-ui/react-dialog": "^1.0.2",
         "@radix-ui/react-icons": "^1.1.1",
         "@radix-ui/react-slot": "^1.0.1",
+        "@radix-ui/react-popover": "*",
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
         "@remix-run/dev": "^1.6.5",
@@ -83251,6 +83461,12 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.4.tgz",
       "integrity": "sha512-fGqsYQzl8kLHF2QpQSgIwgOgJmnh6j5L6SIzQiHdLfwp3q1egUL3btq5Bg2SJysH6A0ILLgT2IqXZKoNJr0nFw==",
+      "requires": {}
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
       "requires": {}
     },
     "use-sidecar": {

--- a/packages/osc-ui/package.json
+++ b/packages/osc-ui/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-avatar": "^1.0.1",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-icons": "^1.1.1",
+    "@radix-ui/react-popover": "^1.0.2",
     "@radix-ui/react-slot": "^1.0.1",
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",

--- a/packages/osc-ui/package.json
+++ b/packages/osc-ui/package.json
@@ -96,6 +96,7 @@
     "postcss-scss": "^4.0.5",
     "prettier": "2.6.2",
     "prettier-plugin-tailwindcss": "^0.1.11",
+    "resize-observer-polyfill": "^1.5.1",
     "sass": "^1.53.0",
     "start-server-and-test": "^1.14.0",
     "storybook-addon-sass-postcss": "^0.1.3",

--- a/packages/osc-ui/src/components/Popover/Popover.spec.tsx
+++ b/packages/osc-ui/src/components/Popover/Popover.spec.tsx
@@ -1,24 +1,63 @@
-import { act, render, screen } from '@testing-library/react';
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import React from 'react';
-import { Popover, PopoverContent, PopoverTrigger } from './Popover';
+import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from './Popover';
 
-test('should render popover content when trigger is clicked and close when trigger is clicked again', () => {
+global.ResizeObserver = require('resize-observer-polyfill');
+
+test('should render popover content when trigger is clicked and close when trigger is clicked again', async () => {
+    const user = userEvent.setup();
     render(
         <Popover>
             <PopoverTrigger>Click to toggle</PopoverTrigger>
             <PopoverContent>Test Content</PopoverContent>
         </Popover>
     );
-
-    act(() => {
-        screen.getByRole('button').click();
-    });
+    await user.click(screen.getByRole('button', { name: /Click to toggle/i }));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toHaveTextContent('Test Content');
 
-    act(() => {
-        screen.getByRole('button').click();
-    });
+    await user.click(screen.getByRole('button', { name: /Click to toggle/i }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('should render popover content when trigger is clicked and close when parent content is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+        <div>
+            Parent content
+            <Popover>
+                <PopoverTrigger>Click to toggle</PopoverTrigger>
+                <PopoverContent>Test Content</PopoverContent>
+            </Popover>
+        </div>
+    );
+    await user.click(screen.getByRole('button', { name: /Click to toggle/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.click(screen.getByText(/Parent content/i));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('should render <PopoverClose> when content is opened and <PopoverClose> should close the content', async () => {
+    const user = userEvent.setup();
+    render(
+        <Popover>
+            <PopoverTrigger>Click to toggle</PopoverTrigger>
+            <PopoverContent>
+                Test Content
+                <PopoverClose>Close</PopoverClose>
+            </PopoverContent>
+        </Popover>
+    );
+
+    await user.click(screen.getByRole('button', { name: /Click to toggle/i }));
+    expect(screen.getByRole('button', { name: /Close/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Close/i }));
+    expect(screen.queryByRole('button', { name: /Close/i })).not.toBeInTheDocument();
 });

--- a/packages/osc-ui/src/components/Popover/Popover.spec.tsx
+++ b/packages/osc-ui/src/components/Popover/Popover.spec.tsx
@@ -1,0 +1,24 @@
+import { act, render, screen } from '@testing-library/react';
+
+import React from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from './Popover';
+
+test('should render popover content when trigger is clicked and close when trigger is clicked again', () => {
+    render(
+        <Popover>
+            <PopoverTrigger>Click to toggle</PopoverTrigger>
+            <PopoverContent>Test Content</PopoverContent>
+        </Popover>
+    );
+
+    act(() => {
+        screen.getByRole('button').click();
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toHaveTextContent('Test Content');
+
+    act(() => {
+        screen.getByRole('button').click();
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});

--- a/packages/osc-ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/osc-ui/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+import type { Props } from './Popover';
+import {
+    Popover,
+    PopoverAnchor,
+    PopoverArrow,
+    PopoverClose,
+    PopoverContent,
+    PopoverTrigger
+} from './Popover';
+import { MixerHorizontalIcon, Cross2Icon } from '@radix-ui/react-icons';
+
+export default {
+    title: 'osc-ui/Popover',
+    component: Popover,
+    parameters: {
+        docs: {
+            description: {
+                component: 'Displays rich content in a portal, triggered by a button.'
+            }
+        }
+    }
+} as Meta;
+
+const Template: Story<Props> = (args) => (
+    <Popover>
+        <PopoverTrigger>Click to toggle</PopoverTrigger>
+        <PopoverContent {...args}>Example Popover</PopoverContent>
+    </Popover>
+);
+const TemplateTwo: Story<Props> = (args) => (
+    <Popover>
+        <PopoverTrigger className="c-popover__icon-button" aria-label="Update dimensions">
+            <MixerHorizontalIcon />
+        </PopoverTrigger>
+        <PopoverContent {...args}>Example Popover</PopoverContent>
+    </Popover>
+);
+const TemplateThree: Story<Props> = (args) => (
+    <Popover>
+        <PopoverTrigger>Click to toggle</PopoverTrigger>
+        <PopoverContent {...args}>
+            Example Popover
+            <PopoverArrow />
+        </PopoverContent>
+    </Popover>
+);
+const TemplateFour: Story<Props> = (args) => (
+    <Popover>
+        <PopoverTrigger>Click to toggle</PopoverTrigger>
+        <PopoverContent {...args}>
+            Example Popover
+            <PopoverClose className="c-popover__close" aria-label="Close">
+                <Cross2Icon />
+            </PopoverClose>
+        </PopoverContent>
+    </Popover>
+);
+const TemplateFive: Story<Props> = (args) => (
+    <Popover>
+        <PopoverTrigger>Click to toggle</PopoverTrigger>
+        <PopoverAnchor
+            style={{
+                position: 'fixed',
+                top: '50%',
+                left: '50%'
+            }}
+        />
+        <PopoverContent {...args}>Example Popover</PopoverContent>
+    </Popover>
+);
+
+export const Primary = Template.bind({});
+export const WithIcon = TemplateTwo.bind({});
+export const WithPopoverArrow = TemplateThree.bind({});
+export const WithPopoverCloseIcon = TemplateFour.bind({});
+export const WithAnchor = TemplateFive.bind({});

--- a/packages/osc-ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/osc-ui/src/components/Popover/Popover.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
-import type { Props } from './Popover';
 import {
     Popover,
     PopoverAnchor,
@@ -45,7 +44,6 @@ export default {
         modal: {
             name: 'modal',
             type: 'boolean',
-            defaultValue: 'false',
             description:
                 'The modality of the popover. When set to true, interaction with outside elements will be disabled and only popover content will be visible to screen readers.'
         }
@@ -59,17 +57,62 @@ export default {
     }
 } as Meta;
 
-const Template: Story<Props> = (args) => (
-    <Popover>
-        {args.children[0]}
-        <PopoverContent {...args}>
-            Example Popover
-            {args.children[1]}
-        </PopoverContent>
-    </Popover>
-);
+const Template: Story = (args) => {
+    const triggerContent = args.children[0];
+    const popoverContent = args.children[1];
 
-const WithAnchorTemplate: Story<Props> = (args) => (
+    return (
+        <Popover>
+            <PopoverTrigger className={args.className}>{triggerContent}</PopoverTrigger>
+            <PopoverContent>{popoverContent}</PopoverContent>
+        </Popover>
+    );
+};
+
+const WithIconTemplate: Story = (args) => {
+    const triggerContent = args.children[0];
+    const popoverContent = args.children[1];
+
+    return (
+        <Popover>
+            <PopoverTrigger className={args.className}>{triggerContent}</PopoverTrigger>
+            <PopoverContent>{popoverContent}</PopoverContent>
+        </Popover>
+    );
+};
+
+const WithContentArrowTemplate: Story = (args) => {
+    const triggerContent = args.children[0];
+    const popoverContent = args.children[1];
+    const popoverArrow = args.children[2];
+
+    return (
+        <Popover>
+            <PopoverTrigger className={args.className}>{triggerContent}</PopoverTrigger>
+            <PopoverContent>
+                {popoverContent}
+                {popoverArrow}
+            </PopoverContent>
+        </Popover>
+    );
+};
+const WithContentCloseIconTemplate: Story = (args) => {
+    const triggerContent = args.children[0];
+    const popoverContent = args.children[1];
+    const closeIcon = args.children[2];
+
+    return (
+        <Popover>
+            <PopoverTrigger className={args.className}>{triggerContent}</PopoverTrigger>
+            <PopoverContent>
+                {popoverContent}
+                {closeIcon}
+            </PopoverContent>
+        </Popover>
+    );
+};
+
+const WithAnchorTemplate: Story = (args) => (
     <Popover>
         <PopoverTrigger>Click to toggle</PopoverTrigger>
         <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
@@ -81,28 +124,19 @@ const WithAnchorTemplate: Story<Props> = (args) => (
 );
 
 export const Primary = Template.bind({});
-export const WithIcon = Template.bind({});
-export const WithPopoverArrow = Template.bind({});
-export const WithPopoverCloseIcon = Template.bind({});
+export const WithIcon = WithIconTemplate.bind({});
+export const WithContentArrow = WithContentArrowTemplate.bind({});
+export const WithContentCloseIcon = WithContentCloseIconTemplate.bind({});
 export const WithAnchor = WithAnchorTemplate.bind({});
-WithAnchor.parameters = {
-    docs: {
-        description: {
-            story: 'Anchor is an optional element to position Popover "Content" against. If not used, the content will position alongside the Popover "Trigger"'
-        }
-    }
-};
 
 Primary.args = {
-    children: [<PopoverTrigger key={0}>Click to toggle</PopoverTrigger>]
+    children: ['Click to Toggle', 'Example Content'],
+    contentClasses: 'class-test'
 };
 
 WithIcon.args = {
-    children: [
-        <PopoverTrigger className="c-popover__icon-button" aria-label="Update dimensions" key={0}>
-            <MixerHorizontalIcon />
-        </PopoverTrigger>
-    ]
+    children: [<MixerHorizontalIcon key={0} />, 'Example Content'],
+    className: 'c-popover__icon-button'
 };
 WithIcon.parameters = {
     docs: {
@@ -112,10 +146,10 @@ WithIcon.parameters = {
     }
 };
 
-WithPopoverArrow.args = {
-    children: [<PopoverTrigger key={0}>Click to toggle</PopoverTrigger>, <PopoverArrow key={1} />]
+WithContentArrow.args = {
+    children: ['Click to Toggle', 'Example Content', <PopoverArrow key={1} />]
 };
-WithPopoverArrow.parameters = {
+WithContentArrow.parameters = {
     docs: {
         description: {
             story: 'Creates an arrow icon in the Popover "Content" that points to the trigger'
@@ -123,11 +157,20 @@ WithPopoverArrow.parameters = {
     }
 };
 
-WithPopoverCloseIcon.args = {
+WithContentCloseIcon.args = {
     children: [
-        <PopoverTrigger key={0}>Click to toggle</PopoverTrigger>,
+        'Click to toggle',
+        'Example Content',
         <PopoverClose className="c-popover__close" aria-label="Close" key={1}>
             <Cross2Icon />
         </PopoverClose>
     ]
+};
+
+WithAnchor.parameters = {
+    docs: {
+        description: {
+            story: 'Anchor is an optional element to position Popover "Content" against. If not used, the content will position alongside the Popover "Trigger"'
+        }
+    }
 };

--- a/packages/osc-ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/osc-ui/src/components/Popover/Popover.stories.tsx
@@ -14,6 +14,42 @@ import { MixerHorizontalIcon, Cross2Icon } from '@radix-ui/react-icons';
 export default {
     title: 'osc-ui/Popover',
     component: Popover,
+    subcomponents: {
+        PopoverAnchor,
+        PopoverArrow,
+        PopoverClose,
+        PopoverContent,
+        PopoverTrigger
+    },
+    argTypes: {
+        children: {
+            description:
+                'Children consist of the subcomponents that can be put together to customise the component.'
+        },
+        defaultOpen: {
+            name: 'defaultOpen',
+            type: 'boolean',
+            description:
+                'The open state of the popover when it is initially rendered. Use when you do not need to control its open state.'
+        },
+        open: {
+            name: 'open',
+            type: 'boolean',
+            description: `The controlled open state of the popover. Must be used in conjunction with onOpenChange.`
+        },
+        openChange: {
+            name: 'onOpenChange',
+            type: 'function',
+            description: 'Event handler called when the open state of the popover changes'
+        },
+        modal: {
+            name: 'modal',
+            type: 'boolean',
+            defaultValue: 'false',
+            description:
+                'The modality of the popover. When set to true, interaction with outside elements will be disabled and only popover content will be visible to screen readers.'
+        }
+    },
     parameters: {
         docs: {
             description: {
@@ -25,54 +61,73 @@ export default {
 
 const Template: Story<Props> = (args) => (
     <Popover>
-        <PopoverTrigger>Click to toggle</PopoverTrigger>
-        <PopoverContent {...args}>Example Popover</PopoverContent>
-    </Popover>
-);
-const TemplateTwo: Story<Props> = (args) => (
-    <Popover>
-        <PopoverTrigger className="c-popover__icon-button" aria-label="Update dimensions">
-            <MixerHorizontalIcon />
-        </PopoverTrigger>
-        <PopoverContent {...args}>Example Popover</PopoverContent>
-    </Popover>
-);
-const TemplateThree: Story<Props> = (args) => (
-    <Popover>
-        <PopoverTrigger>Click to toggle</PopoverTrigger>
+        {args.children[0]}
         <PopoverContent {...args}>
             Example Popover
-            <PopoverArrow />
+            {args.children[1]}
         </PopoverContent>
     </Popover>
 );
-const TemplateFour: Story<Props> = (args) => (
+
+const WithAnchorTemplate: Story<Props> = (args) => (
     <Popover>
         <PopoverTrigger>Click to toggle</PopoverTrigger>
-        <PopoverContent {...args}>
-            Example Popover
-            <PopoverClose className="c-popover__close" aria-label="Close">
-                <Cross2Icon />
-            </PopoverClose>
-        </PopoverContent>
-    </Popover>
-);
-const TemplateFive: Story<Props> = (args) => (
-    <Popover>
-        <PopoverTrigger>Click to toggle</PopoverTrigger>
-        <PopoverAnchor
-            style={{
-                position: 'fixed',
-                top: '50%',
-                left: '50%'
-            }}
-        />
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            Optional anchor
+            <PopoverAnchor />
+        </div>
         <PopoverContent {...args}>Example Popover</PopoverContent>
     </Popover>
 );
 
 export const Primary = Template.bind({});
-export const WithIcon = TemplateTwo.bind({});
-export const WithPopoverArrow = TemplateThree.bind({});
-export const WithPopoverCloseIcon = TemplateFour.bind({});
-export const WithAnchor = TemplateFive.bind({});
+export const WithIcon = Template.bind({});
+export const WithPopoverArrow = Template.bind({});
+export const WithPopoverCloseIcon = Template.bind({});
+export const WithAnchor = WithAnchorTemplate.bind({});
+WithAnchor.parameters = {
+    docs: {
+        description: {
+            story: 'Anchor is an optional element to position Popover "Content" against. If not used, the content will position alongside the Popover "Trigger"'
+        }
+    }
+};
+
+Primary.args = {
+    children: [<PopoverTrigger key={0}>Click to toggle</PopoverTrigger>]
+};
+
+WithIcon.args = {
+    children: [
+        <PopoverTrigger className="c-popover__icon-button" aria-label="Update dimensions" key={0}>
+            <MixerHorizontalIcon />
+        </PopoverTrigger>
+    ]
+};
+WithIcon.parameters = {
+    docs: {
+        description: {
+            story: 'Uses an icon for the Popover "Trigger" rather than text'
+        }
+    }
+};
+
+WithPopoverArrow.args = {
+    children: [<PopoverTrigger key={0}>Click to toggle</PopoverTrigger>, <PopoverArrow key={1} />]
+};
+WithPopoverArrow.parameters = {
+    docs: {
+        description: {
+            story: 'Creates an arrow icon in the Popover "Content" that points to the trigger'
+        }
+    }
+};
+
+WithPopoverCloseIcon.args = {
+    children: [
+        <PopoverTrigger key={0}>Click to toggle</PopoverTrigger>,
+        <PopoverClose className="c-popover__close" aria-label="Close" key={1}>
+            <Cross2Icon />
+        </PopoverClose>
+    ]
+};

--- a/packages/osc-ui/src/components/Popover/Popover.tsx
+++ b/packages/osc-ui/src/components/Popover/Popover.tsx
@@ -1,0 +1,38 @@
+import type { PopoverProps } from '@radix-ui/react-popover';
+import type { ComponentPropsWithoutRef, ElementRef, FC, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { classNames } from '../../utils/classNames';
+import './popover.scss';
+
+export interface Props extends PopoverProps {
+    className?: string;
+    children?: ReactNode;
+}
+
+export const Popover = PopoverPrimitive.Root;
+export const PopoverAnchor = PopoverPrimitive.Anchor;
+export const PopoverArrow = PopoverPrimitive.Arrow;
+export const PopoverClose = PopoverPrimitive.Close;
+export const PopoverTrigger = PopoverPrimitive.Trigger;
+
+export const PopoverContent: FC<PopoverProps> = forwardRef<
+    ElementRef<typeof PopoverPrimitive.Content>,
+    ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>((props: Props, forwardedRef) => {
+    const { className, children } = props;
+    const contentClasses = classNames('c-popover__content', className);
+
+    return (
+        <div className="c-popover">
+            <PopoverPrimitive.Portal>
+                <PopoverPrimitive.Content className={contentClasses} {...props} ref={forwardedRef}>
+                    {children}
+                </PopoverPrimitive.Content>
+            </PopoverPrimitive.Portal>
+        </div>
+    );
+});
+
+PopoverContent.displayName = 'Popover';

--- a/packages/osc-ui/src/components/Popover/Popover.tsx
+++ b/packages/osc-ui/src/components/Popover/Popover.tsx
@@ -25,13 +25,11 @@ export const PopoverContent: FC<PopoverProps> = forwardRef<
     const contentClasses = classNames('c-popover__content', className);
 
     return (
-        <div className="c-popover">
-            <PopoverPrimitive.Portal>
-                <PopoverPrimitive.Content className={contentClasses} {...props} ref={forwardedRef}>
-                    {children}
-                </PopoverPrimitive.Content>
-            </PopoverPrimitive.Portal>
-        </div>
+        <PopoverPrimitive.Portal>
+            <PopoverPrimitive.Content className={contentClasses} {...props} ref={forwardedRef}>
+                {children}
+            </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
     );
 });
 

--- a/packages/osc-ui/src/components/Popover/popover.scss
+++ b/packages/osc-ui/src/components/Popover/popover.scss
@@ -10,13 +10,13 @@
         animation-duration: 400ms;
         animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
         will-change: transform, opacity;
-    }
 
-    &__content:focus {
-        box-shadow:
-            hsl(206deg 22% 7% / 35%) 0 10px 38px -10px,
-            hsl(206deg 22% 7% / 20%) 0 10px 20px -15px,
-            0 0 0 2px rgb(237 237 237);
+        &:focus {
+            box-shadow:
+                hsl(206deg 22% 7% / 35%) 0 10px 38px -10px,
+                hsl(206deg 22% 7% / 20%) 0 10px 20px -15px,
+                0 0 0 2px rgb(237 237 237);
+        }
     }
 
     &__close {
@@ -30,14 +30,14 @@
         height: 25px;
         border-radius: 100%;
         font-family: inherit;
-    }
 
-    &__close:hover {
-        background-color: rgb(237 237 237);
-    }
+        &:hover {
+            background-color: rgb(237 237 237);
+        }
 
-    &__close:focus {
-        box-shadow: 0 0 0 2px rgb(237 237 237);
+        &:focus {
+            box-shadow: 0 0 0 2px rgb(237 237 237);
+        }
     }
 
     &__icon-button {
@@ -50,13 +50,13 @@
         border-radius: 100%;
         color: rgb(0 0 0);
         font-family: inherit;
-    }
 
-    &__icon-button:hover {
-        background-color: rgb(237 237 237);
-    }
+        &:hover {
+            background-color: rgb(237 237 237);
+        }
 
-    &__icon-button:focus {
-        box-shadow: 0 0 0 2px rgb(0 0 0);
+        &:focus {
+            box-shadow: 0 0 0 2px rgb(0 0 0);
+        }
     }
 }

--- a/packages/osc-ui/src/components/Popover/popover.scss
+++ b/packages/osc-ui/src/components/Popover/popover.scss
@@ -1,0 +1,62 @@
+.c-popover {
+    &__content {
+        width: 260px;
+        padding: 20px;
+        background-color: rgb(255 255 255);
+        border-radius: 4px;
+        box-shadow:
+            hsl(206deg 22% 7% / 35%) 0 10px 38px -10px,
+            hsl(206deg 22% 7% / 20%) 0 10px 20px -15px;
+        animation-duration: 400ms;
+        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+        will-change: transform, opacity;
+    }
+
+    &__content:focus {
+        box-shadow:
+            hsl(206deg 22% 7% / 35%) 0 10px 38px -10px,
+            hsl(206deg 22% 7% / 20%) 0 10px 20px -15px,
+            0 0 0 2px rgb(237 237 237);
+    }
+
+    &__close {
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 25px;
+        height: 25px;
+        border-radius: 100%;
+        font-family: inherit;
+    }
+
+    &__close:hover {
+        background-color: rgb(237 237 237);
+    }
+
+    &__close:focus {
+        box-shadow: 0 0 0 2px rgb(237 237 237);
+    }
+
+    &__icon-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 35px;
+        height: 35px;
+        background-color: rgb(255 255 255);
+        border-radius: 100%;
+        color: rgb(0 0 0);
+        font-family: inherit;
+    }
+
+    &__icon-button:hover {
+        background-color: rgb(237 237 237);
+    }
+
+    &__icon-button:focus {
+        box-shadow: 0 0 0 2px rgb(0 0 0);
+    }
+}

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -12,6 +12,7 @@ export { Icon } from './components/Icon/Icon';
 export { Image } from './components/Image/Image';
 export { List } from './components/List/List';
 export { Modal } from './components/Modal/Modal';
+export { Popover } from './components/Popover/Popover';
 export { SkipLink } from './components/SkipLink/SkipLink';
 export { Switch } from './components/Switch/Switch';
 export { Tabs } from './components/Tabs/Tabs';


### PR DESCRIPTION
Closes #536 
Closes #537 

## 📝 Description

Add Popover Component

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

Adds a Popover component to the UI Library

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
The Popover component can be composed of many parts. I haven't abstracted any of this into the component itself (e.g. Close button in content, Arrow in component), but just exported each of the composable parts so they can be custom built. The stories give examples of how the Popover can be composed of these different parts.

A [polyfill](https://www.npmjs.com/package/resize-observer-polyfill) has been added to deal with a testing issue. More details can be found [here](https://discord.com/channels/915621085872029817/1044285090601127989).