### PR TITLE
Refactor/set trailing commas to `es5`

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -18,6 +18,6 @@
     }
   ],
   "semi": true,
-  "trailingComma": "none",
+  "trailingComma": "es5",
   "singleQuote": true
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #561 

## 📝 Description
Sets `trailingCommas` to `es5` in `prettierrc.json`

## ⛳️ Current behaviour (updates)
Trailing commas are removed. Current setting is `none`

## 🚀 New behaviour
Trailing commas are allowed in accepted areas, and prettier will add them automatically where appropriate. Typically only applies to multi line arrays/objects/function calls. Inline arrays/objects/function calls will not have a trailing comma.

This will also make Git diff logs cleaner as they will no longer show an edited line where a commas was added to allow an extra argument, since the commas will already be there.

Affected:
- Array literals
- Object literals
- Parameter definitions
- Function calls
- Named imports
- Named exports
- Array and object destructuring

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
[MDN docs on trailing commas](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas)
