### PR TITLE
Refactor/carousel from embla to keen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32013,6 +32013,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keen-slider": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/keen-slider/-/keen-slider-6.8.5.tgz",
+      "integrity": "sha512-9yoosfffgTCrkmbX8kCUMWsn9KDgPSkxBof5/0yXde001D1xao7i9ppfxQCCK0MLnoCa+Rdssby0jFbTTUM4rw=="
+    },
     "node_modules/keyv": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
@@ -48762,6 +48767,7 @@
         "embla-carousel-autoplay": "^7.0.3",
         "embla-carousel-class-names": "^7.0.3",
         "embla-carousel-react": "^7.0.3",
+        "keen-slider": "^6.8.5",
         "lightgallery": "^2.7.0",
         "rollup": "^2.60.2",
         "rollup-plugin-dts": "^4.2.2",
@@ -73252,6 +73258,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "keen-slider": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/keen-slider/-/keen-slider-6.8.5.tgz",
+      "integrity": "sha512-9yoosfffgTCrkmbX8kCUMWsn9KDgPSkxBof5/0yXde001D1xao7i9ppfxQCCK0MLnoCa+Rdssby0jFbTTUM4rw=="
+    },
     "keyv": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
@@ -77397,6 +77408,7 @@
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
         "husky": "^8.0.1",
+        "keen-slider": "^6.8.5",
         "lerna": "^5.0.0",
         "lightgallery": "^2.7.0",
         "lint-staged": "^13.0.1",

--- a/packages/osc-studio/schemas/objects/module/carousel.ts
+++ b/packages/osc-studio/schemas/objects/module/carousel.ts
@@ -94,16 +94,22 @@ export default {
                     name: 'mobile',
                     title: 'Mobile',
                     type: 'number',
+                    description:
+                        'The number of slides to show on small screens, smaller than 768px. This will default to 1 if not set.',
                 },
                 {
                     name: 'tablet',
                     title: 'Tablet',
                     type: 'number',
+                    description:
+                        'The number of slides to show on screens larger than 768px. This will default to 2 if not set.',
                 },
                 {
                     name: 'desktop',
                     title: 'Desktop',
                     type: 'number',
+                    description:
+                        'The number of slides to show on screens larger than 1440px. This will default to 3 if not set.',
                 },
             ],
         },

--- a/packages/osc-studio/schemas/objects/module/carousel.ts
+++ b/packages/osc-studio/schemas/objects/module/carousel.ts
@@ -53,23 +53,23 @@ export default {
             group: 'settings',
         },
         {
-            name: 'autoplay',
-            title: 'Autoplay',
-            type: 'string',
-            options: {
-                list: ['smooth', 'switch'],
-            },
-            description:
-                'Whether the Carousel should autoplay. Note: That "loop" must be enabled for this to work',
-            group: 'settings',
-        },
-        {
             title: 'Loop',
             name: 'loop',
             type: 'boolean',
             initialValue: true,
             description: 'Whether the Carousel should loop when it reaches the last slide',
             group: 'settings',
+        },
+        {
+            name: 'autoplay',
+            title: 'Autoplay',
+            type: 'string',
+            options: {
+                list: ['smooth', 'switch'],
+            },
+            description: 'Whether the Carousel should autoplay',
+            group: 'settings',
+            hidden: ({ parent }) => parent.loop !== true,
         },
         {
             title: 'Starting slide',

--- a/packages/osc-studio/schemas/objects/module/carousel.ts
+++ b/packages/osc-studio/schemas/objects/module/carousel.ts
@@ -1,7 +1,6 @@
 import { StarIcon } from '@sanity/icons';
 import { capitalizeFirstLetter } from '../../../utils/capitalizeFirstLetter';
 
-// TODO: ak - to add fields in when creating modules, modules are shown on pages, they are spit out in order
 export default {
     name: 'module.carousel',
     title: 'Carousel',
@@ -9,120 +8,115 @@ export default {
     icon: StarIcon,
     groups: [
         {
-            name: 'carousel',
-            title: 'Carousel Properties'
+            default: true,
+            name: 'settings',
+            title: 'Settings',
         },
         {
             name: 'slide',
-            title: 'Slide Properties'
-        }
+            title: 'Slide',
+        },
     ],
     fields: [
         {
-            title: 'Active',
-            name: 'active',
+            title: 'Images',
+            name: 'mediaArray',
+            type: 'array',
+            of: [{ type: 'module.images' }],
+            description: 'The images and text within the Carousel',
+            group: 'slide',
+        },
+        {
+            name: 'carouselName',
+            title: 'Carousel Name',
+            type: 'string',
+            description:
+                'The accessible name of the Carousel, this will not be visible on the page but is required for accessibility.',
+            group: 'settings',
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: 'arrows',
+            title: 'Show Arrows',
             type: 'boolean',
-            description: 'Whether or not the Carousel is active',
-            group: 'carousel'
+            description: 'Whether the Carousel should show arrows to navigate between slides',
+            initialValue: false,
+            group: 'settings',
+        },
+        {
+            name: 'dotNav',
+            title: 'Show Dot Navigation',
+            type: 'boolean',
+            description:
+                'Whether the Carousel should show dot navigation to navigate between slides',
+            initialValue: true,
+            group: 'settings',
+        },
+        {
+            name: 'autoplay',
+            title: 'Autoplay',
+            type: 'string',
+            options: {
+                list: ['smooth', 'switch'],
+            },
+            description:
+                'Whether the Carousel should autoplay. Note: That "loop" must be enabled for this to work',
+            group: 'settings',
         },
         {
             title: 'Loop',
             name: 'loop',
             type: 'boolean',
+            initialValue: true,
             description: 'Whether the Carousel should loop when it reaches the last slide',
-            group: 'carousel'
+            group: 'settings',
         },
         {
-            group: 'carousel',
-            title: 'Height',
-            name: 'height',
-            type: 'number',
-            validation: (Rule) =>
-                Rule.min(200)
-                    .max(3000)
-                    .custom((height, context) => {
-                        if (context.parent.axis === 'y' && !height) return 'Height is required';
-                        return true;
-                    }),
-            description:
-                'The height of the images carosuel, leave this blank to use the Autoheight feature. The autoheight feature changes the height of the carousel container to fit the height of the highest slide in view. Please note, if the carousel axis is set to vertical, the height must be set.'
-        },
-        {
-            group: 'carousel',
-            title: 'Axis',
-            name: 'axis',
-            type: 'string',
-            options: {
-                layout: 'radio',
-                list: [
-                    { title: 'Horizontal', value: 'x' },
-                    { title: 'Vertical', value: 'y' }
-                ]
-            },
-            description: 'Whether the Carousel should scroll horizontally or vertically'
-        },
-        {
-            group: 'slide',
-            title: 'Images',
-            name: 'mediaArray',
-            type: 'array',
-            of: [{ type: 'module.images' }],
-            description: 'The images and text within the Carousel'
-        },
-        {
-            group: 'slide',
             title: 'Starting slide',
             name: 'startIndex',
             type: 'number',
+            initialValue: 1,
             description: 'The image the Carousel will start at when the page loads',
-            validation: (Rule) =>
-                Rule.min(1).custom((startIndex, context) => {
-                    console.log(context);
-                    if (startIndex - 1 >= context.parent.mediaArray.length)
-                        return 'Starting item must be less than or equal to the number of slides';
-                    return true;
-                })
-        },
-        // TODO: ak- add range slider
-        {
-            group: 'carousel',
-            title: 'Delay',
-            name: 'delay',
-            type: 'string',
-            validation: (Rule) => Rule.min(0).max(10000),
-            description:
-                'Assigning a value to this field will cause the Carousel to automatically play when the page loads, a value of 0 means that the Carousel will not be played automatically',
-            options: {
-                layout: 'radio',
-                list: ['0', '2000', '4000', '8000', '10000']
-            }
+            group: 'settings',
         },
         {
-            group: 'carousel',
             title: 'Slides Per Page',
-            name: 'slidesPerPage',
-            type: 'number',
-            validation: (Rule) => Rule.min(1).max(5),
-            description: 'The number of images to show per Carousel slide'
+            name: 'slidesPerView',
+            type: 'object',
+            description: 'The number of slides to show per page',
+            group: 'settings',
+            options: {
+                collapsed: true,
+                collapsible: true,
+            },
+            fields: [
+                {
+                    name: 'mobile',
+                    title: 'Mobile',
+                    type: 'number',
+                },
+                {
+                    name: 'tablet',
+                    title: 'Tablet',
+                    type: 'number',
+                },
+                {
+                    name: 'desktop',
+                    title: 'Desktop',
+                    type: 'number',
+                },
+            ],
         },
-        {
-            group: 'slide',
-            title: 'Slide Gap',
-            name: 'slideGap',
-            type: 'number',
-            validation: (Rule) => Rule.min(0).max(20),
-            description: 'The margin of each image inside a slide'
-        }
     ],
     preview: {
         select: {
-            subtitle: 'type'
+            subtitle: 'type',
         },
         prepare(selection: Record<string, any>) {
             return {
                 title: 'Carousel',
-                subtitle: capitalizeFirstLetter(selection.subtitle)
+                subtitle: capitalizeFirstLetter(selection.subtitle),
             };
-        }
-    }
+        },
+    },
 };

--- a/packages/osc-ui/package.json
+++ b/packages/osc-ui/package.json
@@ -36,6 +36,7 @@
     "embla-carousel-class-names": "^7.0.3",
     "embla-carousel-react": "^7.0.3",
     "lightgallery": "^2.7.0",
+    "keen-slider": "^6.8.5",
     "rollup": "^2.60.2",
     "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-postcss": "^4.0.2",

--- a/packages/osc-ui/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/osc-ui/src/components/Carousel/Carousel.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
+import { Image } from '../Image/Image';
 import type { Props } from './Carousel';
 import { Carousel } from './Carousel';
 
@@ -9,155 +10,223 @@ export default {
     parameters: {
         docs: {
             description: {
-                component: 'Carousel component for displaying various content types'
-            }
-        }
+                component: 'Carousel component for displaying various content types.',
+            },
+        },
     },
     argTypes: {
-        active: {
-            description: 'Setting this to false will not activate or deactivate the carousel.'
+        autoplay: {
+            control: {
+                type: 'select',
+            },
         },
-        axis: {
-            description: 'Direction of the carousel'
+        carouselName: {
+            table: {
+                defaultValue: {
+                    summary: '',
+                },
+            },
         },
-        carouselKey: {
-            description:
-                'ensure the css variables for the height, slidegap, etc. are locally scoped',
-            control: false
+        justifyDotNav: {
+            control: {
+                type: 'select',
+            },
         },
-        delay: {
-            description: 'Delay between transitions in milliseconds'
+        slideOrigin: {
+            table: {
+                defaultValue: {
+                    summary: '"auto"',
+                },
+            },
+            control: {
+                type: 'select',
+            },
         },
-        height: {
-            description: 'Height of the carousel items in pixels'
-        },
-        loop: {
-            description: 'Whether or not the carousel should loop back around to the start'
-        },
-        mediaArray: {
-            description: 'Array of objects containing image urls and alt text',
-            control: false
-        },
-        slideGap: {
-            description: 'The gap between each slide in pixels'
-        },
-        slidesPerPage: {
-            description: 'Number of slides shown per page'
-        },
-        ssr: {
-            description: 'Controls if the carousel is visible before embla-api inits',
-            control: false
-        },
-        startIndex: {
-            description: 'The slide number we should start on'
-        }
-    }
+    },
 } as Meta;
 
-const Template: Story<Props> = (args) => <Carousel {...args} />;
+const Template: Story<Props> = (args) => (
+    <Carousel {...args}>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: '100px' }}>
+            1
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: '100px' }}>
+            2
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: '100px' }}>
+            3
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: '100px' }}>
+            4
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: '100px' }}>
+            5
+        </div>
+    </Carousel>
+);
+
+const AdaptiveHeightTemplate: Story<Props> = (args) => (
+    <Carousel {...args}>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: 200 }}>
+            200px
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: 100 }}>
+            100px
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: 75 }}>
+            75px
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: 100 }}>
+            100px
+        </div>
+        <div className="" style={{ backgroundColor: 'lightgreen', height: 150 }}>
+            150px
+        </div>
+    </Carousel>
+);
+
+const ImagesTemplate: Story<Props> = (args) => (
+    <Carousel {...args}>
+        <Image
+            src="https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg"
+            width={1870}
+            height={1250}
+            alt="A cartoony shoe"
+        />
+        <Image
+            src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1665669940/cld-sample.jpg"
+            width={1870}
+            height={1250}
+            alt="A woman and a dog"
+        />
+
+        <Image
+            src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1665669942/cld-sample-4.jpg"
+            width={1870}
+            height={1250}
+            alt="Some food"
+        />
+
+        <Image
+            src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1665669941/cld-sample-2.jpg"
+            width={1870}
+            height={1250}
+            alt="A mountain"
+        />
+
+        <Image
+            src="https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg"
+            width={1870}
+            height={1250}
+            alt="A cartoony shoe"
+        />
+    </Carousel>
+);
 
 export const Primary = Template.bind({});
-
 Primary.args = {
-    mediaArray: [
-        {
-            _key: '2abff668951c',
-            _type: 'module.images',
-            alt: 'A cartoony shoe',
-            height: 1250,
-            src: 'https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg',
-            width: 1870
+    carouselName: 'Primary',
+};
+
+export const AutoplaySmooth = Template.bind({});
+AutoplaySmooth.args = {
+    ...Primary.args,
+    carouselName: 'AutoPlay Smooth',
+    dotNav: false,
+    autoplay: 'smooth',
+    loop: true,
+};
+AutoplaySmooth.parameters = {
+    docs: {
+        description: {
+            story: 'Plays the carousel automatically, with a smooth transition between slides',
         },
-        {
-            _key: '2abff668952c',
-            _type: 'module.images',
-            alt: 'A cartoony shoe',
-            height: 1250,
-            src: 'https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg',
-            width: 1870
+    },
+};
+
+export const AutoplaySwitch = Template.bind({});
+AutoplaySwitch.args = {
+    ...Primary.args,
+    carouselName: 'AutoPlay Switch',
+    autoplay: 'switch',
+    autoPlaySpeed: 2_000,
+    loop: true,
+};
+AutoplaySwitch.parameters = {
+    docs: {
+        description: {
+            story: 'Plays the carousel automatically, stepping through each slide.',
         },
-        {
-            _key: '2abff668953c',
-            _type: 'module.images',
-            alt: 'A cartoony shoe',
-            height: 1250,
-            src: 'https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg',
-            width: 1870
+    },
+};
+
+export const AdaptiveHeight = AdaptiveHeightTemplate.bind({});
+AdaptiveHeight.args = {
+    ...Primary.args,
+    carouselName: 'Adaptive Height',
+    adaptiveHeight: true,
+};
+AdaptiveHeight.parameters = {
+    docs: {
+        description: {
+            story: 'Changes the height of the carousel to fit the height of the largest slide in view.',
         },
-        {
-            _key: '2abff668954c',
-            _type: 'module.images',
-            alt: 'A cartoony shoe',
-            height: 1250,
-            src: 'https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg',
-            width: 1870
+    },
+};
+
+export const Images = ImagesTemplate.bind({});
+Images.args = {
+    ...Primary.args,
+    carouselName: 'Images',
+};
+Images.parameters = {
+    docs: {
+        description: {
+            story: 'Carousel through images, which are lazy loaded with the native loading attribute.',
         },
-        {
-            _key: '2abff668955c',
-            _type: 'module.images',
-            alt: 'A cartoony shoe',
-            height: 1250,
-            src: 'https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg',
-            width: 1870
+    },
+};
+
+export const Breakpoints = Template.bind({});
+Breakpoints.args = {
+    ...Primary.args,
+    carouselName: 'Breakpoints',
+    slidesPerView: 2,
+    breakpoints: {
+        '(min-width: 768px)': {
+            slides: {
+                origin: 'auto',
+                perView: 3,
+                spacing: 16,
+            },
         },
-        {
-            _key: '2abff668956c',
-            _type: 'module.images',
-            alt: 'A cartoony shoe',
-            height: 1250,
-            src: 'https://res.cloudinary.com/de2iu8gkv/image/upload/c_scale,e_cartoonify,w_1331,f_auto,q_auto/v1665669942/cld-sample-5.jpg',
-            width: 1870
-        }
-    ],
-    active: true,
-    delay: '3000',
-    slidesPerPage: 3,
-    slideGap: 10,
-    axis: 'x',
-    height: 500,
+        '(min-width: 1440px)': {
+            slides: {
+                origin: 'auto',
+                perView: 4,
+                spacing: 16,
+            },
+        },
+    },
+};
+Breakpoints.parameters = {
+    docs: {
+        description: {
+            story: 'Can change the settings of the slide based on a custom breakpoint.',
+        },
+    },
+};
+
+export const CenterOrigin = Template.bind({});
+CenterOrigin.args = {
+    ...Primary.args,
+    slideOrigin: 'center',
     loop: false,
-    startIndex: 1,
-    ssr: false
 };
-
-export const HorizontalOneSlide = Template.bind({});
-HorizontalOneSlide.args = {
-    ...Primary.args,
-    axis: 'x',
-    slidesPerPage: 1
-};
-HorizontalOneSlide.parameters = {
+CenterOrigin.parameters = {
     docs: {
         description: {
-            story: 'Changes one slide at a time.'
-        }
-    }
-};
-
-export const VerticalTwoSlide = Template.bind({});
-VerticalTwoSlide.args = {
-    ...Primary.args,
-    axis: 'y',
-    slidesPerPage: 2
-};
-VerticalTwoSlide.parameters = {
-    docs: {
-        description: {
-            story: 'Changes two slides at a time vetically.'
-        }
-    }
-};
-
-export const VerticalMultiSlide = Template.bind({});
-VerticalMultiSlide.args = {
-    ...Primary.args,
-    axis: 'y',
-    slidesPerPage: 3
-};
-VerticalMultiSlide.parameters = {
-    docs: {
-        description: {
-            story: 'Changes three slides at a time vetically.'
-        }
-    }
+            story: 'Starts carousel with the initial slide in the center.',
+        },
+    },
 };

--- a/packages/osc-ui/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/osc-ui/src/components/Carousel/Carousel.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
+import mq from '../../../../../tokens/media-queries';
+import { rem } from '../../utils/rem';
 import { Image } from '../Image/Image';
 import type { Props } from './Carousel';
 import { Carousel } from './Carousel';
@@ -193,14 +195,14 @@ Breakpoints.args = {
     carouselName: 'Breakpoints',
     slidesPerView: 2,
     breakpoints: {
-        '(min-width: 768px)': {
+        [`(min-width: ${rem(mq['tab'])}rem)`]: {
             slides: {
                 origin: 'auto',
                 perView: 3,
                 spacing: 16,
             },
         },
-        '(min-width: 1440px)': {
+        [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
             slides: {
                 origin: 'auto',
                 perView: 4,

--- a/packages/osc-ui/src/components/Carousel/Carousel.tsx
+++ b/packages/osc-ui/src/components/Carousel/Carousel.tsx
@@ -2,7 +2,9 @@ import type { KeenSliderPlugin } from 'keen-slider/react';
 import { useKeenSlider } from 'keen-slider/react';
 import type { FC, ReactNode } from 'react';
 import React, { Children, useState } from 'react';
+import mq from '../../../../../tokens/media-queries';
 import { classNames } from '../../utils/classNames';
+import { rem } from '../../utils/rem';
 
 import './carousel.scss';
 import { Arrow } from './CarouselArrows';
@@ -119,15 +121,14 @@ export const Carousel: FC<Props> = (props: Props) => {
         startIndex = 0,
         gap = 16, //px
         breakpoints = {
-            // TODO: Update to pull breakpoints from our design tokens & should be rem
-            '(min-width: 48rem)': {
+            [`(min-width: ${rem(mq['tab'])}rem)`]: {
                 slides: {
                     origin: slideOrigin,
                     perView: 2,
                     spacing: gap,
                 },
             },
-            '(min-width: 90rem)': {
+            [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
                 slides: {
                     origin: slideOrigin,
                     perView: 3,

--- a/packages/osc-ui/src/components/Carousel/Carousel.tsx
+++ b/packages/osc-ui/src/components/Carousel/Carousel.tsx
@@ -1,274 +1,443 @@
-import AutoHeight from 'embla-carousel-auto-height';
-import Autoplay from 'embla-carousel-autoplay';
-import ClassNames from 'embla-carousel-class-names';
-import useEmblaCarousel from 'embla-carousel-react';
-import type { FC } from 'react';
-import React, { useCallback, useEffect, useState } from 'react';
-import { useDebouncedCallback } from 'use-debounce';
-import { v4 as uuidv4 } from 'uuid';
-import { Image } from '../Image/Image';
+import type { KeenSliderPlugin } from 'keen-slider/react';
+import { useKeenSlider } from 'keen-slider/react';
+import type { FC, ReactNode } from 'react';
+import React, { Children, useState } from 'react';
+import { classNames } from '../../utils/classNames';
+
 import './carousel.scss';
+import { Arrow } from './CarouselArrows';
+import { CarouselDots } from './CarouselDots';
 
-export type Props = {
-    height?: string;
-    active: boolean;
-    startIndex: number;
-    mediaArray: any[];
-    delay: string;
-    slidesPerPage: number;
-    slideGap: number;
-    axis: 'x' | 'y';
-    loop: boolean;
-    ssr?: boolean;
-    carouselKey?: string;
-};
+type SlideOrigin = 'auto' | 'center';
 
-export const CarouselInner: FC<Props> = (props) => {
+interface Breakpoints {
+    [key: string]: {
+        slides: {
+            origin: SlideOrigin;
+            perView: number;
+            spacing: number;
+        };
+    };
+}
+
+export interface Props {
+    /**
+     * Whether the carousel should change height based on the height of the slides
+     * @default false
+     */
+    adaptiveHeight?: boolean;
+
+    /**
+     * Whether the carousel should have arrows
+     * @default false
+     */
+    arrows?: boolean;
+
+    /**
+     * The type of autoplay we want to use, requires loop to be true
+     * @default false
+     */
+    autoplay?: 'smooth' | 'switch' | false;
+
+    /**
+     * The speed of the autoplay in ms
+     * @default 10_000
+     */
+    autoPlaySpeed?: number;
+
+    /**
+     * We can pass breakpoints in as an object so we can define settings in certain instances
+     */
+    breakpoints?: Breakpoints;
+
+    /**
+     * The accessible name of the carousel
+     * @default ''
+     */
+    carouselName: string;
+
+    /**
+     * The slides to render in the carousel
+     */
+    children: ReactNode | ReactNode[];
+
+    /**
+     * Whether the carousel should have dots
+     * @default true
+     */
+    dotNav?: boolean;
+
+    /**
+     * The gap between slides in px
+     * @default 16
+     */
+    gap?: number;
+
+    /**
+     * The position of the dotnav
+     */
+    justifyDotNav?: 'start' | 'center' | 'end';
+
+    /**
+     * Whether the carousel should loop
+     * @default true
+     */
+    loop?: boolean;
+
+    /**
+     * The number of slides to show per view
+     * @default 1
+     */
+    slidesPerView?: number;
+
+    /**
+     * The index of the slide to start on
+     * @default 0
+     */
+    startIndex?: number;
+
+    /**
+     * The origin of the slides, controls how the slides are positioned on load
+     * @default 'auto'
+     */
+    slideOrigin?: SlideOrigin;
+}
+
+export const Carousel: FC<Props> = (props: Props) => {
     const {
-        ssr,
-        height,
-        active,
-        startIndex,
-        mediaArray,
-        delay,
-        slidesPerPage,
-        slideGap,
-        axis,
-        loop,
-        carouselKey
+        carouselName,
+        adaptiveHeight = false,
+        autoplay = false, // loop must also be true for autoplay to work -- manage this with typescript?
+        autoPlaySpeed = 10_000, // ms
+        loop = true,
+        children,
+        slidesPerView = 1,
+        arrows = false,
+        dotNav = true,
+        justifyDotNav = 'end',
+        slideOrigin = 'auto',
+        startIndex = 0,
+        gap = 16, //px
+        breakpoints = {
+            // TODO: Update to pull breakpoints from our design tokens & should be rem
+            '(min-width: 48rem)': {
+                slides: {
+                    origin: slideOrigin,
+                    perView: 2,
+                    spacing: gap,
+                },
+            },
+            '(min-width: 90rem)': {
+                slides: {
+                    origin: slideOrigin,
+                    perView: 3,
+                    spacing: gap,
+                },
+            },
+        },
     } = props;
 
-    const delayInt = parseInt(delay, 10);
+    const [currentSlide, setCurrentSlide] = useState<number>(startIndex);
+    const [sliderHasLoaded, setSliderHasLoaded] = useState<boolean>(false);
+    const classes = classNames(
+        'c-carousel',
+        arrows && 'has-arrows',
+        adaptiveHeight && 'has-adaptive-height'
+    );
 
-    const trueSlidesPerPage = () => {
-        if (typeof window === 'undefined') return 1;
-        if (window.matchMedia('(min-width: 768px)').matches) return slidesPerPage;
-        if (window.matchMedia('(min-width: 640px)').matches) return 2;
-        return 1;
-    };
+    // Keep track of which slides are in view by assigning their index to an array
+    // Keen slider does expose a property called "portion" which indicates how much of the slide is visible in the viewport
+    // however this doesn't always match with what we'd expect. I.e. it might look like the whole slide is visible but the portion is 0.5
+    // or 0.4, meaning we are getting an inaccurate result when trying to access the slides in view. Similarly the slide may be completely out
+    // of view but the portion is 0.5.
+    // What I've done here is use the IntersectionObserver API to get the slides in that are intersecting with the slider container
+    // and push them into an array. This is a more accurate way of getting the slides that are in view.
+    const saveSlidesInView = (entries: IntersectionObserverEntry[], array: string[]) => {
+        for (const entry of entries) {
+            const target = entry.target as HTMLElement;
 
-    const emblaPlugins = () => {
-        if (!height && delayInt) {
-            return [
-                AutoHeight(),
-                Autoplay({ delay: delayInt, stopOnLastSnap: !loop }),
-                ClassNames()
-            ];
-        } else if (!height && !delayInt) {
-            return [AutoHeight(), ClassNames()];
-        } else if (height && delayInt) {
-            return [Autoplay({ delay: delayInt, stopOnLastSnap: !loop }), ClassNames()];
-        } else if (height && !delayInt) {
-            return [ClassNames()];
+            if (entry.isIntersecting) {
+                array.push(target?.dataset.slideIndex);
+            } else {
+                // Find the index of the slideIndex that is no longer in view
+                const index = array.findIndex((element) => element === target?.dataset.slideIndex);
+
+                // Index will be -1 if the slideIndex is not found so we are checking that it exists
+                index >= 0 && array.splice(index, 1);
+            }
         }
     };
 
-    const [emblaRef, emblaApi] = useEmblaCarousel(
-        {
-            active,
-            align: 'start',
-            inViewThreshold: 1,
-            skipSnaps: false,
-            slidesToScroll: trueSlidesPerPage(),
-            containScroll: 'trimSnaps',
-            startIndex: startIndex ? startIndex - 1 : 0,
-            axis,
-            loop
-        },
-        emblaPlugins()
-    );
+    // Handle setting the aria-hidden attribute on the slides
+    const AriaPlugin: KeenSliderPlugin = (slider) => {
+        const setAriaHidden = () => {
+            const slidesInView = [];
 
-    const [carouselVisible, setCarouselVisible] = useState(ssr ? false : true);
-    const [selectedIndex, setSelectedIndex] = useState(0);
-    const [scrollSnaps, setScrollSnaps] = useState<Array<number>>([]);
+            const observer = new IntersectionObserver(
+                (entries) => {
+                    saveSlidesInView(entries, slidesInView);
 
-    const onSelect = useCallback(() => {
-        if (!emblaApi) return;
-        setSelectedIndex(emblaApi.selectedScrollSnap());
-    }, [emblaApi, setSelectedIndex]);
+                    for (const slide of slider.slides) {
+                        if (slidesInView.includes(slide.dataset.slideIndex)) {
+                            slide.setAttribute('aria-hidden', 'false');
+                        } else {
+                            slide.setAttribute('aria-hidden', 'true');
+                        }
+                    }
+                },
+                {
+                    root: slider.container,
+                    rootMargin: '0px',
+                    threshold: 0,
+                }
+            );
 
-    const setAriaHidden = useCallback(() => {
-        if (!emblaApi) return;
-        const slides = emblaApi.slideNodes();
-        emblaApi.slidesInView(true).forEach((indexInView) => {
-            slides[indexInView].setAttribute('aria-hidden', 'false');
-        });
-        emblaApi.slidesNotInView(true).forEach((indexNotInView) => {
-            slides[indexNotInView].setAttribute('aria-hidden', 'true');
-        });
-    }, [emblaApi]);
-
-    useEffect(() => {
-        setAriaHidden();
-    }, [selectedIndex, setAriaHidden]);
-
-    useEffect(() => {
-        if (!emblaApi) return;
-        setScrollSnaps(emblaApi.scrollSnapList());
-        onSelect();
-        emblaApi.on('resize', () => {
-            onSelect();
-            setScrollSnaps(emblaApi.scrollSnapList());
-        });
-        emblaApi.on('select', onSelect);
-        emblaApi.on('init', () => {
-            setCarouselVisible(true);
-        });
-        // return () => emblaApi.destroy();
-    }, [emblaApi, setScrollSnaps, onSelect]);
-
-    const handleResize = useDebouncedCallback(() => {
-        if (!emblaApi) return;
-        onSelect();
-        setScrollSnaps(emblaApi.scrollSnapList());
-    }, 200);
-
-    useEffect(() => {
-        window.addEventListener('resize', handleResize);
-        return () => {
-            window.removeEventListener('resize', handleResize);
+            for (const slide of slider.slides) {
+                observer.observe(slide);
+            }
         };
-    }, [handleResize]);
 
-    if (typeof document !== 'undefined') {
-        let r = document.querySelector(`.embla__carousel_wrapper_${carouselKey}`) as any;
-        if (r) {
-            if (slidesPerPage) {
-                r.style.setProperty(
-                    '--embla__slidesPerPage',
-                    `calc(${(1 / slidesPerPage) * 100}%)`
-                );
+        slider.on('created', setAriaHidden);
+        slider.on('updated', setAriaHidden);
+        slider.on('slideChanged', setAriaHidden);
+    };
+
+    // Handle the adaptive height of the carousel
+    const AdaptiveHeight: KeenSliderPlugin = (slider) => {
+        if (!adaptiveHeight) return;
+
+        // We want to make sure that the slides don't stretch to fill the height of the container
+        slider.container.style.alignItems = 'flex-start';
+
+        const updateHeight = () => {
+            const slidesInView = [];
+
+            const observer = new IntersectionObserver(
+                (entries) => {
+                    saveSlidesInView(entries, slidesInView);
+
+                    let largestSlideHeight: number =
+                        slider.slides[slider.track.details.rel].offsetHeight;
+
+                    for (const slide of slidesInView) {
+                        if (slider.slides[slide]?.offsetHeight > largestSlideHeight) {
+                            largestSlideHeight = slider.slides[slide]?.offsetHeight;
+                        }
+                    }
+                    slider.container.style.height = largestSlideHeight + 'px';
+                },
+                {
+                    root: slider.container,
+                    rootMargin: '0px',
+                    threshold: 0.5, // Fire when 50% of the slide is in view
+                }
+            );
+
+            for (const slide of slider.slides) {
+                observer.observe(slide);
             }
-            if (slideGap) {
-                r.style.setProperty('--embla__slideGap', slideGap + 'px');
-            }
-            if (axis) {
-                r.style.setProperty('--embla__axis', axis === 'x' ? 'row' : 'column');
-            }
-            if (height) {
-                r.style.setProperty('--embla__height', height + 'px');
-                r.style.setProperty(
-                    '--embla__style_height',
-                    `calc(${parseInt(height, 10) / slidesPerPage}px - ${slideGap * 2}px)`
-                );
-            }
+        };
+        slider.on('created', updateHeight);
+        slider.on('updated', updateHeight);
+        slider.on('slideChanged', updateHeight);
+    };
+
+    // Handle the animation of the slides, this is a "plugin" for keen-slider and gets called in the useKeenSlider hook
+    const AutoPlay: KeenSliderPlugin = (slider) => {
+        switch (autoplay) {
+            case 'switch':
+                let timeout: ReturnType<typeof setTimeout>;
+                let mouseOver = false;
+
+                function clearNextTimeout() {
+                    clearTimeout(timeout);
+                }
+
+                function nextTimeout() {
+                    clearTimeout(timeout);
+
+                    if (mouseOver) return;
+
+                    timeout = setTimeout(() => {
+                        slider.next();
+                    }, autoPlaySpeed);
+                }
+
+                slider.on('created', () => {
+                    slider.container.addEventListener('mouseover', () => {
+                        mouseOver = true;
+                        clearNextTimeout();
+                    });
+
+                    slider.container.addEventListener('mouseout', () => {
+                        mouseOver = false;
+                        nextTimeout();
+                    });
+
+                    nextTimeout();
+                });
+
+                slider.on('dragStarted', clearNextTimeout);
+                slider.on('animationEnded', nextTimeout);
+                slider.on('updated', nextTimeout);
+                slider.on('destroyed', clearNextTimeout); // Prevent memory leak
+                break;
+
+            case 'smooth':
+                const animation = { duration: autoPlaySpeed, easing: (t: number) => t };
+
+                slider.on('created', () => {
+                    // Decrement slides length by 1 as we are targeting the index rather than the count
+                    slider.moveToIdx(slider.track.details.slides.length - 1, true, animation);
+                });
+
+                slider.on('updated', () => {
+                    // Update function called due to a size change or other trigger.
+                    slider.moveToIdx(
+                        slider.track.details.abs + (slider.track.details.slides.length - 1),
+                        true,
+                        animation
+                    );
+                });
+
+                slider.on('animationEnded', () => {
+                    slider.moveToIdx(
+                        slider.track.details.abs + (slider.track.details.slides.length - 1),
+                        true,
+                        animation
+                    );
+                });
+                break;
+
+            default:
+                break;
         }
-    }
+    };
 
-    const scrollTo = useCallback(
-        (index) => {
-            if (emblaApi) {
-                emblaApi.scrollTo(index);
+    // Control the carousel with the keyboard
+    const KeyboardControls: KeenSliderPlugin = (slider) => {
+        let focused = false;
+
+        const eventFocus = () => {
+            focused = true;
+        };
+
+        const eventBlur = () => {
+            focused = false;
+        };
+
+        const eventKeydown = (e: KeyboardEvent) => {
+            if (!focused) return;
+
+            switch (e.key) {
+                case 'Left':
+                case 'ArrowLeft':
+                    slider.prev();
+                    break;
+
+                case 'Right':
+                case 'ArrowRight':
+                    slider.next();
+                    break;
+
+                default:
+                    break;
             }
+        };
+
+        slider.on('created', () => {
+            slider.container.setAttribute('tabindex', '0');
+            slider.container.addEventListener('focus', eventFocus);
+            slider.container.addEventListener('blur', eventBlur);
+            slider.container.addEventListener('keydown', eventKeydown);
+        });
+    };
+
+    // Handle keen-slider settings and call plugins
+    const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>(
+        {
+            initial: startIndex,
+            created() {
+                setSliderHasLoaded(true);
+            },
+            slideChanged(slider) {
+                setCurrentSlide(slider.track.details.rel);
+            },
+            loop: loop,
+            slides: {
+                origin: slideOrigin,
+                perView: slidesPerView,
+                spacing: gap,
+            },
+            breakpoints,
         },
-        [emblaApi]
+        [
+            // add plugins here
+            AdaptiveHeight,
+            AutoPlay,
+            AriaPlugin,
+            KeyboardControls,
+        ]
     );
-
-    const scrollPrev = useCallback(() => {
-        if (emblaApi) {
-            emblaApi.scrollPrev();
-        }
-    }, [emblaApi]);
-
-    const scrollNext = useCallback(() => {
-        if (emblaApi) {
-            emblaApi.scrollNext();
-        }
-    }, [emblaApi]);
 
     return (
-        <div>
-            <div className="embla">
-                <div
-                    aria-roledescription="carousel"
-                    role="region"
-                    className="embla__viewport"
-                    ref={emblaRef}
-                >
-                    <div aria-live={delay ? 'off' : 'polite'} className="embla__container">
-                        {mediaArray?.map((q, index) => {
-                            return (
-                                <div
-                                    key={`${index}`}
-                                    role="group"
-                                    aria-label={`${index + 1} of ${mediaArray?.length}`}
-                                    aria-roledescription="slide"
-                                    className={`embla__slide ${
-                                        typeof document !== 'undefined' && carouselVisible
-                                            ? 'embla-carousel-loaded'
-                                            : ''
-                                    }`}
-                                >
-                                    <div className="embla__slide_inner">
-                                        <p className="embla__slide_caption">{q.caption}</p>
-                                        {q.src && (
-                                            <Image
-                                                className="o-img o-img--cover"
-                                                height={q.height}
-                                                width={q.width}
-                                                src={q.src}
-                                                artDirectedImages={q.responsiveImages}
-                                                alt={q.alt ?? ''}
-                                            />
-                                        )}
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                    <div className="indicators">
-                        {scrollSnaps.length > 1 && (
-                            <button className="embla__prev" onClick={scrollPrev}>
-                                Prev
-                            </button>
-                        )}
-                        {scrollSnaps.length > 1 && (
-                            <button className="embla__next" onClick={scrollNext}>
-                                Next
-                            </button>
-                        )}
-                    </div>
-                </div>
-            </div>
-            <div className="embla__navigator">
-                {scrollSnaps.map((_, indicatorIndex) => {
-                    if (scrollSnaps.length > 1) {
-                        return (
-                            <button
-                                className="embla__dots"
-                                key={indicatorIndex + '_indicator'}
-                                style={{
-                                    backgroundColor:
-                                        selectedIndex === indicatorIndex ? 'lightblue' : 'lightgray'
-                                }}
-                                onClick={() => {
-                                    scrollTo(indicatorIndex);
-                                }}
-                            />
-                        );
-                    }
-                    return <></>;
+        <section
+            className={classes}
+            aria-label={carouselName}
+            aria-roledescription="carousel"
+            // If autoplay is enabled, we don't want to announce the slides as they change
+            // See basic carousel elements: https://www.w3.org/WAI/ARIA/apg/patterns/carousel/
+            aria-live={autoplay ? 'off' : 'polite'}
+            aria-atomic="true"
+        >
+            <div ref={sliderRef} className="c-carousel__inner keen-slider">
+                {Children.map(children, (child, index) => {
+                    const numberOfChildren = Children.count(children);
+
+                    return (
+                        // We need the keen-slider__slide class to be able to use the keen-slider
+                        <div
+                            role="group"
+                            aria-label={`${index + 1} of ${numberOfChildren}`}
+                            aria-roledescription="slide"
+                            className="c-carousel__slide keen-slider__slide"
+                            key={index}
+                            data-slide-index={index}
+                        >
+                            {child}
+                        </div>
+                    );
                 })}
             </div>
-        </div>
-    );
-};
 
-export const Carousel: FC<Props> = (props) => {
-    const { mediaArray } = props;
-    const [carouselKey, setCarouselKey] = useState('');
+            {/* IF we have arrows enabled AND the slider has loaded AND the current object is available on the instance */}
+            {arrows && sliderHasLoaded && instanceRef.current && (
+                <>
+                    <Arrow
+                        left
+                        onClick={(e: any) => e.stopPropagation() || instanceRef.current?.prev()}
+                        // IF the loop is false AND the current slide is the first slide
+                        disabled={!loop && currentSlide === 0}
+                    />
 
-    useEffect(() => {
-        if (!carouselKey) setCarouselKey(uuidv4());
-        setCarouselKey(props.carouselKey);
-    }, [carouselKey, props.carouselKey]);
+                    <Arrow
+                        onClick={(e: any) => e.stopPropagation() || instanceRef.current?.next()}
+                        // IF the loop is false AND the current slide matches the max index
+                        disabled={
+                            !loop && currentSlide === instanceRef.current.track.details.maxIdx
+                        }
+                    />
+                </>
+            )}
 
-    return (
-        <div
-            key={`${carouselKey}-${mediaArray.length}`}
-            className={`embla__carousel_wrapper_${carouselKey}`}
-        >
-            <CarouselInner {...props} carouselKey={carouselKey}></CarouselInner>
-        </div>
+            {/* IF we have dots enabled AND the slider has loaded AND the current object is available on the instance */}
+            {dotNav && sliderHasLoaded && instanceRef.current && (
+                <CarouselDots
+                    instanceRef={instanceRef}
+                    currentSlide={currentSlide}
+                    justifyDotNav={justifyDotNav}
+                />
+            )}
+        </section>
     );
 };

--- a/packages/osc-ui/src/components/Carousel/CarouselArrows.tsx
+++ b/packages/osc-ui/src/components/Carousel/CarouselArrows.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { classNames } from '../../utils/classNames';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
+
+interface ArrowProps {
+    disabled: boolean;
+    left?: boolean;
+    onClick: (e: any) => void;
+}
+
+export const Arrow = (props: ArrowProps) => {
+    const { disabled, left, onClick } = props;
+    const classes = classNames(
+        'c-carousel__arrow',
+        left && 'c-carousel__arrow--left',
+        !left && 'c-carousel__arrow--right'
+    );
+
+    return (
+        <button className={classes} onClick={onClick} disabled={disabled}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                {left ? (
+                    <path d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z" />
+                ) : null}
+
+                {!left ? <path d="M5 3l3.057-3 11.943 12-11.943 12-3.057-3 9-9z" /> : null}
+            </svg>
+            <VisuallyHidden>{left ? 'Previous slide' : 'Next slide'}</VisuallyHidden>
+        </button>
+    );
+};

--- a/packages/osc-ui/src/components/Carousel/CarouselDots.tsx
+++ b/packages/osc-ui/src/components/Carousel/CarouselDots.tsx
@@ -1,0 +1,49 @@
+import type { KeenSliderHooks, KeenSliderInstance } from 'keen-slider/react';
+import type { FC, MutableRefObject } from 'react';
+import React from 'react';
+import { useVariant } from '../../hooks/useVariant';
+import { classNames } from '../../utils/classNames';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
+
+interface Props {
+    instanceRef: MutableRefObject<KeenSliderInstance<{}, {}, KeenSliderHooks>>;
+    currentSlide: number;
+    justifyDotNav?: 'start' | 'center' | 'end';
+}
+
+export const CarouselDots: FC<Props> = (props: Props) => {
+    const { instanceRef, currentSlide } = props;
+    const justify = useVariant('c-carousel__dots', props.justifyDotNav);
+
+    const classes = classNames('c-carousel__dots', justify);
+
+    // IF loop is true we want to the number of dots to match the number of slides
+    // ELSE we want to create an array from the max index value (plus one as it's zero indexed)
+    /*
+     * NOTE: If you swap from loop to not loop, the dots will not update until you interact with the carousel
+     * The only likely instance of being able to toggle between looping and not looping is in Storybook so I've
+     * decided to leave this as is for now.
+     */
+    const dots =
+        instanceRef.current?.track?.details?.maxIdx === Infinity
+            ? instanceRef.current?.slides
+            : [...Array(instanceRef.current?.track?.details?.maxIdx + 1).keys()];
+
+    return (
+        <div className={classes}>
+            {dots.map((slide, index) => {
+                return (
+                    <button
+                        key={index}
+                        onClick={() => {
+                            instanceRef.current?.moveToIdx(index);
+                        }}
+                        className={'c-carousel__dot' + (currentSlide === index ? ' is-active' : '')}
+                    >
+                        <VisuallyHidden>{`Go to slide ${index + 1}`}</VisuallyHidden>
+                    </button>
+                );
+            })}
+        </div>
+    );
+};

--- a/packages/osc-ui/src/components/Carousel/CarouselDots.tsx
+++ b/packages/osc-ui/src/components/Carousel/CarouselDots.tsx
@@ -1,7 +1,7 @@
 import type { KeenSliderHooks, KeenSliderInstance } from 'keen-slider/react';
 import type { FC, MutableRefObject } from 'react';
 import React from 'react';
-import { useVariant } from '../../hooks/useVariant';
+import { useModifier } from '../../hooks/useModifier';
 import { classNames } from '../../utils/classNames';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 
@@ -13,7 +13,7 @@ interface Props {
 
 export const CarouselDots: FC<Props> = (props: Props) => {
     const { instanceRef, currentSlide } = props;
-    const justify = useVariant('c-carousel__dots', props.justifyDotNav);
+    const justify = useModifier('c-carousel__dots', props.justifyDotNav);
 
     const classes = classNames('c-carousel__dots', justify);
 

--- a/packages/osc-ui/src/components/Carousel/carousel.scss
+++ b/packages/osc-ui/src/components/Carousel/carousel.scss
@@ -1,101 +1,117 @@
-/* stylelint-disable all */
-@use "../../styles/tools/functions/get-tokens" as *;
-@use "../../styles/tools/mq" as *;
+/* stylelint-disable selector-class-pattern */
+.c-carousel {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
 
-.embla {
-    overflow: hidden;
-    display: flex;
-    flex-direction: row;
-    position: relative;
+    &__inner {
+        grid-column: 1 / -1;
 
-    .embla__slide_caption {
-        padding: 0;
-        margin: 0;
+        // Required Keen styles
+        &:not([data-keen-slider-disabled]) {
+            position: relative;
+            display: flex;
+            align-content: flex-start;
+            width: 100%;
+            overflow: hidden;
+            -webkit-touch-callout: none;
+            touch-action: pan-y;
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        &:not([data-keen-slider-disabled]) .keen-slider__slide {
+            position: relative;
+            width: 100%;
+            min-height: 100%;
+            overflow: hidden;
+        }
+
+        &:not([data-keen-slider-disabled])[data-keen-slider-reverse] {
+            flex-direction: row-reverse;
+        }
+
+        &:not([data-keen-slider-disabled])[data-keen-slider-v] {
+            flex-wrap: wrap;
+        }
+
+        // End required Keen styles
     }
 
-    .indicators {
-        position: absolute;
-        top: 0;
-        width: 100%;
-        height: 100%;
+    // Arrows
+    /* stylelint-disable-next-line plugin/selector-bem-pattern */
+    &.has-adaptive-height .c-carousel__slide {
+        min-height: auto;
+    }
+
+    &__arrow {
+        width: 30px;
+        height: 30px;
+        color: hsl(0deg 0% 73%); // TODO: Use a variable
+        cursor: pointer;
+
+        &--left {
+            grid-column: 1 / 2;
+        }
+
+        &--right {
+            grid-column: 3 / 4;
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        &[disabled] {
+            color: hsl(0deg 0% 73% / 50%);
+            cursor: auto;
+        }
+    }
+
+    // DotNav
+    &__dots {
         display: flex;
-        justify-content: space-between;
-        color: white;
+        padding: 10px 0;
 
-        .embla__next {
-            position: relative;
-            right: 30px;
+        &--start {
+            justify-content: flex-start;
         }
 
-        .embla__prev {
-            position: relative;
-            left: 30px;
+        &--end {
+            justify-content: flex-end;
+        }
+
+        &--center {
+            justify-content: center;
+        }
+    }
+
+    &__dot {
+        width: 12px;
+        height: 12px;
+        margin: 0 2px;
+        background: hsl(0deg 0% 100% / 0%); // TODO: Use a variable
+        border: 1px solid hsl(0deg 0% 73%); // TODO: Use a variable
+        border-radius: 50%;
+        cursor: pointer;
+
+        &:focus {
+            outline: none;
+        }
+
+        &.is-active {
+            background: hsl(0deg 0% 73%); // TODO: Use a variable
+        }
+    }
+
+    &.has-arrows {
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+
+        .c-carousel__inner,
+        .c-carousel__dots {
+            grid-column: 2 / 3;
+        }
+
+        .c-carousel__inner,
+        .c-carousel__arrow {
+            grid-row: 1;
         }
     }
 }
-
-.embla .embla-carousel-loaded {
-    opacity: 1;
-}
-
-.embla__container {
-    display: flex;
-    flex-direction: var(--embla__axis);
-    height: var(--embla__height);
-    align-items: flex-start;
-    transition: height 0.2s;
-}
-
-.embla__slide {
-    opacity: 0;
-    flex: 0 0 100%;
-    overflow: hidden;
-
-    .embla__slide-loaded {
-        overflow: visible;
-    }
-
-    @include mq(mq-token("mob")) {
-        flex: 0 0 100%;
-    }
-
-    @include mq(mq-token("mob-lrg")) {
-        flex: 0 0 50%;
-    }
-
-    @include mq(mq-token("tab")) {
-        flex: 0 0 var(--embla__slidesPerPage);
-    }
-}
-
-// img {
-//     width: 100%;
-//     height: 100%;
-//     object-fit: cover;
-// }
-
-.embla__slide_inner {
-    height: var(--embla__height);
-    margin: var(--embla__slideGap);
-    padding: var(--embla__slideGap);
-}
-
-.embla__navigator {
-    display: flex;
-    justify-content: center;
-    margin-bottom: 24px;
-    margin-top: 10px;
-}
-.embla__dots {
-    cursor: pointer;
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    margin: 3px;
-    box-shadow: 0px 0px 20px rgb(0 0 0 / 10%);
-}
-
-// IF slide layout is 3 slides per page
-// 0px -> 560px = width of slide = 100% - 1 slide per page
-// 561px -> 768px = width of slide = 50%
-// 769px ->  = width of slide = 33.33%

--- a/packages/osc-ui/src/utils/rem.spec.ts
+++ b/packages/osc-ui/src/utils/rem.spec.ts
@@ -1,0 +1,7 @@
+import { rem } from './rem';
+
+test('returns a calculated rem value', () => {
+    expect(rem(16)).toBe(1);
+    expect(rem(32)).toBe(2);
+    expect(rem(48)).toBe(3);
+});

--- a/packages/osc-ui/src/utils/rem.ts
+++ b/packages/osc-ui/src/utils/rem.ts
@@ -1,0 +1,8 @@
+/**
+ * Calculates the rem value of a number, based on the base font size of 16px
+ *
+ * @param n A number in px to convert to rem
+ * @returns A number in rem
+ * @example rem(32) // 2
+ */
+export const rem = (n: number) => n / 16;

--- a/packages/osc-ui/tsconfig.json
+++ b/packages/osc-ui/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2019",
     "moduleResolution": "node",
     "declaration": true,
     "declarationDir": "dist/dts",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #227 

## 📝 Description

Refactors carousel component from Embla to Keen Slider

## ⛳️ Current behavior (updates)

Current carousel depends on [Embla Carousel](https://www.embla-carousel.com/)

## 🚀 New behavior

New carousel depends on [Keen Slider](https://keen-slider.io/)

Tests and stories have been updated to reflect these new props. 

## 💣 Is this a breaking change (Yes/No): Yes

I have updated the Sanity schema but I **have not** updated the queries into `ecommerce` in this PR as they will be more related to elements like the cards(https://github.com/Open-Study-College/osc/pull/540) or the hero which will depend on this component -- so it felt out of scope for this PR, especially if we'll be updating the usage of the schema anyway.

## 📝 Additional Information
https://keen-slider.io/docs
