### PR TITLE
Refactor/downgrade sanity cli

### DIFF
--- a/packages/osc-studio/package.json
+++ b/packages/osc-studio/package.json
@@ -5,8 +5,8 @@
   "description": "",
   "main": "package.json",
   "scripts": {
-    "dev": "npx @sanity/cli start",
-    "build": "npx @sanity/cli build"
+    "dev": "npx @sanity/cli@2.29.3 start",
+    "build": "npx @sanity/cli@2.29.3 build"
   },
   "keywords": [
     "sanity"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Enforces version 2 of the Sanity cli in the `osc-studio` `package.json` file

## ⛳️ Current behavior (updates)

Currently the package will try to use the `v3` cli by default. This is causing an issue with reading our environment variables so will take us through the default setup and add the project id and dataset to our config file instead.

## 🚀 New behavior

This change makes sure we are using the cli package to match our studio version (2) and keeps the expected behaviour until we upgrade.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
