### PR TITLE
feat: add TextInput component, styles and tests

### DIFF
--- a/packages/osc-ui/package.json
+++ b/packages/osc-ui/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-dropdown-menu": "^2.0.1",
     "@radix-ui/react-icons": "^1.1.1",
+    "@radix-ui/react-label": "^2.0.0",
     "@radix-ui/react-popover": "^1.0.2",
     "@radix-ui/react-slider": "^1.1.0",
     "@radix-ui/react-slot": "^1.0.1",

--- a/packages/osc-ui/src/components/Label/Label.tsx
+++ b/packages/osc-ui/src/components/Label/Label.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { FC } from 'react';
+import * as RadixLabel from '@radix-ui/react-label';
+import './label.scss';
+import { useModifier } from '../../hooks/useModifier';
+import { classNames } from '../../utils/classNames';
+export interface Props {
+    htmlFor: string;
+    name: string;
+    required?: boolean;
+    variants?: string[];
+}
+
+export const Label: FC<Props> = (props: Props) => {
+    const { htmlFor, name, required = false, variants } = props;
+    const modifier = useModifier('c-label', variants);
+    const classes = classNames('c-label', modifier);
+    return (
+        <>
+            <RadixLabel.Root className={classes} htmlFor={htmlFor}>
+                {name}
+                {required ? <span className="c-label__required">* </span> : null}
+            </RadixLabel.Root>
+        </>
+    );
+};

--- a/packages/osc-ui/src/components/Label/Label.tsx
+++ b/packages/osc-ui/src/components/Label/Label.tsx
@@ -4,17 +4,30 @@ import * as RadixLabel from '@radix-ui/react-label';
 import './label.scss';
 import { useModifier } from '../../hooks/useModifier';
 import { classNames } from '../../utils/classNames';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 export interface Props {
     htmlFor: string;
+    hidden?: boolean;
     name: string;
     required?: boolean;
     variants?: string[];
 }
 
 export const Label: FC<Props> = (props: Props) => {
-    const { htmlFor, name, required = false, variants } = props;
+    const { hidden, htmlFor, name, required = false, variants } = props;
     const modifier = useModifier('c-label', variants);
     const classes = classNames('c-label', modifier);
+
+    if (hidden) {
+        return (
+            <VisuallyHidden>
+                <RadixLabel.Root className={classes} htmlFor={htmlFor}>
+                    {name}
+                    {required ? <span className="c-label__required">* </span> : null}
+                </RadixLabel.Root>
+            </VisuallyHidden>
+        );
+    }
     return (
         <>
             <RadixLabel.Root className={classes} htmlFor={htmlFor}>

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -7,12 +7,12 @@
     font-weight: $weight-reg;
     cursor: pointer;
 
+    &__required {
+        padding-left: 0.063em;
+        font-size: var(--font-scale-centi);
+    }
+
     &--bold {
         font-weight: $weight-bold;
     }
-}
-
-.c-label__required {
-    padding-left: 1px;
-    font-size: var(--font-scale-centi);
 }

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -1,0 +1,18 @@
+/* stylelint-disable selector-class-pattern */
+@use "../../styles/settings" as *;
+/* stylelint-disable plugin/selector-bem-pattern */
+
+.c-label {
+    font-size: var(--font-scale-centi);
+    font-weight: $weight-reg;
+    cursor: pointer;
+
+    &--bold {
+        font-weight: $weight-bold;
+    }
+}
+
+.c-label__required {
+    padding-left: 1px;
+    font-size: var(--font-scale-centi);
+}

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -4,7 +4,6 @@
 /* stylelint-disable plugin/selector-bem-pattern */
 
 .c-label {
-    font-size: var(--font-scale-base);
     font-weight: $fw-reg;
     cursor: pointer;
 

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -1,15 +1,15 @@
 /* stylelint-disable selector-class-pattern */
+@use "sass:math";
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
 .c-label {
-    font-size: var(--font-scale-centi);
+    font-size: var(--font-scale-base);
     font-weight: $weight-reg;
     cursor: pointer;
 
     &__required {
         padding-left: 0.063em;
-        font-size: var(--font-scale-centi);
     }
 
     &--bold {

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -5,14 +5,14 @@
 
 .c-label {
     font-size: var(--font-scale-base);
-    font-weight: $weight-reg;
+    font-weight: $fw-reg;
     cursor: pointer;
 
     &__required {
-        padding-inline-start: #{math.div(1, $base-font-size)}em;
+        padding-inline-start: #{math.div(1, $base-fs)}em;
     }
 
     &--bold {
-        font-weight: $weight-bold;
+        font-weight: $fw-bold;
     }
 }

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -9,7 +9,7 @@
     cursor: pointer;
 
     &__required {
-        padding-left: 0.063em;
+        padding-inline-start: #{math.div(1, $base-font-size)}em;
     }
 
     &--bold {

--- a/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
@@ -33,7 +33,10 @@ test('should render a button with icon if action is set to type "submit" and pas
             type="text"
             id="test-input"
             name="Test Input"
-            action={{ label: 'Magnifying Glass', icon: <MagnifyingGlassIcon />, type: 'submit' }}
+            action={{
+                icon: { content: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+                type: 'submit',
+            }}
         />
     );
     expect(screen.getByRole('button')).toBeInTheDocument();

--- a/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { TextInput } from './TextInput';
-import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
+import { ExclamationTriangleIcon, MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import userEvent from '@testing-library/user-event';
 
 test('should render a text input component and a label', () => {
@@ -49,16 +49,9 @@ test('should disable the input when disabled prop is true', () => {
 });
 
 test('should render correct variant classes', () => {
-    render(
-        <TextInput
-            type="text"
-            id="test-input"
-            name="Test Input"
-            variants={['secondary', 'error']}
-        />
-    );
+    render(<TextInput type="text" id="test-input" name="Test Input" variants={['secondary']} />);
     expect(screen.getByLabelText('Test Input')).toHaveClass(
-        'c-input__text c-input__text--secondary c-input__text--error'
+        'c-input__text c-input__text--secondary'
     );
 });
 
@@ -67,9 +60,13 @@ test('should render error message if "wasSubmitted" is true, the field is requir
         <TextInput
             type="text"
             id="test-input"
+            icon={{
+                content: <ExclamationTriangleIcon />,
+                label: 'Exclamation Triangle Icon',
+                type: 'error',
+            }}
             name="Test Input"
             required={true}
-            variants={['error']}
             wasSubmitted={true}
         />
     );

--- a/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { TextInput } from './TextInput';
+import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
+import userEvent from '@testing-library/user-event';
+
+test('should render a text input component and a label', () => {
+    render(<TextInput type="text" id="test-input" name="Test Input" />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByLabelText('Test Input')).toBeInTheDocument();
+});
+
+test('should render an asterisk when input field is required', () => {
+    render(<TextInput type="text" id="test-input" name="Test Input" required={true} />);
+    expect(screen.getByRole('textbox', { name: 'Test Input *' })).toBeInTheDocument();
+});
+
+test('should render an icon when passed as a prop', () => {
+    render(
+        <TextInput
+            type="text"
+            id="test-input"
+            name="Test Input"
+            icon={{ content: <MagnifyingGlassIcon />, label: 'Magnifying Glass' }}
+        />
+    );
+    expect(screen.getByText('Magnifying Glass')).toBeInTheDocument();
+});
+
+test('should render a button with icon if action is set to type "submit" and passed an Icon', () => {
+    render(
+        <TextInput
+            type="text"
+            id="test-input"
+            name="Test Input"
+            action={{ label: 'Magnifying Glass', icon: <MagnifyingGlassIcon />, type: 'submit' }}
+        />
+    );
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByText('Magnifying Glass')).toBeInTheDocument();
+});
+
+test('should disable the input when disabled prop is true', () => {
+    render(<TextInput type="text" id="test-input" name="Test Input" disabled={true} />);
+    expect(screen.getByRole('textbox')).toBeDisabled();
+});
+
+test('should render correct variant classes', () => {
+    render(
+        <TextInput
+            type="text"
+            id="test-input"
+            name="Test Input"
+            variants={['secondary', 'error']}
+        />
+    );
+    expect(screen.getByLabelText('Test Input')).toHaveClass(
+        'c-input__text c-input__text--secondary c-input__text--error'
+    );
+});
+
+test('should render error message if "wasSubmitted" is true, the field is required, and no value is present', () => {
+    render(
+        <TextInput
+            type="text"
+            id="test-input"
+            name="Test Input"
+            required={true}
+            variants={['error']}
+            wasSubmitted={true}
+        />
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+});
+
+test('should change focus to second input when using the tab key', () => {
+    render(
+        <>
+            <TextInput type="text" id="test-input-1" name="Test Input 1" />
+            <TextInput type="text" id="test-input-2" name="Test Input 2" />
+        </>
+    );
+
+    const input1 = screen.getByRole('textbox', { name: 'Test Input 1' });
+    const input2 = screen.getByRole('textbox', { name: 'Test Input 2' });
+
+    input1.focus();
+    userEvent.tab();
+
+    expect(input2).toHaveFocus();
+});

--- a/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta, Story } from '@storybook/react';
 import React, { useEffect, useRef } from 'react';
 
 import { TextInput } from './TextInput';
-import { ExclamationTriangleIcon, MagnifyingGlassIcon } from '@radix-ui/react-icons';
+import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
+import { Icon } from '../Icon/Icon';
 
 export default {
     title: 'osc-ui/TextInput',
@@ -109,7 +110,7 @@ Primary.args = {
             name: 'Full Name',
             editor: 'input',
             icon: {
-                content: <ExclamationTriangleIcon />,
+                content: <Icon id="exclamation-mark" />,
                 label: 'Exclamation Triangle Icon',
                 type: 'error',
             },
@@ -163,7 +164,7 @@ Secondary.args = {
             name: 'Full Name',
             editor: 'input',
             icon: {
-                content: <ExclamationTriangleIcon />,
+                content: <Icon id="exclamation-mark" />,
                 label: 'Exclamation Triangle Icon',
                 type: 'error',
             },
@@ -218,7 +219,7 @@ Tertiary.args = {
             name: 'Full Name',
             editor: 'input',
             icon: {
-                content: <ExclamationTriangleIcon />,
+                content: <Icon id="exclamation-mark" />,
                 label: 'Exclamation Triangle Icon',
                 type: 'error',
             },

--- a/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, Story } from '@storybook/react';
+import React, { useEffect, useRef } from 'react';
+
+import { TextInput } from './TextInput';
+import { ExclamationTriangleIcon, MagnifyingGlassIcon } from '@radix-ui/react-icons';
+
+export default {
+    title: 'osc-ui/TextInput',
+    component: TextInput,
+    parameters: {
+        docs: {
+            description: {
+                component: 'Input component',
+            },
+        },
+    },
+    argTypes: {},
+} as Meta;
+
+const states = {
+    default: 'Default',
+    hasValue: 'Has Value',
+    hasFocus: 'Has Focus',
+    isDisabled: 'Is Disabled',
+    hasValidation: 'Has Validation',
+    inline: 'Inline',
+    inlineIcon: 'Inline Icon',
+};
+
+const Template: Story = ({ items }) => {
+    const selectRef = useRef(null);
+
+    useEffect(() => {
+        selectRef.current?.focus();
+    }, []);
+
+    return (
+        <div>
+            {items.map((item, i) => (
+                <div key={i} style={{ margin: '1em' }}>
+                    <p style={{ fontWeight: '700', padding: '.5em 0' }}>{states[item.state]}</p>
+                    <TextInput {...item} ref={item.ref ? selectRef : null} />
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export const Primary = Template.bind({});
+export const Secondary = Template.bind({});
+export const Tertiary = Template.bind({});
+export const Quaternary = Template.bind({});
+
+Primary.args = {
+    items: [
+        {
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-1',
+            required: true,
+            type: 'text',
+            state: 'default',
+        },
+        {
+            defaultValue: 'Sarah',
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-2',
+            required: true,
+            type: 'text',
+            state: 'hasValue',
+        },
+        {
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-3',
+            ref: true,
+            required: true,
+            type: 'text',
+            state: 'hasFocus',
+        },
+        {
+            name: 'Full Name',
+            editor: 'input',
+            icon: { content: <ExclamationTriangleIcon />, label: 'Exclamation Triangle Icon' },
+            id: 'full-name-4',
+            required: true,
+            type: 'text',
+            state: 'hasValidation',
+            variants: ['error'],
+            wasSubmitted: true,
+        },
+        {
+            defaultValue: 'Sarah',
+            name: 'Full Name',
+            disabled: true,
+            editor: 'input',
+            id: 'full-name-5',
+            type: 'text',
+            state: 'isDisabled',
+        },
+    ],
+};
+
+Secondary.args = {
+    items: [
+        {
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-1',
+            type: 'text',
+            variants: ['secondary'],
+            state: 'default',
+        },
+        {
+            defaultValue: 'Sarah',
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-2',
+            type: 'text',
+            variants: ['secondary'],
+            state: 'hasValue',
+        },
+        {
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-3',
+            ref: true,
+            type: 'text',
+            variants: ['secondary'],
+            state: 'hasFocus',
+        },
+        {
+            name: 'Full Name',
+            editor: 'input',
+            icon: { content: <ExclamationTriangleIcon />, label: 'Exclamation Triangle Icon' },
+            id: 'full-name-4',
+            required: true,
+            type: 'text',
+            variants: ['secondary', 'error'],
+            state: 'hasValidation',
+            wasSubmitted: true,
+        },
+        {
+            name: 'Full Name',
+            disabled: true,
+            editor: 'input',
+            id: 'full-name-5',
+            type: 'text',
+            variants: ['secondary'],
+            state: 'isDisabled',
+        },
+    ],
+};
+
+Tertiary.args = {
+    items: [
+        {
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-1',
+            state: 'default',
+            type: 'text',
+            variants: ['tertiary'],
+        },
+        {
+            defaultValue: 'Sarah',
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-2',
+            state: 'hasValue',
+            type: 'text',
+            variants: ['tertiary'],
+        },
+        {
+            name: 'Full Name',
+            editor: 'input',
+            id: 'full-name-3',
+            ref: true,
+            state: 'hasFocus',
+            type: 'text',
+            variants: ['tertiary'],
+        },
+        {
+            name: 'Full Name',
+            editor: 'input',
+            icon: { content: <ExclamationTriangleIcon />, label: 'Exclamation Triangle Icon' },
+            id: 'full-name-4',
+            required: true,
+            state: 'hasValidation',
+            type: 'text',
+            variants: ['tertiary', 'error'],
+            wasSubmitted: true,
+        },
+        {
+            name: 'Full Name',
+            disabled: true,
+            editor: 'input',
+            id: 'full-name-5',
+            state: 'isDisabled',
+            type: 'text',
+            variants: ['tertiary'],
+        },
+    ],
+};
+
+Quaternary.args = {
+    items: [
+        {
+            action: { type: 'submit', icon: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+            editor: 'input',
+            id: 'search',
+            name: 'Search',
+            state: 'default',
+            type: 'text',
+            variants: ['quaternary'],
+        },
+        {
+            action: { type: 'submit', icon: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+            defaultValue: 'GCSE English',
+            editor: 'input',
+            id: 'search-1',
+            name: 'Search',
+            state: 'hasValue',
+            type: 'text',
+            variants: ['quaternary'],
+        },
+    ],
+};

--- a/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
@@ -108,12 +108,15 @@ Primary.args = {
         {
             name: 'Full Name',
             editor: 'input',
-            icon: { content: <ExclamationTriangleIcon />, label: 'Exclamation Triangle Icon' },
+            icon: {
+                content: <ExclamationTriangleIcon />,
+                label: 'Exclamation Triangle Icon',
+                type: 'error',
+            },
             id: 'full-name-4',
             required: true,
             type: 'text',
             state: 'hasValidation',
-            variants: ['error'],
             wasSubmitted: true,
         },
         {
@@ -159,11 +162,15 @@ Secondary.args = {
         {
             name: 'Full Name',
             editor: 'input',
-            icon: { content: <ExclamationTriangleIcon />, label: 'Exclamation Triangle Icon' },
+            icon: {
+                content: <ExclamationTriangleIcon />,
+                label: 'Exclamation Triangle Icon',
+                type: 'error',
+            },
             id: 'full-name-4',
             required: true,
             type: 'text',
-            variants: ['secondary', 'error'],
+            variants: ['secondary'],
             state: 'hasValidation',
             wasSubmitted: true,
         },
@@ -210,12 +217,16 @@ Tertiary.args = {
         {
             name: 'Full Name',
             editor: 'input',
-            icon: { content: <ExclamationTriangleIcon />, label: 'Exclamation Triangle Icon' },
+            icon: {
+                content: <ExclamationTriangleIcon />,
+                label: 'Exclamation Triangle Icon',
+                type: 'error',
+            },
             id: 'full-name-4',
             required: true,
             state: 'hasValidation',
             type: 'text',
-            variants: ['tertiary', 'error'],
+            variants: ['tertiary'],
             wasSubmitted: true,
         },
         {

--- a/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
@@ -64,7 +64,7 @@ const Template: Story = ({ items }) => {
     return (
         <div>
             {items.map((item, i) => (
-                <div key={i} style={{ margin: '1em' }}>
+                <div key={i} style={{ margin: '1em', width: '300px' }}>
                     <p style={{ fontWeight: '700', padding: '.5em 0' }}>{states[item.state]}</p>
                     <TextInput {...item} ref={item.ref ? selectRef : null} />
                 </div>
@@ -247,7 +247,11 @@ Quaternary.args = {
         {
             action: {
                 type: 'submit',
-                icon: { content: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+                icon: {
+                    content: <MagnifyingGlassIcon />,
+                    label: 'Magnifying Glass',
+                },
+                variant: 'quaternary',
             },
             editor: 'input',
             id: 'search',
@@ -259,7 +263,11 @@ Quaternary.args = {
         {
             action: {
                 type: 'submit',
-                icon: { content: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+                icon: {
+                    content: <MagnifyingGlassIcon />,
+                    label: 'Magnifying Glass',
+                },
+                variant: 'quaternary',
             },
             defaultValue: 'GCSE English',
             editor: 'input',

--- a/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
@@ -10,11 +10,37 @@ export default {
     parameters: {
         docs: {
             description: {
-                component: 'Input component',
+                component: 'Text Input component with Label for inputting form data',
             },
         },
     },
-    argTypes: {},
+    argTypes: {
+        action: { description: 'An action, such as a button which accepts an icon and a label' },
+        defaultValue: {
+            description: 'The value of the select when initially rendered.',
+        },
+        disabled: {
+            description: 'Sets a Select component as disabled',
+        },
+        id: {
+            description:
+                'The id of the select. Submitted with its owning form as part of a name/value pair.',
+        },
+        icon: {
+            description:
+                'An icon to be used with the input which requires both the Icon and a label for accessibility',
+        },
+        name: {
+            description: 'The name of input shown to the user which is displayed in the Label',
+        },
+        placeholder: { description: 'A placeholder value for the input field' },
+        ref: { description: 'A ref that is forwarded to the TextInput component' },
+        required: { description: 'Sets a Select as being a required field' },
+        variants: { description: 'Sets the custom styles, e.g. "Secondary", "Tertiary"' },
+        wasSubmitted: {
+            description: 'A boolean that alerts when form is submitted for error handling',
+        },
+    },
 } as Meta;
 
 const states = {

--- a/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
@@ -233,7 +233,10 @@ Tertiary.args = {
 Quaternary.args = {
     items: [
         {
-            action: { type: 'submit', icon: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+            action: {
+                type: 'submit',
+                icon: { content: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+            },
             editor: 'input',
             id: 'search',
             name: 'Search',
@@ -242,7 +245,10 @@ Quaternary.args = {
             variants: ['quaternary'],
         },
         {
-            action: { type: 'submit', icon: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+            action: {
+                type: 'submit',
+                icon: { content: <MagnifyingGlassIcon />, label: 'Magnifying Glass' },
+            },
             defaultValue: 'GCSE English',
             editor: 'input',
             id: 'search-1',

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -57,7 +57,9 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
         ...rest
     } = props;
 
-    const [value, setValue] = useState<string | number | readonly string[]>('');
+    const [value, setValue] = useState<string | number | readonly string[]>(
+        defaultValue ? defaultValue : ''
+    );
 
     const errorMessage = getFieldError(value, required);
     const displayError = wasSubmitted && errorMessage;
@@ -71,13 +73,6 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
 
     const iconModifier = useModifier('c-input__icon', variants);
     const iconClasses = classNames('c-input__icon', iconModifier);
-
-    useEffect(() => {
-        if (defaultValue) {
-            setValue(defaultValue);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- only needs to run on mount
-    }, []);
 
     return (
         <div className="c-input__outer-container">

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -18,6 +18,8 @@ type IconType = {
 type Action = {
     icon?: IconType;
     type: string;
+    variant?: Variants;
+    size?: 'sm' | 'md' | 'lg';
 };
 
 type Variants = 'secondary' | 'tertiary' | 'quaternary';
@@ -86,7 +88,11 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
         </div>
     );
 
-    const InputButton = ({ action: { icon, size, variant } }) => {
+    const InputButton = (props: { action: Action }) => {
+        const {
+            action: { icon, size, variant },
+        } = props;
+
         return (
             <Button className="c-input__button" variant={variant} size={size}>
                 {icon ? <AccessibleIcon label={icon.label}>{icon.content}</AccessibleIcon> : null}

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -1,0 +1,109 @@
+import type { HTMLInputTypeAttribute, InputHTMLAttributes, ReactNode } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
+import { useElement } from '../../hooks/useElement';
+import { useModifier } from '../../hooks/useModifier';
+import { classNames } from '../../utils/classNames';
+import { getFieldError } from '../../utils/getFieldError';
+import { Label } from '../Label/Label';
+import './text-input.scss';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+
+type Action = {
+    label?: string;
+    icon?: ReactNode;
+    type: string;
+};
+export interface Props extends InputHTMLAttributes<HTMLInputElement> {
+    action?: Action;
+    icon?: { content: ReactNode; label: string };
+    type: HTMLInputTypeAttribute;
+    variants?: string[];
+    wasSubmitted?: boolean;
+}
+
+export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forwardedRef) => {
+    const {
+        action,
+        defaultValue,
+        id,
+        icon,
+        name,
+        placeholder,
+        required,
+        type,
+        variants,
+        wasSubmitted = false,
+        ...rest
+    } = props;
+
+    const [value, setValue] = useState<string | number | readonly string[]>('');
+
+    const errorMessage = getFieldError(value, required);
+    const displayError = wasSubmitted && errorMessage;
+
+    const element = useElement('c-input', type);
+    const variantsModifier = useModifier(element, variants);
+    const inputClasses = classNames('c-input', element, variantsModifier);
+
+    const containerModifier = useModifier('c-input__container', variants);
+    const containerClasses = classNames('c-input__container', containerModifier);
+
+    const iconModifier = useModifier('c-input__icon', variants);
+    const iconClasses = classNames('c-input__icon', iconModifier);
+
+    useEffect(() => {
+        if (defaultValue) {
+            setValue(defaultValue);
+        }
+    }, []);
+
+    return (
+        <div className="c-input__outer-container">
+            <div
+                className={
+                    displayError
+                        ? `${containerClasses} c-input__container--error`
+                        : `${containerClasses}`
+                }
+            >
+                <input
+                    aria-invalid={displayError ? true : false}
+                    aria-describedby={displayError ? `${id}-error` : undefined}
+                    className={inputClasses}
+                    defaultValue={defaultValue}
+                    id={id}
+                    name={id}
+                    onChange={(event) => setValue(event.currentTarget.value)}
+                    placeholder={placeholder}
+                    ref={forwardedRef}
+                    type={type}
+                    {...rest}
+                />
+                <Label
+                    htmlFor={id}
+                    name={name}
+                    required={required}
+                    variants={value ? ['filled'] : null}
+                />
+                {icon ? (
+                    <div className={iconClasses}>
+                        <Icon label={icon.label}>{icon.content}</Icon>
+                    </div>
+                ) : null}
+                {displayError ? (
+                    <span className="c-input__error-message" role="alert" id={`${id}-error`}>
+                        {errorMessage}
+                    </span>
+                ) : null}
+            </div>
+            {action?.type === 'submit' ? (
+                <Button className="c-input__button">
+                    <Icon label={action?.label}>{action?.icon}</Icon>
+                </Button>
+            ) : null}
+        </div>
+    );
+});
+
+TextInput.displayName = 'TextInput';

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -73,6 +73,29 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
     const iconModifier = useModifier('c-input__icon', variants);
     const iconClasses = classNames('c-input__icon', iconModifier);
 
+    const InputError = () => (
+        <>
+            <div className="c-input__icon c-input__icon--error">
+                <Icon label={icon?.label}>{icon?.content}</Icon>
+            </div>
+            <span className="c-input__error-message" role="alert" id={`${id}-error`}>
+                {errorMessage}
+            </span>
+        </>
+    );
+
+    const InputIcon = () => (
+        <div className={iconClasses}>
+            <Icon label={icon.label}>{icon.content}</Icon>
+        </div>
+    );
+
+    const InputButton = () => (
+        <Button className="c-input__button">
+            <Icon label={action?.icon?.label}>{action?.icon?.content}</Icon>
+        </Button>
+    );
+
     return (
         <div className="c-input__outer-container">
             <div
@@ -100,27 +123,10 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
                     required={required}
                     variants={value ? ['filled'] : null}
                 />
-                {icon && icon.type !== 'error' ? (
-                    <div className={iconClasses}>
-                        <Icon label={icon.label}>{icon.content}</Icon>
-                    </div>
-                ) : null}
-                {displayError ? (
-                    <>
-                        <div className="c-input__icon c-input__icon--error">
-                            <Icon label={icon?.label}>{icon?.content}</Icon>
-                        </div>
-                        <span className="c-input__error-message" role="alert" id={`${id}-error`}>
-                            {errorMessage}
-                        </span>
-                    </>
-                ) : null}
+                {icon && icon.type !== 'error' ? <InputIcon /> : null}
+                {displayError ? <InputError /> : null}
             </div>
-            {action?.type === 'submit' ? (
-                <Button className="c-input__button">
-                    <Icon label={action?.icon?.label}>{action?.icon?.content}</Icon>
-                </Button>
-            ) : null}
+            {action?.type === 'submit' ? <InputButton /> : null}
         </div>
     );
 });

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -1,5 +1,5 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
-import React, { forwardRef, useEffect, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { useElement } from '../../hooks/useElement';
 import { useModifier } from '../../hooks/useModifier';
 import { classNames } from '../../utils/classNames';

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -7,7 +7,7 @@ import { getFieldError } from '../../utils/getFieldError';
 import { Label } from '../Label/Label';
 import './text-input.scss';
 import { Button } from '../Button/Button';
-import { Icon } from '../Icon/Icon';
+import { AccessibleIcon } from '../Icon/Icon';
 
 type IconType = {
     content: ReactNode;
@@ -56,9 +56,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
         ...rest
     } = props;
 
-    const [value, setValue] = useState<string | number | readonly string[]>(
-        defaultValue ? defaultValue : ''
-    );
+    const [value, setValue] = useState(defaultValue ? defaultValue : '');
 
     const errorMessage = getFieldError(value, required);
     const displayError = wasSubmitted && errorMessage;
@@ -75,9 +73,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
 
     const InputError = () => (
         <>
-            <div className="c-input__icon c-input__icon--error">
-                <Icon label={icon?.label}>{icon?.content}</Icon>
-            </div>
+            <div className="c-input__icon c-input__icon--error">{icon?.content}</div>
             <span className="c-input__error-message" role="alert" id={`${id}-error`}>
                 {errorMessage}
             </span>
@@ -86,13 +82,13 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
 
     const InputIcon = () => (
         <div className={iconClasses}>
-            <Icon label={icon.label}>{icon.content}</Icon>
+            <AccessibleIcon label={icon.label}>{icon.content}</AccessibleIcon>
         </div>
     );
 
     const InputButton = () => (
         <Button className="c-input__button">
-            <Icon label={action?.icon?.label}>{action?.icon?.content}</Icon>
+            <AccessibleIcon label={action?.icon?.label}>{action?.icon?.content}</AccessibleIcon>
         </Button>
     );
 

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -49,7 +49,6 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
         id,
         icon,
         name,
-        placeholder,
         required,
         type,
         variants,
@@ -91,7 +90,6 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
                     id={id}
                     name={id}
                     onChange={(event) => setValue(event.currentTarget.value)}
-                    placeholder={placeholder}
                     ref={forwardedRef}
                     type={type}
                     {...rest}

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -19,6 +19,9 @@ type Action = {
     icon?: IconType;
     type: string;
 };
+
+type Variants = 'secondary' | 'tertiary' | 'quaternary';
+
 export interface Props extends InputHTMLAttributes<HTMLInputElement> {
     /**
      * An object that contains the type of action, e.g. Submit, plus an optional icon and label for accessibility
@@ -31,7 +34,7 @@ export interface Props extends InputHTMLAttributes<HTMLInputElement> {
     /**
      * Sets the custom styles, e.g. "Secondary", "Tertiary"
      */
-    variants?: string[];
+    variants?: Variants[];
     /**
      * A boolean that alerts when form is submitted for error handling
      * @default false

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -76,6 +76,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
         if (defaultValue) {
             setValue(defaultValue);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- only needs to run on mount
     }, []);
 
     return (

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import type { HTMLInputTypeAttribute, InputHTMLAttributes, ReactNode } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 import React, { forwardRef, useEffect, useState } from 'react';
 import { useElement } from '../../hooks/useElement';
 import { useModifier } from '../../hooks/useModifier';
@@ -9,16 +9,32 @@ import './text-input.scss';
 import { Button } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
 
+type IconType = {
+    content: ReactNode;
+    label: string;
+};
+
 type Action = {
-    label?: string;
-    icon?: ReactNode;
+    icon?: IconType;
     type: string;
 };
 export interface Props extends InputHTMLAttributes<HTMLInputElement> {
+    /**
+     * An object that contains the type of action, e.g. Submit, plus an optional icon and label for accessibility
+     */
     action?: Action;
-    icon?: { content: ReactNode; label: string };
-    type: HTMLInputTypeAttribute;
+    /**
+     * An object that contains an Icon and a label for accessibility
+     */
+    icon?: IconType;
+    /**
+     * Sets the custom styles, e.g. "Secondary", "Tertiary"
+     */
     variants?: string[];
+    /**
+     * A boolean that alerts when form is submitted for error handling
+     * @default false
+     */
     wasSubmitted?: boolean;
 }
 
@@ -99,7 +115,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
             </div>
             {action?.type === 'submit' ? (
                 <Button className="c-input__button">
-                    <Icon label={action?.label}>{action?.icon}</Icon>
+                    <Icon label={action?.icon?.label}>{action?.icon?.content}</Icon>
                 </Button>
             ) : null}
         </div>

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -86,11 +86,13 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
         </div>
     );
 
-    const InputButton = () => (
-        <Button className="c-input__button">
-            <AccessibleIcon label={action?.icon?.label}>{action?.icon?.content}</AccessibleIcon>
-        </Button>
-    );
+    const InputButton = ({ action: { icon, size, variant } }) => {
+        return (
+            <Button className="c-input__button" variant={variant} size={size}>
+                {icon ? <AccessibleIcon label={icon.label}>{icon.content}</AccessibleIcon> : null}
+            </Button>
+        );
+    };
 
     return (
         <div className="c-input__outer-container">
@@ -124,7 +126,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
                 {icon && icon.type !== 'error' ? <InputIcon /> : null}
                 {displayError ? <InputError /> : null}
             </div>
-            {action?.type === 'submit' ? <InputButton /> : null}
+            {action?.type === 'submit' ? <InputButton action={action} /> : null}
         </div>
     );
 });

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -118,6 +118,8 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
                     {...rest}
                 />
                 <Label
+                    // If Quaternary variation then wrap in VisuallyHidden to hide the label
+                    hidden={variants?.some((variant) => variant === 'quaternary')}
                     htmlFor={id}
                     name={name}
                     required={required}

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -12,6 +12,7 @@ import { Icon } from '../Icon/Icon';
 type IconType = {
     content: ReactNode;
     label: string;
+    type?: string;
 };
 
 type Action = {
@@ -102,15 +103,20 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
                     required={required}
                     variants={value ? ['filled'] : null}
                 />
-                {icon ? (
+                {icon && icon.type !== 'error' ? (
                     <div className={iconClasses}>
                         <Icon label={icon.label}>{icon.content}</Icon>
                     </div>
                 ) : null}
                 {displayError ? (
-                    <span className="c-input__error-message" role="alert" id={`${id}-error`}>
-                        {errorMessage}
-                    </span>
+                    <>
+                        <div className="c-input__icon c-input__icon--error">
+                            <Icon label={icon?.label}>{icon?.content}</Icon>
+                        </div>
+                        <span className="c-input__error-message" role="alert" id={`${id}-error`}>
+                            {errorMessage}
+                        </span>
+                    </>
                 ) : null}
             </div>
             {action?.type === 'submit' ? (

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -1,0 +1,161 @@
+/* stylelint-disable no-descending-specificity */
+/* stylelint-disable selector-class-pattern */
+@use "../../styles/settings" as *;
+/* stylelint-disable plugin/selector-bem-pattern */
+
+.c-input__outer-container {
+    display: flex;
+}
+
+.c-input__container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+
+    .c-input {
+        display: flex;
+        order: 1;
+        min-width: 20ch;
+        max-width: 30ch;
+        padding: 0.375em 2.563em 0.375em 1.25em;
+        border: solid 1px var(--color-quinary);
+        font-size: var(--font-scale-centi);
+        cursor: text;
+
+        &:focus {
+            outline: 3px solid transparent;
+            box-shadow: 0 0 0 2px var(--color-primary);
+        }
+
+        &[disabled] {
+            background-color: hsl(0deg 0% 98%);
+            color: hsl(0deg 0% 73%);
+            pointer-events: none;
+        }
+
+        &__number {
+            padding: 0.375em 0.375em 0.375em 1.25em;
+        }
+
+        &__icon {
+            position: absolute;
+            top: 50%;
+            right: 5%;
+            transform: translateY(-50%);
+        }
+    }
+
+    .c-label {
+        cursor: text;
+    }
+
+    &--secondary {
+        .c-input {
+            border-radius: 6px;
+        }
+    }
+
+    &--tertiary,
+    &--quaternary {
+        position: relative;
+
+        .c-label {
+            position: absolute;
+            display: flex;
+            align-items: center;
+            transform: scale(1);
+            transform-origin: top left;
+            transition: 100ms ease-in-out;
+            pointer-events: none;
+
+            &.c-label--filled {
+                transform: translate(0, -20px) scale(0.8);
+            }
+        }
+
+        .c-label,
+        .c-input {
+            height: 30px;
+        }
+
+        .c-input {
+            &__text {
+                border: none;
+                border-bottom: solid 2px var(--color-secondary);
+            }
+
+            &[disabled] {
+                background: none;
+                pointer-events: cursor;
+                border-bottom: solid 2px hsl(255deg 3.7% 78.8%);
+
+                + .c-label {
+                    color: hsl(255deg 3.7% 78.8%);
+                }
+            }
+        }
+
+        .c-input:focus {
+            box-shadow: none;
+        }
+
+        .c-input:focus + .c-label {
+            transform: translate(0, -20px) scale(0.8);
+        }
+    }
+
+    &--tertiary {
+        .c-input__icon {
+            top: 35%;
+        }
+    }
+
+    &--quaternary {
+        .c-input {
+            padding: 0.375em 2.563em 0.375em 0;
+            color: hsl(0deg 0% 60%);
+        }
+
+        .c-label {
+            position: absolute;
+            top: -9999px;
+            left: -9999px;
+        }
+    }
+
+    &--quaternary + .c-input__button {
+        svg {
+            width: 30px;
+            height: 30px;
+        }
+    }
+
+    &--error {
+        .c-input {
+            background-color: hsl(0deg 93% 55% / 20%);
+            border: 1px solid hsl(0deg 92% 55%);
+            box-shadow: 0 1px 2px hsl(220deg 43% 11% / 5%), 0 0 5px 3px hsl(334deg 79% 89%);
+
+            &__error-message {
+                order: 2;
+                color: hsl(0deg 92% 55%);
+                font-size: var(--font-scale-centi);
+            }
+
+            &__icon {
+                &--error {
+                    color: hsl(0deg 92% 55%);
+                }
+            }
+        }
+
+        &.c-input__container--tertiary {
+            .c-input {
+                background: none;
+                border: none;
+                border-bottom: solid 0.125em hsl(0deg 92% 55%);
+                box-shadow: none;
+            }
+        }
+    }
+}

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -159,3 +159,7 @@
         }
     }
 }
+
+::placeholder {
+    color: hsl(0deg 0% 73%);
+}

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -3,16 +3,15 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-$input-py: calc(var(--space-scale-2xs) - 3px);
-$input-pr: var(--space-scale-xl);
-$input-pl: var(--space-scale-l);
+$input-py: calc($space-2xs - 3px);
+$input-pr: $space-xl;
+$input-pl: $space-l;
 
 .c-input {
     display: flex;
     order: 1;
     padding: $input-py $input-pr $input-py $input-pl;
     border: solid 1px var(--color-quinary);
-    font-size: var(--font-scale-base);
     cursor: text;
     grid-column: 1;
     grid-row: 2;
@@ -131,7 +130,6 @@ $input-pl: var(--space-scale-l);
                     display: flex;
                     order: 2;
                     color: var(--color-error);
-                    font-size: var(--font-scale-base);
                     grid-row: 3;
                     grid-column: 1;
                 }

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -28,8 +28,8 @@
         }
 
         &[disabled] {
-            background-color: hsl(0deg 0% 98%);
-            color: hsl(0deg 0% 73%);
+            background-color: var(--color-neutral-100);
+            color: var(--color-neutral-500);
             pointer-events: none;
         }
 
@@ -69,13 +69,13 @@
             pointer-events: none;
 
             &.c-label--filled {
-                transform: translate(0, -20px) scale(0.8);
+                transform: translate(0, -1.25em) scale(0.8);
             }
         }
 
         .c-label,
         .c-input {
-            height: 30px;
+            height: 1.875em;
         }
 
         .c-input {
@@ -87,10 +87,10 @@
             &[disabled] {
                 background: none;
                 pointer-events: cursor;
-                border-bottom: solid 2px hsl(255deg 3.7% 78.8%);
+                border-bottom: solid 2px var(--color-neutral-500);
 
                 + .c-label {
-                    color: hsl(255deg 3.7% 78.8%);
+                    color: var(--color-neutral-500);
                 }
             }
         }
@@ -100,7 +100,7 @@
         }
 
         .c-input:focus + .c-label {
-            transform: translate(0, -20px) scale(0.8);
+            transform: translate(0, -1.25em) scale(0.8);
         }
     }
 
@@ -113,7 +113,7 @@
     &--quaternary {
         .c-input {
             padding: 0.375em 2.563em 0.375em 0;
-            color: hsl(0deg 0% 60%);
+            color: var(--color-neutral-600);
         }
 
         .c-label {
@@ -125,26 +125,26 @@
 
     &--quaternary + .c-input__button {
         svg {
-            width: 30px;
-            height: 30px;
+            width: 1.875em;
+            height: 1.875em;
         }
     }
 
     &--error {
         .c-input {
-            background-color: hsl(0deg 93% 55% / 20%);
-            border: 1px solid hsl(0deg 92% 55%);
-            box-shadow: 0 1px 2px hsl(220deg 43% 11% / 5%), 0 0 5px 3px hsl(334deg 79% 89%);
+            background-color: var(--color-error-20);
+            border: 1px solid var(--color-error);
+            box-shadow: 0 1px 2px var(--color-neutral-500), 0 0 5px 3px var(--color-septenary);
 
             &__error-message {
                 order: 2;
-                color: hsl(0deg 92% 55%);
+                color: var(--color-error);
                 font-size: var(--font-scale-centi);
             }
 
             &__icon {
                 &--error {
-                    color: hsl(0deg 92% 55%);
+                    color: var(--color-error);
                 }
             }
         }
@@ -153,7 +153,7 @@
             .c-input {
                 background: none;
                 border: none;
-                border-bottom: solid 0.125em hsl(0deg 92% 55%);
+                border-bottom: solid 0.125em var(--color-error);
                 box-shadow: none;
             }
         }
@@ -161,5 +161,5 @@
 }
 
 ::placeholder {
-    color: hsl(0deg 0% 73%);
+    color: var(--color-neutral-500);
 }

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -21,12 +21,11 @@ $input-pl: $space-l;
         align-self: center;
         grid-row: 2;
         grid-column: 1;
-        padding-right: 5%;
+        padding-right: $space-xs;
     }
 
     &:focus {
-        outline: 3px solid transparent;
-        box-shadow: 0 0 0 2px var(--color-primary);
+        box-shadow: $shadow-focus-s;
     }
 
     &[disabled] {
@@ -63,7 +62,7 @@ $input-pl: $space-l;
                 align-items: center;
                 grid-row: 2;
                 transform-origin: top left;
-                transition: 100ms ease-in-out;
+                transition: $timing-s ease-in-out;
                 pointer-events: none;
 
                 &.c-label--filled {
@@ -102,12 +101,6 @@ $input-pl: $space-l;
             .c-input {
                 padding: $input-py $input-pr $input-py 0;
                 color: var(--color-neutral-600);
-            }
-
-            .c-label {
-                position: absolute;
-                top: -9999px;
-                left: -9999px;
             }
         }
 

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -118,7 +118,7 @@ $label-transform-up: translate(0, -1.25em) scale(0.8);
             .c-input {
                 background-color: var(--color-error-20);
                 border: 1px solid var(--color-error);
-                box-shadow: 0 1px 2px var(--color-neutral-500), 0 0 5px 3px var(--color-septenary);
+                box-shadow: $shadow-error;
 
                 &__error-message {
                     display: flex;

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -10,8 +10,6 @@ $input-pl: var(--space-scale-epsilon);
 .c-input {
     display: flex;
     order: 1;
-    min-width: 20ch;
-    max-width: 30ch;
     padding: $input-py $input-pr $input-py $input-pl;
     border: solid 1px var(--color-quinary);
     font-size: var(--font-scale-base);
@@ -44,7 +42,7 @@ $input-pl: var(--space-scale-epsilon);
 
     &__container {
         display: grid;
-        flex-direction: column;
+        width: 100%;
 
         .c-label {
             grid-row: 1;
@@ -115,9 +113,11 @@ $input-pl: var(--space-scale-epsilon);
         }
 
         &--quaternary + .c-input__button {
+            cursor: pointer;
+
             svg {
-                width: 1em;
-                height: 1em;
+                width: 2em;
+                height: 2em;
             }
         }
 

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -6,6 +6,7 @@
 $input-py: calc($space-2xs - 3px);
 $input-pr: $space-xl;
 $input-pl: $space-l;
+$label-transform-up: translate(0, -1.25em) scale(0.8);
 
 .c-input {
     display: flex;
@@ -67,7 +68,7 @@ $input-pl: $space-l;
 
                 &.c-label--filled {
                     top: 10px;
-                    transform: translate(0, -1.25em) scale(0.8);
+                    transform: $label-transform-up;
                 }
             }
 
@@ -93,7 +94,7 @@ $input-pl: $space-l;
             }
 
             .c-input:focus + .c-label {
-                transform: translate(0, -1.25em) scale(0.8);
+                transform: $label-transform-up;
             }
         }
 

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -3,9 +3,9 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-$input-py: calc(var(--space-scale-micro) - 3px);
-$input-pr: var(--space-scale-delta);
-$input-pl: var(--space-scale-epsilon);
+$input-py: calc(var(--space-scale-2xs) - 3px);
+$input-pr: var(--space-scale-xl);
+$input-pl: var(--space-scale-l);
 
 .c-input {
     display: flex;
@@ -51,7 +51,7 @@ $input-pl: var(--space-scale-epsilon);
 
         &--secondary {
             .c-input {
-                border-radius: 6px;
+                border-radius: $rad-xs;
             }
         }
 

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -132,6 +132,7 @@
                 box-shadow: 0 1px 2px var(--color-neutral-500), 0 0 5px 3px var(--color-septenary);
 
                 &__error-message {
+                    display: flex;
                     order: 2;
                     color: var(--color-error);
                     font-size: var(--font-scale-centi);

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -116,8 +116,8 @@ $input-pl: var(--space-scale-epsilon);
 
         &--quaternary + .c-input__button {
             svg {
-                width: 1.875em;
-                height: 1.875em;
+                width: 1em;
+                height: 1em;
             }
         }
 

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -160,7 +160,3 @@
         cursor: text;
     }
 }
-
-::placeholder {
-    color: var(--color-neutral-500);
-}

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -10,7 +10,7 @@
     max-width: 30ch;
     padding: 0.375em 2.563em 0.375em 1.25em;
     border: solid 1px var(--color-quinary);
-    font-size: var(--font-scale-centi);
+    font-size: var(--font-scale-base);
     cursor: text;
 
     &:focus {
@@ -135,7 +135,7 @@
                     display: flex;
                     order: 2;
                     color: var(--color-error);
-                    font-size: var(--font-scale-centi);
+                    font-size: var(--font-scale-base);
                 }
 
                 &__icon {

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -3,15 +3,29 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
+$input-py: calc(var(--space-scale-micro) - 3px);
+$input-pr: var(--space-scale-delta);
+$input-pl: var(--space-scale-epsilon);
+
 .c-input {
     display: flex;
     order: 1;
     min-width: 20ch;
     max-width: 30ch;
-    padding: 0.375em 2.563em 0.375em 1.25em;
+    padding: $input-py $input-pr $input-py $input-pl;
     border: solid 1px var(--color-quinary);
     font-size: var(--font-scale-base);
     cursor: text;
+    grid-column: 1;
+    grid-row: 2;
+
+    &__icon {
+        justify-self: end;
+        align-self: center;
+        grid-row: 2;
+        grid-column: 1;
+        padding-right: 5%;
+    }
 
     &:focus {
         outline: 3px solid transparent;
@@ -24,25 +38,18 @@
         pointer-events: none;
     }
 
-    &__number {
-        padding: 0.375em 0.375em 0.375em 1.25em;
-    }
-
-    &__icon {
-        position: absolute;
-        top: 50%;
-        right: 5%;
-        transform: translateY(-50%);
-    }
-
     &__outer-container {
         display: flex;
     }
 
     &__container {
-        position: relative;
-        display: flex;
+        display: grid;
         flex-direction: column;
+
+        .c-label {
+            grid-row: 1;
+            grid-column: 1;
+        }
 
         &--secondary {
             .c-input {
@@ -55,22 +62,17 @@
             position: relative;
 
             .c-label {
-                position: absolute;
                 display: flex;
                 align-items: center;
-                transform: scale(1);
+                grid-row: 2;
                 transform-origin: top left;
                 transition: 100ms ease-in-out;
                 pointer-events: none;
 
                 &.c-label--filled {
+                    top: 10px;
                     transform: translate(0, -1.25em) scale(0.8);
                 }
-            }
-
-            .c-label,
-            .c-input {
-                height: 1.875em;
             }
 
             .c-input {
@@ -99,15 +101,9 @@
             }
         }
 
-        &--tertiary {
-            .c-input__icon {
-                top: 35%;
-            }
-        }
-
         &--quaternary {
             .c-input {
-                padding: 0.375em 2.563em 0.375em 0;
+                padding: $input-py $input-pr $input-py 0;
                 color: var(--color-neutral-600);
             }
 
@@ -136,6 +132,8 @@
                     order: 2;
                     color: var(--color-error);
                     font-size: var(--font-scale-base);
+                    grid-row: 3;
+                    grid-column: 1;
                 }
 
                 &__icon {

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -3,160 +3,160 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-.c-input__outer-container {
+.c-input {
     display: flex;
-}
+    order: 1;
+    min-width: 20ch;
+    max-width: 30ch;
+    padding: 0.375em 2.563em 0.375em 1.25em;
+    border: solid 1px var(--color-quinary);
+    font-size: var(--font-scale-centi);
+    cursor: text;
 
-.c-input__container {
-    position: relative;
-    display: flex;
-    flex-direction: column;
+    &:focus {
+        outline: 3px solid transparent;
+        box-shadow: 0 0 0 2px var(--color-primary);
+    }
 
-    .c-input {
+    &[disabled] {
+        background-color: var(--color-neutral-100);
+        color: var(--color-neutral-500);
+        pointer-events: none;
+    }
+
+    &__number {
+        padding: 0.375em 0.375em 0.375em 1.25em;
+    }
+
+    &__icon {
+        position: absolute;
+        top: 50%;
+        right: 5%;
+        transform: translateY(-50%);
+    }
+
+    &__outer-container {
         display: flex;
-        order: 1;
-        min-width: 20ch;
-        max-width: 30ch;
-        padding: 0.375em 2.563em 0.375em 1.25em;
-        border: solid 1px var(--color-quinary);
-        font-size: var(--font-scale-centi);
-        cursor: text;
+    }
 
-        &:focus {
-            outline: 3px solid transparent;
-            box-shadow: 0 0 0 2px var(--color-primary);
+    &__container {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+
+        &--secondary {
+            .c-input {
+                border-radius: 6px;
+            }
         }
 
-        &[disabled] {
-            background-color: var(--color-neutral-100);
-            color: var(--color-neutral-500);
-            pointer-events: none;
+        &--tertiary,
+        &--quaternary {
+            position: relative;
+
+            .c-label {
+                position: absolute;
+                display: flex;
+                align-items: center;
+                transform: scale(1);
+                transform-origin: top left;
+                transition: 100ms ease-in-out;
+                pointer-events: none;
+
+                &.c-label--filled {
+                    transform: translate(0, -1.25em) scale(0.8);
+                }
+            }
+
+            .c-label,
+            .c-input {
+                height: 1.875em;
+            }
+
+            .c-input {
+                &__text {
+                    border: none;
+                    border-bottom: solid 2px var(--color-secondary);
+                }
+
+                &[disabled] {
+                    background: none;
+                    pointer-events: cursor;
+                    border-bottom: solid 2px var(--color-neutral-500);
+
+                    + .c-label {
+                        color: var(--color-neutral-500);
+                    }
+                }
+            }
+
+            .c-input:focus {
+                box-shadow: none;
+            }
+
+            .c-input:focus + .c-label {
+                transform: translate(0, -1.25em) scale(0.8);
+            }
         }
 
-        &__number {
-            padding: 0.375em 0.375em 0.375em 1.25em;
+        &--tertiary {
+            .c-input__icon {
+                top: 35%;
+            }
         }
 
-        &__icon {
-            position: absolute;
-            top: 50%;
-            right: 5%;
-            transform: translateY(-50%);
+        &--quaternary {
+            .c-input {
+                padding: 0.375em 2.563em 0.375em 0;
+                color: var(--color-neutral-600);
+            }
+
+            .c-label {
+                position: absolute;
+                top: -9999px;
+                left: -9999px;
+            }
+        }
+
+        &--quaternary + .c-input__button {
+            svg {
+                width: 1.875em;
+                height: 1.875em;
+            }
+        }
+
+        &--error {
+            .c-input {
+                background-color: var(--color-error-20);
+                border: 1px solid var(--color-error);
+                box-shadow: 0 1px 2px var(--color-neutral-500), 0 0 5px 3px var(--color-septenary);
+
+                &__error-message {
+                    order: 2;
+                    color: var(--color-error);
+                    font-size: var(--font-scale-centi);
+                }
+
+                &__icon {
+                    &--error {
+                        color: var(--color-error);
+                    }
+                }
+            }
+
+            &.c-input__container--tertiary {
+                .c-input {
+                    background: none;
+                    border: none;
+                    border-bottom: solid 0.125em var(--color-error);
+                    box-shadow: none;
+                }
+            }
         }
     }
 
     .c-label {
         cursor: text;
-    }
-
-    &--secondary {
-        .c-input {
-            border-radius: 6px;
-        }
-    }
-
-    &--tertiary,
-    &--quaternary {
-        position: relative;
-
-        .c-label {
-            position: absolute;
-            display: flex;
-            align-items: center;
-            transform: scale(1);
-            transform-origin: top left;
-            transition: 100ms ease-in-out;
-            pointer-events: none;
-
-            &.c-label--filled {
-                transform: translate(0, -1.25em) scale(0.8);
-            }
-        }
-
-        .c-label,
-        .c-input {
-            height: 1.875em;
-        }
-
-        .c-input {
-            &__text {
-                border: none;
-                border-bottom: solid 2px var(--color-secondary);
-            }
-
-            &[disabled] {
-                background: none;
-                pointer-events: cursor;
-                border-bottom: solid 2px var(--color-neutral-500);
-
-                + .c-label {
-                    color: var(--color-neutral-500);
-                }
-            }
-        }
-
-        .c-input:focus {
-            box-shadow: none;
-        }
-
-        .c-input:focus + .c-label {
-            transform: translate(0, -1.25em) scale(0.8);
-        }
-    }
-
-    &--tertiary {
-        .c-input__icon {
-            top: 35%;
-        }
-    }
-
-    &--quaternary {
-        .c-input {
-            padding: 0.375em 2.563em 0.375em 0;
-            color: var(--color-neutral-600);
-        }
-
-        .c-label {
-            position: absolute;
-            top: -9999px;
-            left: -9999px;
-        }
-    }
-
-    &--quaternary + .c-input__button {
-        svg {
-            width: 1.875em;
-            height: 1.875em;
-        }
-    }
-
-    &--error {
-        .c-input {
-            background-color: var(--color-error-20);
-            border: 1px solid var(--color-error);
-            box-shadow: 0 1px 2px var(--color-neutral-500), 0 0 5px 3px var(--color-septenary);
-
-            &__error-message {
-                order: 2;
-                color: var(--color-error);
-                font-size: var(--font-scale-centi);
-            }
-
-            &__icon {
-                &--error {
-                    color: var(--color-error);
-                }
-            }
-        }
-
-        &.c-input__container--tertiary {
-            .c-input {
-                background: none;
-                border: none;
-                border-bottom: solid 0.125em var(--color-error);
-                box-shadow: none;
-            }
-        }
     }
 }
 

--- a/packages/osc-ui/src/hooks/useElement.ts
+++ b/packages/osc-ui/src/hooks/useElement.ts
@@ -1,0 +1,7 @@
+export const useElement = (block: string, element: string) => {
+    if (block && element) {
+        return `${block}__${element}`;
+    } else {
+        return '';
+    }
+};

--- a/packages/osc-ui/src/icons/exclamation-mark.svg
+++ b/packages/osc-ui/src/icons/exclamation-mark.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 20C4.477 20 0 15.523 0 10C0 4.477 4.477 0 10 0C15.523 0 20 4.477 20 10C20 15.523 15.523 20 10 20ZM9 13V15H11V13H9ZM9 5V11H11V5H9Z" fill="#EC0909"/>
+</svg>

--- a/packages/osc-ui/src/styles/elements/_input.scss
+++ b/packages/osc-ui/src/styles/elements/_input.scss
@@ -1,0 +1,5 @@
+@use "../settings" as *;
+
+::placeholder {
+    color: var(--color-neutral-500);
+}

--- a/packages/osc-ui/src/styles/main.scss
+++ b/packages/osc-ui/src/styles/main.scss
@@ -37,6 +37,7 @@
 @use "elements/address";
 @use "elements/iframe";
 @use "elements/image";
+@use "elements/input";
 @use "elements/list";
 @use "elements/page";
 @use "elements/table";

--- a/packages/osc-ui/src/styles/settings/_shadows.scss
+++ b/packages/osc-ui/src/styles/settings/_shadows.scss
@@ -12,6 +12,7 @@
 
 :root {
     --shadow-ring: inset 0 2px 4px 0 hsla(0, 0%, 0%, 0.05);
+    --shadow-error: 0 1px 2px var(--color-neutral-500), 0 0 5px 3px var(--color-error-20);
     --shadow-focus: 0 0 0 #{rem(calc($base-fs / 3))} var(--color-tertiary),
         0 0 0 #{rem(calc($base-fs / 2))} var(--color-primary);
     --shadow-focus-s: 0 0 0 #{rem(calc($base-fs / 5))} var(--color-tertiary),
@@ -43,3 +44,4 @@ $shadow-inner: var(--shadow-inner);
 $shadow-ring: var(--shadow-ring);
 $shadow-focus: var(--shadow-focus);
 $shadow-focus-s: var(--shadow-focus-s);
+$shadow-error: var(--shadow-error);

--- a/packages/osc-ui/src/utils/getFieldError.ts
+++ b/packages/osc-ui/src/utils/getFieldError.ts
@@ -1,4 +1,4 @@
-export const getFieldError = (value: string | boolean | undefined, required: boolean) => {
+export const getFieldError = (value: string | number | readonly string[], required: boolean) => {
     if (!value && required) return 'Field is required';
 
     // TODO - And in error conditions...

--- a/packages/osc-ui/src/utils/getFieldError.ts
+++ b/packages/osc-ui/src/utils/getFieldError.ts
@@ -1,4 +1,7 @@
-export const getFieldError = (value: string | number | readonly string[], required: boolean) => {
+export const getFieldError = (
+    value: string | number | readonly string[] | boolean,
+    required: boolean
+) => {
     if (!value && required) return 'Field is required';
 
     // TODO - And in error conditions...


### PR DESCRIPTION
Closes #614 

## 📝 Description

Adds TextInput component. 

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

Adds TextInput component and covers all required styles

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
There is one accessibility issue on the error message text. It says there is insufficient colour contrast of 4.05 and the expected ratio is 4:5:1. So it's not far off but maybe we need to make the error red colour a touch darker?
