### PR TITLE
Feature/spritesheet provider

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 // OSC-UI
+import { SpritesheetProvider } from '../packages/osc-ui/src/components/Icon/Icon';
 import '../packages/osc-ui/src/styles/main.scss';
 
 import React from 'react';
@@ -13,7 +14,11 @@ const withTheme = (story, context) => {
         document.documentElement.classList.remove('theme--dark');
     }
 
-    return <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>;
+    return (
+        <MemoryRouter initialEntries={['/']}>
+            <SpritesheetProvider>{story()}</SpritesheetProvider>
+        </MemoryRouter>
+    );
 };
 
 export const decorators = [withTheme];

--- a/packages/osc-academic-hub/app/entry.client.tsx
+++ b/packages/osc-academic-hub/app/entry.client.tsx
@@ -5,11 +5,7 @@ import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import { hydrate } from 'react-dom';
 
 hydrate(
-    <SpritesheetProvider
-        value={{
-            spriteSheetPath: spritesheet,
-        }}
-    >
+    <SpritesheetProvider spriteSheetPath={spritesheet}>
         <RemixBrowser />
     </SpritesheetProvider>,
 

--- a/packages/osc-academic-hub/app/entry.client.tsx
+++ b/packages/osc-academic-hub/app/entry.client.tsx
@@ -1,8 +1,20 @@
 // entry.client.tsx
 import { RemixBrowser } from '@remix-run/react';
+import { SpritesheetProvider } from 'osc-ui';
+import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import { hydrate } from 'react-dom';
 
-hydrate(<RemixBrowser />, document);
+hydrate(
+    <SpritesheetProvider
+        value={{
+            spriteSheetPath: spritesheet,
+        }}
+    >
+        <RemixBrowser />
+    </SpritesheetProvider>,
+
+    document
+);
 
 if ('serviceWorker' in navigator) {
     // Use the window load event to keep the page load performant
@@ -14,13 +26,13 @@ if ('serviceWorker' in navigator) {
                 if (navigator.serviceWorker.controller) {
                     navigator.serviceWorker.controller.postMessage({
                         type: 'SYNC_REMIX_MANIFEST',
-                        manifest: window.__remixManifest
+                        manifest: window.__remixManifest,
                     });
                 } else {
                     navigator.serviceWorker.addEventListener('controllerchange', () => {
                         navigator.serviceWorker.controller?.postMessage({
                             type: 'SYNC_REMIX_MANIFEST',
-                            manifest: window.__remixManifest
+                            manifest: window.__remixManifest,
                         });
                     });
                 }
@@ -60,7 +72,7 @@ navigator.serviceWorker.ready
         const convertedVapidKey = urlBase64ToUint8Array(returnedSubscription);
         return sub.registration.pushManager.subscribe({
             userVisibleOnly: true,
-            applicationServerKey: convertedVapidKey
+            applicationServerKey: convertedVapidKey,
         });
     })
     .then(async (subscription) => {
@@ -68,7 +80,7 @@ navigator.serviceWorker.ready
             method: 'POST',
             body: JSON.stringify({
                 subscription: subscription,
-                type: 'POST_SUBSCRIPTION'
-            })
+                type: 'POST_SUBSCRIPTION',
+            }),
         });
     });

--- a/packages/osc-academic-hub/app/entry.server.tsx
+++ b/packages/osc-academic-hub/app/entry.server.tsx
@@ -2,6 +2,8 @@
 import type { EntryContext } from '@remix-run/node'; // Depends on the runtime you choose
 import { RemixServer } from '@remix-run/react';
 import 'dotenv/config';
+import { SpritesheetProvider } from 'osc-ui';
+import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import { renderToString } from 'react-dom/server';
 
 export default function handleRequest(
@@ -10,12 +12,20 @@ export default function handleRequest(
     responseHeaders: Headers,
     remixContext: EntryContext
 ) {
-    const markup = renderToString(<RemixServer context={remixContext} url={request.url} />);
+    const markup = renderToString(
+        <SpritesheetProvider
+            value={{
+                spriteSheetPath: spritesheet,
+            }}
+        >
+            <RemixServer context={remixContext} url={request.url} />
+        </SpritesheetProvider>
+    );
 
     responseHeaders.set('Content-Type', 'text/html');
 
     return new Response(`<!DOCTYPE html>${markup}`, {
         status: responseStatusCode,
-        headers: responseHeaders
+        headers: responseHeaders,
     });
 }

--- a/packages/osc-academic-hub/app/entry.server.tsx
+++ b/packages/osc-academic-hub/app/entry.server.tsx
@@ -13,11 +13,7 @@ export default function handleRequest(
     remixContext: EntryContext
 ) {
     const markup = renderToString(
-        <SpritesheetProvider
-            value={{
-                spriteSheetPath: spritesheet,
-            }}
-        >
+        <SpritesheetProvider spriteSheetPath={spritesheet}>
             <RemixServer context={remixContext} url={request.url} />
         </SpritesheetProvider>
     );

--- a/packages/osc-academic-hub/app/root.tsx
+++ b/packages/osc-academic-hub/app/root.tsx
@@ -8,9 +8,10 @@ import {
     Scripts,
     ScrollRestoration,
     useLocation,
-    useMatches
+    useMatches,
 } from '@remix-run/react';
 import { SkipLink } from 'osc-ui';
+import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import oscUiSkipLinkStyle from 'osc-ui/dist/src-components-SkipLink-skip-link.css';
 import oscUiSwitchStyles from 'osc-ui/dist/src-components-Switch-switch.css';
 import styles from 'osc-ui/dist/src-styles-main.css';
@@ -22,6 +23,12 @@ import { getColorScheme } from './utils/colorScheme';
 let isMount = true;
 export const links: LinksFunction = () => {
     return [
+        // Preload the spritesheet to avoid a flash of unstyled content
+        {
+            rel: 'preload',
+            href: spritesheet,
+            as: 'image',
+        },
         { rel: 'stylesheet', href: oscUiSwitchStyles },
         { rel: 'stylesheet', href: oscUiSkipLinkStyle },
         { rel: 'stylesheet', href: styles },
@@ -39,18 +46,18 @@ export const links: LinksFunction = () => {
             rel: 'icon',
             type: 'image/png',
             sizes: '192x192',
-            href: '/icons/android-icon-192x192.png'
+            href: '/icons/android-icon-192x192.png',
         },
         { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/icons/favicon-32x32.png' },
         { rel: 'icon', type: 'image/png', sizes: '96x96', href: '/icons/favicon-96x96.png' },
-        { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/icons/favicon-16x16.png' }
+        { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/icons/favicon-16x16.png' },
     ];
 };
 
 export const meta: MetaFunction = () => ({
     charset: 'utf-8',
     title: 'OSC Academic Hub',
-    viewport: 'width=device-width,initial-scale=1'
+    viewport: 'width=device-width,initial-scale=1',
 });
 
 type LoaderData = {
@@ -59,13 +66,13 @@ type LoaderData = {
 };
 
 export const headers: HeadersFunction = () => ({
-    'Accept-CH': 'Sec-CH-Prefers-Color-Scheme'
+    'Accept-CH': 'Sec-CH-Prefers-Color-Scheme',
 });
 
 export const loader: LoaderFunction = async ({ request }) => {
     return json<LoaderData>({
         user: await getUser(request),
-        colorScheme: await getColorScheme(request)
+        colorScheme: await getColorScheme(request),
     });
 };
 
@@ -117,7 +124,7 @@ export default function App() {
                     isMount: mounted,
                     location,
                     matches,
-                    manifest: window.__remixManifest
+                    manifest: window.__remixManifest,
                 });
             } else {
                 let listener = async () => {
@@ -127,7 +134,7 @@ export default function App() {
                         isMount: mounted,
                         location,
                         matches,
-                        manifest: window.__remixManifest
+                        manifest: window.__remixManifest,
                     });
                 };
                 navigator.serviceWorker.addEventListener('controllerchange', listener);

--- a/packages/osc-academic-hub/remix.config.js
+++ b/packages/osc-academic-hub/remix.config.js
@@ -5,5 +5,8 @@ module.exports = {
     cacheDirectory: './node_modules/.cache/remix',
     ignoredRouteFiles: ['**/.*', '**/*.css', '**/*.test.{js,jsx,ts,tsx}'],
     // serverDependenciesToBundle: [/^header.*/],
-    watchPaths: ['../osc-ui/dist/*']
+    watchPaths: ['../osc-ui/dist/*'],
+    serverDependenciesToBundle: [
+        /^osc-ui\/dist\/.*\.svg$/, // match svg files in dist folder, this prevents the unhandled token error being thrown
+    ],
 };

--- a/packages/osc-ecommerce/app/entry.client.tsx
+++ b/packages/osc-ecommerce/app/entry.client.tsx
@@ -1,8 +1,19 @@
 // entry.client.tsx
 import { RemixBrowser } from '@remix-run/react';
+import { SpritesheetProvider } from 'osc-ui';
+import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import { hydrate } from 'react-dom';
 
-hydrate(<RemixBrowser />, document);
+hydrate(
+    <SpritesheetProvider
+        value={{
+            spriteSheetPath: spritesheet,
+        }}
+    >
+        <RemixBrowser />
+    </SpritesheetProvider>,
+    document
+);
 
 if ('serviceWorker' in navigator) {
     // Use the window load event to keep the page load performant
@@ -14,13 +25,13 @@ if ('serviceWorker' in navigator) {
                 if (navigator.serviceWorker.controller) {
                     navigator.serviceWorker.controller.postMessage({
                         type: 'SYNC_REMIX_MANIFEST',
-                        manifest: window.__remixManifest
+                        manifest: window.__remixManifest,
                     });
                 } else {
                     navigator.serviceWorker.addEventListener('controllerchange', () => {
                         navigator.serviceWorker.controller?.postMessage({
                             type: 'SYNC_REMIX_MANIFEST',
-                            manifest: window.__remixManifest
+                            manifest: window.__remixManifest,
                         });
                     });
                 }
@@ -60,7 +71,7 @@ navigator.serviceWorker.ready
         const convertedVapidKey = urlBase64ToUint8Array(returnedSubscription);
         return sub.registration.pushManager.subscribe({
             userVisibleOnly: true,
-            applicationServerKey: convertedVapidKey
+            applicationServerKey: convertedVapidKey,
         });
     })
     .then(async (subscription) => {
@@ -68,7 +79,7 @@ navigator.serviceWorker.ready
             method: 'POST',
             body: JSON.stringify({
                 subscription: subscription,
-                type: 'POST_SUBSCRIPTION'
-            })
+                type: 'POST_SUBSCRIPTION',
+            }),
         });
     });

--- a/packages/osc-ecommerce/app/entry.client.tsx
+++ b/packages/osc-ecommerce/app/entry.client.tsx
@@ -5,11 +5,7 @@ import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import { hydrate } from 'react-dom';
 
 hydrate(
-    <SpritesheetProvider
-        value={{
-            spriteSheetPath: spritesheet,
-        }}
-    >
+    <SpritesheetProvider spriteSheetPath={spritesheet}>
         <RemixBrowser />
     </SpritesheetProvider>,
     document

--- a/packages/osc-ecommerce/app/entry.server.tsx
+++ b/packages/osc-ecommerce/app/entry.server.tsx
@@ -13,11 +13,7 @@ export default function handleRequest(
     remixContext: EntryContext
 ) {
     const markup = renderToString(
-        <SpritesheetProvider
-            value={{
-                spriteSheetPath: spritesheet,
-            }}
-        >
+        <SpritesheetProvider spriteSheetPath={spritesheet}>
             <RemixServer context={remixContext} url={request.url} />
         </SpritesheetProvider>
     );

--- a/packages/osc-ecommerce/app/entry.server.tsx
+++ b/packages/osc-ecommerce/app/entry.server.tsx
@@ -2,6 +2,8 @@
 import type { EntryContext } from '@remix-run/node'; // Depends on the runtime you choose
 import { RemixServer } from '@remix-run/react';
 import 'dotenv/config';
+import { SpritesheetProvider } from 'osc-ui';
+import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import { renderToString } from 'react-dom/server';
 
 export default function handleRequest(
@@ -10,7 +12,15 @@ export default function handleRequest(
     responseHeaders: Headers,
     remixContext: EntryContext
 ) {
-    const markup = renderToString(<RemixServer context={remixContext} url={request.url} />);
+    const markup = renderToString(
+        <SpritesheetProvider
+            value={{
+                spriteSheetPath: spritesheet,
+            }}
+        >
+            <RemixServer context={remixContext} url={request.url} />
+        </SpritesheetProvider>
+    );
 
     responseHeaders.set('Content-Type', 'text/html');
 
@@ -40,6 +50,6 @@ export default function handleRequest(
 
     return new Response(`<!DOCTYPE html>${markup}`, {
         status: responseStatusCode,
-        headers: responseHeaders
+        headers: responseHeaders,
     });
 }

--- a/packages/osc-ui/src/components/Icon/Icon.spec.tsx
+++ b/packages/osc-ui/src/components/Icon/Icon.spec.tsx
@@ -26,11 +26,7 @@ test('passes correct classNames', () => {
 
 test('provider provides a custom spritesheet path', () => {
     render(
-        <SpritesheetProvider
-            value={{
-                spriteSheetPath: './custom-spritesheet.svg',
-            }}
-        >
+        <SpritesheetProvider spriteSheetPath="./custom-spritesheet.svg">
             <Icon id="arrow" />
         </SpritesheetProvider>
     );

--- a/packages/osc-ui/src/components/Icon/Icon.spec.tsx
+++ b/packages/osc-ui/src/components/Icon/Icon.spec.tsx
@@ -1,17 +1,40 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { Icon } from './Icon';
+import { Icon, SpritesheetProvider } from './Icon';
 
 test('correctly passes the ID to the href', () => {
-    render(<Icon id="arrow" />);
+    render(
+        <SpritesheetProvider>
+            <Icon id="arrow" />
+        </SpritesheetProvider>
+    );
     const use = document.querySelector('use');
 
     expect(use).toHaveAttribute('href', './spritesheet.svg#arrow');
 });
 
 test('passes correct classNames', () => {
-    render(<Icon className="test" id="arrow" />);
+    render(
+        <SpritesheetProvider>
+            <Icon className="test" id="arrow" />
+        </SpritesheetProvider>
+    );
     const svg = document.querySelector('svg');
 
     expect(svg).toHaveClass('o-icon test');
+});
+
+test('provider provides a custom spritesheet path', () => {
+    render(
+        <SpritesheetProvider
+            value={{
+                spriteSheetPath: './custom-spritesheet.svg',
+            }}
+        >
+            <Icon id="arrow" />
+        </SpritesheetProvider>
+    );
+    const use = document.querySelector('use');
+
+    expect(use).toHaveAttribute('href', './custom-spritesheet.svg#arrow');
 });

--- a/packages/osc-ui/src/components/Icon/Icon.stories.tsx
+++ b/packages/osc-ui/src/components/Icon/Icon.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 import type { IconProps } from './Icon';
-import { AccessibleIcon, Icon } from './Icon';
+import { AccessibleIcon, Icon, SpritesheetProvider } from './Icon';
 
 // Can't use fs in a browser, so we have to manually list the icons 😭
 const icons: string[] = [
@@ -46,11 +46,12 @@ const icons: string[] = [
 export default {
     title: 'osc-ui/Icons',
     component: Icon,
+    subcomponents: { AccessibleIcon, SpritesheetProvider },
     parameters: {
         docs: {
             description: {
                 component:
-                    'Icons are used to represent actions, objects, and concepts. They are used to communicate information and help users navigate the interface.<br>Icons can appear small in navy or white or as a featured icon in a gradient that matches with the page colours.',
+                    'Icons are used to represent actions, objects, and concepts. They are used to communicate information and help users navigate the interface.<br>Icons can appear small in navy or white or as a featured icon in a gradient that matches with the page colours.<br>Must be wrapped in the `<SpritesheetProvider>` to work.',
             },
         },
     },

--- a/packages/osc-ui/src/components/Icon/Icon.tsx
+++ b/packages/osc-ui/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import * as AccessibleIconPrimitive from '@radix-ui/react-accessible-icon';
 import type { ReactNode } from 'react';
-import React, { forwardRef } from 'react';
+import React, { createContext, forwardRef, useContext } from 'react';
 import { classNames } from '../../utils/classNames';
 
 export interface IconProps {
@@ -19,6 +19,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>((props, forwardedRef) =
     const { className, id, ...attr } = props;
     const classes = classNames('o-icon', className);
     const size = 30; // an arbitrary size that constrains the width and height of the icon if css isn't loaded for whatever reason
+    const { spriteSheetPath } = useSpritesheetContext();
 
     return (
         <svg
@@ -31,7 +32,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>((props, forwardedRef) =
             {...attr}
             ref={forwardedRef}
         >
-            <use href={`./spritesheet.svg#${id}`} />
+            <use href={`${spriteSheetPath}#${id}`} />
         </svg>
     );
 });
@@ -53,4 +54,48 @@ export const AccessibleIcon = (props: AccessibleIconProps) => {
     const { children, label } = props;
 
     return <AccessibleIconPrimitive.Root label={label}>{children}</AccessibleIconPrimitive.Root>;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * Spritesheet provider
+ * -----------------------------------------------------------------------------------------------*/
+const SpritesheetContext = createContext(null);
+
+export interface SpritesheetProviderProps {
+    /**
+     * The content of the button.
+     */
+    children?: ReactNode;
+
+    /**
+     * Spritesheet path context value for the spritesheet provider.
+     * @default ./spritesheet.svg
+     */
+    value?: {
+        spriteSheetPath: string;
+    };
+}
+export const SpritesheetProvider = (props: SpritesheetProviderProps) => {
+    const {
+        children,
+        value = {
+            spriteSheetPath: './spritesheet.svg',
+        },
+    } = props;
+
+    return <SpritesheetContext.Provider value={value}>{children}</SpritesheetContext.Provider>;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * useSpritesheetContext
+ * -----------------------------------------------------------------------------------------------*/
+const useSpritesheetContext = () => {
+    const context = useContext(SpritesheetContext);
+
+    // if `undefined`, throw an error
+    if (context === undefined) {
+        throw new Error('useSpritesheetContext was used outside of its Provider');
+    }
+
+    return context;
 };

--- a/packages/osc-ui/src/components/Icon/Icon.tsx
+++ b/packages/osc-ui/src/components/Icon/Icon.tsx
@@ -68,22 +68,24 @@ export interface SpritesheetProviderProps {
     children?: ReactNode;
 
     /**
-     * Spritesheet path context value for the spritesheet provider.
+     * Spritesheet path.
+     *
      * @default ./spritesheet.svg
      */
-    value?: {
-        spriteSheetPath: string;
-    };
+    spriteSheetPath?: string;
 }
 export const SpritesheetProvider = (props: SpritesheetProviderProps) => {
-    const {
-        children,
-        value = {
-            spriteSheetPath: './spritesheet.svg',
-        },
-    } = props;
+    const { children, spriteSheetPath = './spritesheet.svg' } = props;
 
-    return <SpritesheetContext.Provider value={value}>{children}</SpritesheetContext.Provider>;
+    return (
+        <SpritesheetContext.Provider
+            value={{
+                spriteSheetPath: spriteSheetPath,
+            }}
+        >
+            {children}
+        </SpritesheetContext.Provider>
+    );
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/osc-ui/src/components/Select/Select.spec.tsx
+++ b/packages/osc-ui/src/components/Select/Select.spec.tsx
@@ -1,21 +1,26 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { SpritesheetProvider } from '../Icon/Icon';
 import { Select, SelectItem } from './Select';
 
 test('should render a select component', () => {
     render(
-        <Select name="courses-1">
-            <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
-        </Select>
+        <SpritesheetProvider>
+            <Select name="courses-1">
+                <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
+            </Select>
+        </SpritesheetProvider>
     );
 
     expect(screen.getByRole('combobox')).toBeInTheDocument();
 });
 test('should render a disabled select component', () => {
     const { container } = render(
-        <Select disabled={true} name="courses-1">
-            <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
-        </Select>
+        <SpritesheetProvider>
+            <Select disabled={true} name="courses-1">
+                <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
+            </Select>
+        </SpritesheetProvider>
     );
 
     expect(container.querySelector(`button[data-disabled]`)).toBeInTheDocument();
@@ -23,9 +28,11 @@ test('should render a disabled select component', () => {
 });
 test('should render a placeholder in the select component', () => {
     const { container } = render(
-        <Select placeholder="Please Select" name="courses-1">
-            <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
-        </Select>
+        <SpritesheetProvider>
+            <Select placeholder="Please Select" name="courses-1">
+                <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
+            </Select>
+        </SpritesheetProvider>
     );
 
     expect(screen.getByText('Please Select')).toHaveTextContent('Please Select');

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -15,7 +15,7 @@ export { Content } from './components/Content/Content';
 export { CountdownClock } from './components/CountdownClock/CountdownClock';
 export { Footer } from './components/Footer/Footer';
 export { Header } from './components/Header/Header';
-export { Icon } from './components/Icon/Icon';
+export { Icon, SpritesheetProvider } from './components/Icon/Icon';
 export { Image } from './components/Image/Image';
 export { ImageGallery } from './components/ImageGallery/ImageGallery';
 export { List } from './components/List/List';


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I've come across a small bug in some of my other work, where the path to the spritesheet is 404ing on our Remix apps. Turns out this is because Remix hashes the files that are in the `build/_assets` directory. Meaning that on remix `spritesheet.svg` would become `spritesheet-32asdf.svg` for example.

I have put in some temporary fixes (for example in #668) where I've added the ability to add a path to the Icon. This works fine if the `<Icon>` is used directly inside of Remix however you have to do a bit of prop drilling if the `<Icon>` is nested inside another component, and adding an extra `spritesheetPath` prop to all of our components will get annoying & verbose.

What I've done here instead, is create a context provider we can wrap around our app and pass the specified spritesheet path through, there is then a `useContext` hook in the `<Icon>` which will read this path.

## ⛳️ Current behavior (updates)

`<Icon>` fails to show sprite within Remix apps due to the `./spritesheet.svg`path 404ing.

## 🚀 New behavior

Created a `<SpritesheetProvider>` which we can wrap around our apps and pass in the Remix hashed path for the spritesheet.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
