### PR TITLE
Feature/academic hub setup

### DIFF
--- a/packages/osc-academic-hub/app/lib/apollo/getClient.server.ts
+++ b/packages/osc-academic-hub/app/lib/apollo/getClient.server.ts
@@ -1,0 +1,12 @@
+import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
+import invariant from 'tiny-invariant';
+
+invariant(process.env.API_GATEWAY_URL, `process.env.API_GATEWAY_URL must be set`);
+
+export const graphQLClient = new ApolloClient({
+    cache: new InMemoryCache(),
+    ssrMode: true,
+    link: createHttpLink({
+        uri: process.env.API_GATEWAY_URL,
+    }),
+});

--- a/packages/osc-academic-hub/app/models/user.server.ts
+++ b/packages/osc-academic-hub/app/models/user.server.ts
@@ -1,56 +1,11 @@
 import type { Password, User } from '@prisma/client';
-import bcrypt from 'bcryptjs';
-
-import { prisma } from '~/db.server';
 
 export type { User } from '@prisma/client';
 
-export async function getUserById(id: User['id']) {
-    return prisma.user.findUnique({ where: { id } });
-}
+export async function getUserById(id: User['id']) {}
 
-export async function getUserByEmail(email: User['email']) {
-    return prisma.user.findUnique({ where: { email } });
-}
+export async function getUserByEmail(email: User['email']) {}
 
-export async function createUser(email: User['email'], password: string) {
-    const hashedPassword = await bcrypt.hash(password, 10);
+export async function createUser(email: User['email'], password: string) {}
 
-    return prisma.user.create({
-        data: {
-            email,
-            password: {
-                create: {
-                    hash: hashedPassword
-                }
-            }
-        }
-    });
-}
-
-export async function deleteUserByEmail(email: User['email']) {
-    return prisma.user.delete({ where: { email } });
-}
-
-export async function verifyLogin(email: User['email'], password: Password['hash']) {
-    const userWithPassword = await prisma.user.findUnique({
-        where: { email },
-        include: {
-            password: true
-        }
-    });
-
-    if (!userWithPassword || !userWithPassword.password) {
-        return null;
-    }
-
-    const isValid = await bcrypt.compare(password, userWithPassword.password.hash);
-
-    if (!isValid) {
-        return null;
-    }
-
-    const { password: _password, ...userWithoutPassword } = userWithPassword;
-
-    return userWithoutPassword;
-}
+export async function verifyLogin(email: User['email'], password: Password['hash']) {}

--- a/packages/osc-academic-hub/app/root.tsx
+++ b/packages/osc-academic-hub/app/root.tsx
@@ -17,7 +17,6 @@ import oscUiSwitchStyles from 'osc-ui/dist/src-components-Switch-switch.css';
 import styles from 'osc-ui/dist/src-styles-main.css';
 import React, { useEffect } from 'react';
 import { checkConnectivity } from '~/utils/client/pwa-utils.client';
-import { getUser } from './session.server';
 import { getColorScheme } from './utils/colorScheme';
 
 let isMount = true;
@@ -61,7 +60,7 @@ export const meta: MetaFunction = () => ({
 });
 
 type LoaderData = {
-    user: Awaited<ReturnType<typeof getUser>>;
+    // user: Awaited<ReturnType<typeof getUser>>;
     colorScheme: string;
 };
 
@@ -71,7 +70,7 @@ export const headers: HeadersFunction = () => ({
 
 export const loader: LoaderFunction = async ({ request }) => {
     return json<LoaderData>({
-        user: await getUser(request),
+        // user: await getUser(request),
         colorScheme: await getColorScheme(request),
     });
 };

--- a/packages/osc-academic-hub/app/routes/courses.tsx
+++ b/packages/osc-academic-hub/app/routes/courses.tsx
@@ -1,0 +1,26 @@
+import { Outlet, useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Courses() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the courses page</h1>
+
+            <Outlet />
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/courses/$id.tsx
+++ b/packages/osc-academic-hub/app/routes/courses/$id.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Course() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the course page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/dashboard.tsx
+++ b/packages/osc-academic-hub/app/routes/dashboard.tsx
@@ -12,13 +12,13 @@ export const loader: LoaderFunction = async ({ request }) => {
     });
 };
 
-export default function Index() {
+export default function Dashboard() {
     const { userAccessToken } = useLoaderData();
     console.log(userAccessToken);
 
     return (
         <div>
-            <h1>This is the admin index page</h1>
+            <h1>This is the dashboard page</h1>
 
             <Form action="/logout" method="post">
                 <button type="submit">Logout</button>

--- a/packages/osc-academic-hub/app/routes/invoices.tsx
+++ b/packages/osc-academic-hub/app/routes/invoices.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Invoices() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the invoices page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/login.tsx
+++ b/packages/osc-academic-hub/app/routes/login.tsx
@@ -1,23 +1,28 @@
+import { gql } from '@apollo/client';
 import type { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
-import { Form, Link, useActionData, useSearchParams } from '@remix-run/react';
+import { Form, Link, useActionData } from '@remix-run/react';
 import * as React from 'react';
+import { useEffect } from 'react';
+import { graphQLClient } from '~/lib/apollo/getClient.server';
 
-import { createUserSession, getUserId } from '~/session.server';
-import { verifyLogin } from '~/models/user.server';
-import { validateEmail } from '~/utils/_tmp_/validateEmail';
-import { safeRedirect } from '~/utils/_tmp_/safeRedirect';
+import { createUserSession, getUserToken } from '~/session.server';
+
+const DASHBOARD_ROUTE = '/dashboard';
 
 export const loader: LoaderFunction = async ({ request }) => {
-    const userId = await getUserId(request);
-    if (userId) return redirect('/admin');
+    const userAccessToken = await getUserToken(request);
+    // TODO: need to change redirect based on user type (student goes to student route, for example)
+    if (userAccessToken) return redirect(DASHBOARD_ROUTE);
+
     return json({});
 };
 
 interface ActionData {
-    errors?: {
-        email?: string;
-        password?: string;
+    error?: {
+        graphQLErrors: {
+            message: string;
+        }[];
     };
 }
 
@@ -25,148 +30,103 @@ export const action: ActionFunction = async ({ request }) => {
     const formData = await request.formData();
     const email = formData.get('email');
     const password = formData.get('password');
-    const redirectTo = safeRedirect(formData.get('redirectTo'), '/admin');
-    const remember = formData.get('remember');
+    // TODO: need to capture previous page if timed out & redirect to that
+    // TODO: if login required to access a link provided by someone else, redirect to original destination after login
+    const redirectTo = DASHBOARD_ROUTE;
 
-    if (!validateEmail(email)) {
-        return json<ActionData>({ errors: { email: 'Email is invalid' } }, { status: 400 });
+    const mutation = gql`
+        mutation Login($input: loginInput!) {
+            login(input: $input) {
+                accessToken
+            }
+        }
+    `;
+
+    try {
+        const { data, errors } = await graphQLClient.mutate({
+            mutation,
+            variables: {
+                input: {
+                    email,
+                    password,
+                },
+            },
+        });
+
+        if (errors) throw new Error(String(errors));
+
+        return createUserSession({
+            request,
+            accessToken: data.login.accessToken,
+            redirectTo,
+        });
+    } catch (error) {
+        return json({
+            error,
+        });
     }
-
-    if (typeof password !== 'string' || password.length === 0) {
-        return json<ActionData>({ errors: { password: 'Password is required' } }, { status: 400 });
-    }
-
-    if (password.length < 8) {
-        return json<ActionData>({ errors: { password: 'Password is too short' } }, { status: 400 });
-    }
-
-    const user = await verifyLogin(email, password);
-
-    if (!user) {
-        return json<ActionData>(
-            { errors: { email: 'Invalid email or password' } },
-            { status: 400 }
-        );
-    }
-
-    return createUserSession({
-        request,
-        userId: user.id,
-        remember: remember === 'on' ? true : false,
-        redirectTo
-    });
 };
 
 export const meta: MetaFunction = () => {
     return {
-        title: 'Login'
+        title: 'Login',
     };
 };
 
 export default function LoginPage() {
-    const [searchParams] = useSearchParams();
-    const redirectTo = searchParams.get('redirectTo') || '/admin';
     const actionData = useActionData() as ActionData;
     const emailRef = React.useRef<HTMLInputElement>(null);
     const passwordRef = React.useRef<HTMLInputElement>(null);
+    const errorMessage = actionData?.error?.graphQLErrors[0].message;
 
-    React.useEffect(() => {
-        if (actionData?.errors?.email) {
+    useEffect(() => {
+        if (errorMessage) {
             emailRef.current?.focus();
-        } else if (actionData?.errors?.password) {
-            passwordRef.current?.focus();
         }
-    }, [actionData]);
+    }, [errorMessage]);
 
     return (
-        <div className="flex min-h-screen flex-col justify-center">
-            <div className="mx-auto w-full max-w-md px-8">
-                <Form method="post" className="space-y-6">
-                    <div>
-                        <label htmlFor="email" className="block text-sm font-medium text-slate-100">
-                            Email address
-                        </label>
-                        <div className="mt-1">
-                            <input
-                                ref={emailRef}
-                                id="email"
-                                required
-                                autoFocus={true}
-                                name="email"
-                                type="email"
-                                autoComplete="email"
-                                aria-invalid={actionData?.errors?.email ? true : undefined}
-                                aria-describedby="email-error"
-                                className="w-full rounded border border-gray-500 px-2 py-1 text-lg"
-                            />
-                            {actionData?.errors?.email && (
-                                <div className="pt-1 text-red-700" id="email-error">
-                                    {actionData.errors.email}
-                                </div>
-                            )}
-                        </div>
-                    </div>
+        <Form method="post">
+            <div>
+                {errorMessage ? <div>{errorMessage}</div> : null}
 
-                    <div>
-                        <label
-                            htmlFor="password"
-                            className="block text-sm font-medium text-slate-100"
-                        >
-                            Password
-                        </label>
-                        <div className="mt-1">
-                            <input
-                                id="password"
-                                ref={passwordRef}
-                                name="password"
-                                type="password"
-                                autoComplete="current-password"
-                                aria-invalid={actionData?.errors?.password ? true : undefined}
-                                aria-describedby="password-error"
-                                className="w-full rounded border border-gray-500 px-2 py-1 text-lg"
-                            />
-                            {actionData?.errors?.password && (
-                                <div className="pt-1 text-red-700" id="password-error">
-                                    {actionData.errors.password}
-                                </div>
-                            )}
-                        </div>
-                    </div>
-
-                    <input type="hidden" name="redirectTo" value={redirectTo} />
-                    <button
-                        type="submit"
-                        className="w-full rounded bg-blue-500  py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400"
-                    >
-                        Log in
-                    </button>
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center">
-                            <input
-                                id="remember"
-                                name="remember"
-                                type="checkbox"
-                                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                            />
-                            <label htmlFor="remember" className="ml-2 block text-sm text-slate-100">
-                                Remember me
-                            </label>
-                        </div>
-                        <div className="text-center text-sm text-slate-100">
-                            Don't have an account?{' '}
-                            <Link
-                                className="text-blue-500 underline"
-                                to={{
-                                    pathname: '/join',
-                                    search: searchParams.toString()
-                                }}
-                            >
-                                Sign up
-                            </Link>
-                        </div>
-                    </div>
-                </Form>
+                <label htmlFor="email">Email address</label>
+                <div>
+                    {/* // TODO: Replace with input components from osc-ui */}
+                    <input
+                        ref={emailRef}
+                        id="email"
+                        required
+                        autoFocus={true}
+                        name="email"
+                        type="email"
+                        autoComplete="email"
+                        aria-invalid={errorMessage ? true : undefined}
+                        aria-describedby="email-error"
+                    />
+                </div>
             </div>
-        </div>
+
+            <div>
+                <label htmlFor="password">Password</label>
+                <div>
+                    <input
+                        id="password"
+                        ref={passwordRef}
+                        name="password"
+                        type="password"
+                        autoComplete="current-password"
+                        aria-invalid={errorMessage ? true : undefined}
+                        aria-describedby="password-error"
+                    />
+                </div>
+            </div>
+
+            <button type="submit">Log in</button>
+
+            <div>
+                Don't have an account? <Link to={'/register'}>Sign up</Link>
+            </div>
+        </Form>
     );
 }

--- a/packages/osc-academic-hub/app/routes/preferences.tsx
+++ b/packages/osc-academic-hub/app/routes/preferences.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Preferences() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the Preferences page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/profile.tsx
+++ b/packages/osc-academic-hub/app/routes/profile.tsx
@@ -1,0 +1,30 @@
+import { NavLink, Outlet, useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Profile() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>My Profile</h1>
+
+            <NavLink to="details">Details</NavLink>
+            <NavLink to="additional-info">Additional Info</NavLink>
+            <NavLink to="courses">Courses</NavLink>
+
+            <Outlet />
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/profile/additional-info.tsx
+++ b/packages/osc-academic-hub/app/routes/profile/additional-info.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function AdditionalInfo() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the additional info page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/profile/courses.tsx
+++ b/packages/osc-academic-hub/app/routes/profile/courses.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Courses() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the courses page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/profile/details.tsx
+++ b/packages/osc-academic-hub/app/routes/profile/details.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Details() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the details page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/register.tsx
+++ b/packages/osc-academic-hub/app/routes/register.tsx
@@ -1,17 +1,17 @@
 import type { ActionFunction, LoaderFunction, MetaFunction } from '@remix-run/node';
-import { json, redirect } from '@remix-run/node';
+import { json } from '@remix-run/node';
 import { Form, Link, useActionData, useSearchParams } from '@remix-run/react';
 import * as React from 'react';
 
-import { getUserId, createUserSession } from '~/session.server';
+import { createUserSession } from '~/session.server';
 
 import { createUser, getUserByEmail } from '~/models/user.server';
-import { validateEmail } from '~/utils/_tmp_/validateEmail';
 import { safeRedirect } from '~/utils/_tmp_/safeRedirect';
+import { validateEmail } from '~/utils/_tmp_/validateEmail';
 
 export const loader: LoaderFunction = async ({ request }) => {
-    const userId = await getUserId(request);
-    if (userId) return redirect('/admin');
+    // const userId = await getUserId(request);
+    // if (userId) return redirect('/admin');
     return json({});
 };
 
@@ -54,13 +54,13 @@ export const action: ActionFunction = async ({ request }) => {
         request,
         userId: user.id,
         remember: false,
-        redirectTo
+        redirectTo,
     });
 };
 
 export const meta: MetaFunction = () => {
     return {
-        title: 'Sign Up'
+        title: 'Sign Up',
     };
 };
 
@@ -148,7 +148,7 @@ export default function Join() {
                                 className="text-blue-500 underline"
                                 to={{
                                     pathname: '/login',
-                                    search: searchParams.toString()
+                                    search: searchParams.toString(),
                                 }}
                             >
                                 Log in

--- a/packages/osc-academic-hub/app/routes/reports.tsx
+++ b/packages/osc-academic-hub/app/routes/reports.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function Reports() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the Reports page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/reset-password.tsx
+++ b/packages/osc-academic-hub/app/routes/reset-password.tsx
@@ -1,0 +1,7 @@
+// export const loader: LoaderFunction = async ({ request }) => {};
+
+// export const action: ActionFunction = async ({ request }) => {};
+
+export default function ResetPage() {
+    return <h1>Reset password</h1>;
+}

--- a/packages/osc-academic-hub/app/routes/student-list.tsx
+++ b/packages/osc-academic-hub/app/routes/student-list.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function StudentList() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the StudentList page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/routes/student-record.tsx
+++ b/packages/osc-academic-hub/app/routes/student-record.tsx
@@ -1,4 +1,4 @@
-import { Form, useLoaderData } from '@remix-run/react';
+import { useLoaderData } from '@remix-run/react';
 import type { LoaderFunction } from '@remix-run/server-runtime';
 import { json, redirect } from '@remix-run/server-runtime';
 import { getUserToken } from '~/session.server';
@@ -12,17 +12,13 @@ export const loader: LoaderFunction = async ({ request }) => {
     });
 };
 
-export default function Index() {
+export default function StudentRecord() {
     const { userAccessToken } = useLoaderData();
     console.log(userAccessToken);
 
     return (
         <div>
-            <h1>This is the admin index page</h1>
-
-            <Form action="/logout" method="post">
-                <button type="submit">Logout</button>
-            </Form>
+            <h1>This is the student record page</h1>
         </div>
     );
 }

--- a/packages/osc-academic-hub/app/routes/tutor-allocation.tsx
+++ b/packages/osc-academic-hub/app/routes/tutor-allocation.tsx
@@ -1,0 +1,24 @@
+import { useLoaderData } from '@remix-run/react';
+import type { LoaderFunction } from '@remix-run/server-runtime';
+import { json, redirect } from '@remix-run/server-runtime';
+import { getUserToken } from '~/session.server';
+
+export const loader: LoaderFunction = async ({ request }) => {
+    const userAccessToken = await getUserToken(request);
+    if (!getUserToken) return redirect('/');
+
+    return json({
+        userAccessToken, // Only here for testing
+    });
+};
+
+export default function TutorAllocation() {
+    const { userAccessToken } = useLoaderData();
+    console.log(userAccessToken);
+
+    return (
+        <div>
+            <h1>This is the tutor allocation page</h1>
+        </div>
+    );
+}

--- a/packages/osc-academic-hub/app/session.server.ts
+++ b/packages/osc-academic-hub/app/session.server.ts
@@ -1,9 +1,6 @@
 import { createCookieSessionStorage, redirect } from '@remix-run/node';
 import invariant from 'tiny-invariant';
 
-import type { User } from '~/models/user.server';
-import { getUserById } from '~/models/user.server';
-
 invariant(process.env.SESSION_SECRET, 'SESSION_SECRET must be set');
 
 export const sessionStorage = createCookieSessionStorage({
@@ -14,75 +11,42 @@ export const sessionStorage = createCookieSessionStorage({
         path: '/',
         sameSite: 'lax',
         secrets: [process.env.SESSION_SECRET],
-        secure: process.env.NODE_ENV === 'production'
-    }
+        secure: process.env.NODE_ENV === 'production',
+    },
 });
 
-const USER_SESSION_KEY = 'userId';
+const USER_SESSION_KEY = 'accessToken';
 
 export async function getSession(request: Request) {
     const cookie = request.headers.get('Cookie');
     return sessionStorage.getSession(cookie);
 }
 
-export async function getUserId(request: Request): Promise<User['id'] | undefined> {
+export async function getUserToken(request: Request) {
     const session = await getSession(request);
-    const userId = session.get(USER_SESSION_KEY);
-    return userId;
-}
+    const token = session.get(USER_SESSION_KEY);
 
-export async function getUser(request: Request) {
-    const userId = await getUserId(request);
-    if (userId === undefined) return null;
-
-    const user = await getUserById(userId);
-    if (user) return user;
-
-    throw await logout(request);
-}
-
-export async function requireUserId(
-    request: Request,
-    redirectTo: string = new URL(request.url).pathname
-) {
-    const userId = await getUserId(request);
-    if (!userId) {
-        const searchParams = new URLSearchParams([['redirectTo', redirectTo]]);
-        throw redirect(`/login?${searchParams}`);
-    }
-    return userId;
-}
-
-export async function requireUser(request: Request) {
-    const userId = await requireUserId(request);
-
-    const user = await getUserById(userId);
-    if (user) return user;
-
-    throw await logout(request);
+    return token;
 }
 
 export async function createUserSession({
     request,
-    userId,
-    remember,
-    redirectTo
+    accessToken,
+    redirectTo,
 }: {
     request: Request;
-    userId: string;
-    remember: boolean;
+    accessToken: string;
     redirectTo: string;
 }) {
     const session = await getSession(request);
-    session.set(USER_SESSION_KEY, userId);
+    session.set(USER_SESSION_KEY, accessToken);
+
     return redirect(redirectTo, {
         headers: {
             'Set-Cookie': await sessionStorage.commitSession(session, {
-                maxAge: remember
-                    ? 60 * 60 * 24 * 7 // 7 days
-                    : undefined
-            })
-        }
+                maxAge: undefined, // not sure if undefined is correct, but need a maxAge & value to make this work
+            }),
+        },
     });
 }
 
@@ -90,7 +54,7 @@ export async function logout(request: Request) {
     const session = await getSession(request);
     return redirect('/login', {
         headers: {
-            'Set-Cookie': await sessionStorage.destroySession(session)
-        }
+            'Set-Cookie': await sessionStorage.destroySession(session),
+        },
     });
 }

--- a/packages/osc-academic-hub/package.json
+++ b/packages/osc-academic-hub/package.json
@@ -26,6 +26,7 @@
     "copy-fonts": "run-s copy-fonts:*"
   },
   "dependencies": {
+    "@apollo/client": "^3.7.7",
     "@prisma/client": "^4.11.0",
     "@radix-ui/react-icons": "^1.2.0",
     "@remix-run/node": "^1.13.0",
@@ -34,6 +35,7 @@
     "@remix-run/server-runtime": "^1.13.0",
     "bcryptjs": "^2.4.3",
     "dotenv": "^16.0.3",
+    "graphql": "^16.6.0",
     "node-persist": "^3.1.3",
     "osc-ui": "*",
     "react": "^18.2.0",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Sets up initial routes and links up the auth api so we can do a simple login.

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

We've installed Apollo Client and set it up inside `/lib/apollo/getClient.server.ts` but instead of using the providers and hooks we can use it in this way to run inside Remix's loaders and actions. You can see this being used in the `login.tsx`

We've also created a bunch of initial routes which contain basic placeholder markup to identify them, it's intended to be removed once work starts on them.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information

Not added any tests yet, once the auth flow is finalised and we're returning more user data will setup integration/e2e tests.

Any TODO's are intentional and reminders for upcoming work.