### PR TITLE
Chore: upgrade to latest prisma version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "osc",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "workspaces": [
         "packages/osc-ui",
         "packages/osc-ecommerce",
@@ -9853,9 +9853,9 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0.tgz",
-      "integrity": "sha512-4t9ir2SbQQr/wMCNU4YpHWp5hU14J2m3wHUZnGJPpmBF8YtkisxyVyQsKd1e6FyLTaGq8LOLhm6VLYHKqKNm+g==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.10.1.tgz",
+      "integrity": "sha512-B3tcTxjx196nuAu1GOTKO9cGPUgTFHYRdkPkTS4m5ptb2cejyBlH9X7GOfSt3xlI7p4zAJDshJP4JJivCg9ouA==",
       "devOptional": true,
       "hasInstallScript": true
     },
@@ -36246,14 +36246,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.5.0.tgz",
-      "integrity": "sha512-9Aeg4qiKlv9Wsjz4NO8k2CzRzlvS3A4FYVJ5+28sBBZ0eEwbiVOE/Jj7v6rZC1tFW2s4GSICQOAyuOjc6WsNew==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.10.1.tgz",
+      "integrity": "sha512-0jDxgg+DruB1kHVNlcspXQB9au62IFfVg9drkhzXudszHNUAQn0lVuu+T8np0uC2z1nKD5S3qPeCyR8u5YFLnA==",
       "devOptional": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "4.5.0"
+        "@prisma/engines": "4.10.1"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -51390,9 +51389,9 @@
       }
     },
     "@prisma/engines": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0.tgz",
-      "integrity": "sha512-4t9ir2SbQQr/wMCNU4YpHWp5hU14J2m3wHUZnGJPpmBF8YtkisxyVyQsKd1e6FyLTaGq8LOLhm6VLYHKqKNm+g==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.10.1.tgz",
+      "integrity": "sha512-B3tcTxjx196nuAu1GOTKO9cGPUgTFHYRdkPkTS4m5ptb2cejyBlH9X7GOfSt3xlI7p4zAJDshJP4JJivCg9ouA==",
       "devOptional": true
     },
     "@prisma/engines-version": {
@@ -69453,12 +69452,12 @@
       }
     },
     "prisma": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.5.0.tgz",
-      "integrity": "sha512-9Aeg4qiKlv9Wsjz4NO8k2CzRzlvS3A4FYVJ5+28sBBZ0eEwbiVOE/Jj7v6rZC1tFW2s4GSICQOAyuOjc6WsNew==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.10.1.tgz",
+      "integrity": "sha512-0jDxgg+DruB1kHVNlcspXQB9au62IFfVg9drkhzXudszHNUAQn0lVuu+T8np0uC2z1nKD5S3qPeCyR8u5YFLnA==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.5.0"
+        "@prisma/engines": "4.10.1"
       }
     },
     "prismjs": {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Updated repo to use latest Prisma version (v4.10.1). v4.9 includes a new `@default()` option I want to utilise. `nanoid()`.

Details here https://github.com/prisma/prisma-engines/pull/3556

This is basically the same as UUID/GUIDs but better for smaller scale systems. We have no real use for 128 bit IDs, a simple 20 characters is sufficient for our needs. It also remains perfectly scalable as we can just increase the length as needed in the future.

## ⛳️ Current behavior (updates)

v4.5
No `nanoid()`

## 🚀 New behavior

v4.10.1
Access to use `nanoid()` for DB IDs.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
I will redefine the schema to use the IDs in a seperate PR once this merges, as it will also include a lot of API/TS tweaks.

Additional reading:
https://planetscale.com/blog/why-we-chose-nanoids-for-planetscales-api
https://zelark.github.io/nano-id-cc/
