### PR TITLE
fix: add SpriteSheetProvider and re-write test

### DIFF
--- a/packages/osc-ui/src/components/TextArea/TextArea.spec.tsx
+++ b/packages/osc-ui/src/components/TextArea/TextArea.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { Icon, SpritesheetProvider } from '../Icon/Icon';
 import { TextArea } from './TextArea';
-import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 
 test('should render a textarea component with a label', () => {
     render(<TextArea id="enquiry" name="Enquiry" />);
@@ -18,27 +18,39 @@ test('should render an asterisk when input field is required', () => {
 
 test('should render an icon when passed as a prop', () => {
     render(
-        <TextArea
-            icon={{
-                content: <ExclamationTriangleIcon />,
-                label: 'Exclamation Triangle Icon',
-                type: 'error',
-            }}
-            id="enquiry"
-            name="Enquiry"
-            required={true}
-            wasSubmitted={true}
-        />
+        <SpritesheetProvider>
+            <TextArea
+                icon={{
+                    content: <Icon id="exclamation-mark" />,
+                    label: 'Exclamation Triangle Icon',
+                    type: 'error',
+                }}
+                id="enquiry"
+                name="Enquiry"
+                required={true}
+                wasSubmitted={true}
+            />
+        </SpritesheetProvider>
     );
-    expect(screen.getByText('Exclamation Triangle Icon')).toBeInTheDocument();
+
+    expect(document.querySelector('use')).toBeInTheDocument();
+    expect(document.querySelector('use')).toHaveAttribute('href');
 });
 
 test('should disable the input when disabled prop is true', () => {
-    render(<TextArea id="enquiry" name="Enquiry" disabled={true} />);
+    render(
+        <SpritesheetProvider>
+            <TextArea id="enquiry" name="Enquiry" disabled={true} />
+        </SpritesheetProvider>
+    );
     expect(screen.getByRole('textbox')).toBeDisabled();
 });
 
 test('should render an error message if "wasSubmitted" is true, the field is required, and no value is present', () => {
-    render(<TextArea id="enquiry" name="Enquiry" required={true} wasSubmitted={true} />);
+    render(
+        <SpritesheetProvider>
+            <TextArea id="enquiry" name="Enquiry" required={true} wasSubmitted={true} />
+        </SpritesheetProvider>
+    );
     expect(screen.getByRole('alert')).toBeInTheDocument();
 });

--- a/packages/osc-ui/src/components/TextArea/TextArea.spec.tsx
+++ b/packages/osc-ui/src/components/TextArea/TextArea.spec.tsx
@@ -34,7 +34,10 @@ test('should render an icon when passed as a prop', () => {
     );
 
     expect(document.querySelector('use')).toBeInTheDocument();
-    expect(document.querySelector('use')).toHaveAttribute('href');
+    expect(document.querySelector('use')).toHaveAttribute(
+        'href',
+        './spritesheet.svg#exclamation-mark'
+    );
 });
 
 test('should disable the input when disabled prop is true', () => {


### PR DESCRIPTION
Closes #705 

## 📝 Description

Fix failing TextArea test

## ⛳️ Current behavior (updates)

Fails on Icon test

## 🚀 New behavior

Passes Icon test

## 💣 Is this a breaking change (Yes/No): No 

