### PR TITLE
Feature/island grid

### DIFF
--- a/packages/osc-ui/src/components/IslandGrid/IslandGrid.spec.tsx
+++ b/packages/osc-ui/src/components/IslandGrid/IslandGrid.spec.tsx
@@ -1,0 +1,99 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { IslandGrid } from './IslandGrid';
+
+test('renders IslandGrid with three islands', () => {
+    render(
+        <IslandGrid>
+            <div
+                style={{
+                    height: '638px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+        </IslandGrid>
+    );
+
+    const IslandGridElement = document.querySelector('.c-island-grid');
+    const Islands = document.querySelectorAll('.c-island-grid__island');
+
+    expect(IslandGridElement).toBeInTheDocument();
+    expect(Islands).toHaveLength(3);
+});
+
+test('renders IslandGrid with four islands', () => {
+    render(
+        <IslandGrid>
+            <div
+                style={{
+                    height: '638px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+        </IslandGrid>
+    );
+
+    const IslandGridElement = document.querySelector('.c-island-grid');
+    const Islands = document.querySelectorAll('.c-island-grid__island');
+
+    expect(IslandGridElement).toBeInTheDocument();
+    expect(Islands).toHaveLength(4);
+});
+
+test('renders IslandGrid with custom classname', () => {
+    render(
+        <IslandGrid className="custom-class">
+            <div
+                style={{
+                    height: '638px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+        </IslandGrid>
+    );
+
+    const IslandGridElement = document.querySelector('.c-island-grid');
+    expect(IslandGridElement).toHaveClass('custom-class');
+});

--- a/packages/osc-ui/src/components/IslandGrid/IslandGrid.stories.tsx
+++ b/packages/osc-ui/src/components/IslandGrid/IslandGrid.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+import type { IslandGridProps } from './IslandGrid';
+import { IslandGrid } from './IslandGrid';
+
+export default {
+    title: 'osc-ui/IslandGrid',
+    component: IslandGrid,
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'A specific layout grid component for displaying items in a two column layout, with one item on the left and two to three on the right.',
+            },
+        },
+    },
+} as Meta;
+
+const Template: Story<IslandGridProps> = ({ ...args }) => (
+    <div className="o-container">
+        <IslandGrid {...args}>
+            <div
+                style={{
+                    height: '638px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '310px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+        </IslandGrid>
+    </div>
+);
+
+const TemplateWithFour: Story<IslandGridProps> = ({ ...args }) => (
+    <div className="o-container">
+        <IslandGrid {...args}>
+            <div
+                style={{
+                    height: '665px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '200px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '200px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+            <div
+                style={{
+                    height: '200px',
+                    backgroundImage: 'var(--color-gradient-quaternary-90)',
+                }}
+            />
+        </IslandGrid>
+    </div>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {};
+export const HasFourChildren = TemplateWithFour.bind({});
+TemplateWithFour.args = {};
+TemplateWithFour.parameters = {
+    docs: {
+        description: {
+            story: 'To bring the grid up to having three items on the right, add four children.',
+        },
+    },
+};

--- a/packages/osc-ui/src/components/IslandGrid/IslandGrid.tsx
+++ b/packages/osc-ui/src/components/IslandGrid/IslandGrid.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+import React, { Children } from 'react';
+import { classNames } from '../../utils/classNames';
+
+import './island-grid.scss';
+
+export interface IslandGridProps {
+    /**
+     * The content of the IslandGrid
+     * Must take a minimum of 3 children, or a maximum of 4
+     */
+    children: [ReactNode, ReactNode, ReactNode, ReactNode?];
+    /**
+     * Custom class
+     */
+    className?: string;
+}
+
+export const IslandGrid = (props: IslandGridProps) => {
+    const { children, className } = props;
+
+    const classes = classNames('c-island-grid', 'o-grid', className);
+
+    return (
+        <div className={classes}>
+            {Children.map(children, (child, index) => {
+                return (
+                    <div
+                        className="c-island-grid__island o-grid__col--12 o-grid__col--6@tab"
+                        key={index}
+                    >
+                        {child}
+                    </div>
+                );
+            })}
+        </div>
+    );
+};

--- a/packages/osc-ui/src/components/IslandGrid/island-grid.scss
+++ b/packages/osc-ui/src/components/IslandGrid/island-grid.scss
@@ -1,0 +1,26 @@
+@use "sass:list";
+@import "../../styles/settings";
+@import "../../styles/tools";
+
+$island-cols: 2;
+$max-islands: 4;
+
+.c-island-grid {
+    @include mq($mq-tab) {
+        grid-template-rows: repeat($island-cols, minmax(0, 1fr));
+    }
+
+    &__island {
+        @include mq($mq-tab) {
+            &:nth-child(1) {
+                grid-row: list.slash(1, $max-islands);
+            }
+
+            @for $i from 2 through $max-islands {
+                &:nth-child(#{$i}) {
+                    grid-row: #{$i - 1}; // Position the island in the row minus 1 place from it's index
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #695 

## 📝 Description

Adds a special layout component for presenting content in a two colum/three (or four) row grid:

<img width="298" alt="image" src="https://user-images.githubusercontent.com/23461173/219476196-a1caf925-409a-4ddc-be6e-0c7da7d91a64.png">

The components styles are handled by the number of children using the `nth-child` pseudo selector. Because of the css  limitations we can't dynamically change the `$max-islands` values. To counter this I've set the children type on the component to take at least 3 nodes or a maximum of 4. (This will need to be accounted for in the CMS by applying some validation or a max length to the controls.)

As there are not cards in main at the moment I've just added a background colour and an arbitrary height to each child to demonstrate the space.

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

Adds `<IslandGrid>` to component library

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information

Sanity ticket #696 will be handled in a separate PR