### PR TITLE
Refactor/types-maybe-generic

### DIFF
--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -96,7 +96,11 @@ export default function Module(props: Props) {
                 <article>
                     <Content
                         align={moduleContent.horizontalAlignment}
-                        backgroundColor={moduleContent.backgroundColor}
+                        backgroundColor={
+                            moduleContent.backgroundColor
+                                ? moduleContent.backgroundColor
+                                : undefined
+                        }
                         marginBottom={moduleContent.marginBottom}
                         paddingBottom={moduleContent.paddingBottom}
                         paddingTop={moduleContent.paddingTop}
@@ -113,7 +117,9 @@ export default function Module(props: Props) {
                 <Image
                     key={moduleImage._key}
                     src={moduleImage.src}
-                    artDirectedImages={moduleImage.responsiveImages}
+                    artDirectedImages={
+                        moduleImage.responsiveImages ? moduleImage.responsiveImages : undefined
+                    }
                     alt={moduleImage.alt}
                     width={moduleImage.width}
                     height={moduleImage.height}

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -1,5 +1,5 @@
 import type { PortableTextBlock } from '@portabletext/types';
-import type { Spacing, Themes } from 'osc-ui/src/types';
+import type { Maybe, Spacing, Themes } from 'osc-ui/src/types';
 import type { ImgHTMLAttributes } from 'react';
 
 export interface SanityLinkItem {
@@ -28,7 +28,7 @@ interface SanityImage<T> extends ImgHTMLAttributes<T> {
 
 export interface imageModule<T> extends SanityImage<T> {
     alt: string;
-    responsiveImages?: SanityImage<T>[] | undefined;
+    responsiveImages: Maybe<SanityImage<T>[]>;
     className?: string;
     loading?: 'eager' | 'lazy';
     responsiveWidths?: number[];
@@ -36,8 +36,8 @@ export interface imageModule<T> extends SanityImage<T> {
 }
 
 export interface module {
-    _type?: string;
-    _key?: string;
+    _type?: Maybe<string>;
+    _key?: Maybe<string>;
 }
 
 interface buttonModule extends module {
@@ -67,11 +67,11 @@ interface buttonModule extends module {
 }
 
 export interface contentModule extends module {
-    backgroundColor?: Themes;
+    backgroundColor?: Maybe<Themes>;
     horizontalAlignment?: 'left' | 'centre' | 'right';
-    marginBottom?: Spacing;
-    paddingBottom?: Spacing;
-    paddingTop?: Spacing;
+    marginBottom?: Maybe<Spacing>;
+    paddingBottom?: Maybe<Spacing>;
+    paddingTop?: Maybe<Spacing>;
     body?: PortableTextBlock[];
     buttons?: buttonModule[];
 }

--- a/packages/osc-ui/src/components/Content/Content.tsx
+++ b/packages/osc-ui/src/components/Content/Content.tsx
@@ -7,7 +7,7 @@ import colors from '../../../../../tokens/colors';
 import sizes from '../../../../../tokens/fluid-scale';
 import typography from '../../../../../tokens/typography';
 import { useSpacing } from '../../hooks/useSpacing';
-import type { Spacing } from '../../types';
+import type { Maybe, Spacing } from '../../types';
 import { classNames } from '../../utils/classNames';
 import { Button, ButtonGroup, CopyButton } from '../Button/Button';
 import { Image } from '../Image/Image';
@@ -35,11 +35,11 @@ export interface ButtonProps {
 
 export interface Props {
     align?: 'left' | 'centre' | 'right';
-    backgroundColor?: string;
+    backgroundColor?: Maybe<string>;
     className?: string;
-    marginBottom?: Spacing;
-    paddingBottom?: Spacing;
-    paddingTop?: Spacing;
+    marginBottom?: Maybe<Spacing>;
+    paddingBottom?: Maybe<Spacing>;
+    paddingTop?: Maybe<Spacing>;
     value: PortableTextBlock[];
     buttons?: ButtonProps[];
 }

--- a/packages/osc-ui/src/types.ts
+++ b/packages/osc-ui/src/types.ts
@@ -31,6 +31,8 @@ export type Spacing =
 
 export type Direction = 'top' | 'right' | 'bottom' | 'left';
 
+export type Maybe<T> = T | null | undefined;
+
 // StrictUnion type allows us to set up props that are mutually exclusive
 // For example if you have a prop called isSuccess and isError, you can't have both
 // Using this helper you can set up the type to only allow one of the two at a time


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes N/a

## 📝 Description

Originally part of #691 but pulled it out as it impacts more than just that PR

Adds a `<Maybe>` generic in our types file, I found I was having to add `| undefined | null` in a few places to keep TS happy in osc-ecommerce so now we can just wrap our type in that when we need to.

## ⛳️ Current behavior (updates)

When adding types we are often having to include `| undefined | null` especially when creating components getting data from Sanity, which may or may not exist.

## 🚀 New behavior

Wrap your type in `<Maybe>` e.g. `Maybe<string>` and this will auto apply `| undefined | null` union.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
