### PR TITLE
Bugfix/xl modifiers not being applied to utility classes

### DIFF
--- a/packages/osc-ui/src/styles/utilities/_util.scss
+++ b/packages/osc-ui/src/styles/utilities/_util.scss
@@ -21,9 +21,11 @@
 
     @each $step in scale-token("steps") {
         @if ($scale == "relative") {
-            $map: map.set($map, $step, var(--font-scale-#{$step}));
+            // Interpolate the $step to convert it into a string
+            // This prevents it getting stripped apart if we use the strip-unit function
+            $map: map.set($map, #{$step}, var(--font-scale-#{$step}));
         } @else {
-            $map: map.set($map, $step, var(--space-scale-#{$step}));
+            $map: map.set($map, #{$step}, var(--space-scale-#{$step}));
         }
     }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Discovered a small bug when using the padding / margin util classes such as `u-pt-2xl`. When trying to apply them the styles wouldn't be applied, however `u-pt-xl` would still work. 
This was because in the loop where we generate these classnames we use our `strip-unit` function to remove things like `px` or `rem` from the classname. As it turns out Sass types `2xl` as a number rather than a string, so the `xl` part was getting stripped.

I've implemented a fix in the `scales-map` function to convert the step into a string.

## ⛳️ Current behavior (updates)

The `xl` / `xs` parts of the padding/margin utility functions were getting stripped off by the `strip-unit` function as Sass was treating them as units to a number, in the same way as `2px`

## 🚀 New behavior

Inside of `scales-map` we now interpolate the `$step` variable when setting the map to coerce it into a string, therefore allowing it to be skipped by `strip-unit`.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
