### PR TITLE
Feature/callout banner

### DIFF
--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.spec.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.spec.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { CalloutBanner } from './calloutBanner';
+
+test('renders calloutBanner', () => {
+    render(<CalloutBanner>Hello, world!</CalloutBanner>);
+    const calloutBannerElement = screen.getByText(/Hello, world!/i);
+    expect(calloutBannerElement).toBeInTheDocument();
+});

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.spec.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.spec.tsx
@@ -5,7 +5,7 @@ import {
     CalloutBannerTitle,
     CalloutContentGroup,
     CalloutFooter,
-} from './calloutBanner';
+} from './CalloutBanner';
 
 test('renders CalloutBanner with content', () => {
     render(

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.spec.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.spec.tsx
@@ -1,9 +1,57 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { CalloutBanner } from './calloutBanner';
+import {
+    CalloutBanner,
+    CalloutBannerTitle,
+    CalloutContentGroup,
+    CalloutFooter,
+} from './calloutBanner';
 
-test('renders calloutBanner', () => {
-    render(<CalloutBanner>Hello, world!</CalloutBanner>);
-    const calloutBannerElement = screen.getByText(/Hello, world!/i);
-    expect(calloutBannerElement).toBeInTheDocument();
+test('renders CalloutBanner with content', () => {
+    render(
+        <CalloutBanner>
+            <CalloutBannerTitle className="u-color-gradient-quaternary-90">
+                OSC STUDENT DISCOUNT
+            </CalloutBannerTitle>
+            <CalloutContentGroup>
+                <p>
+                    We're offering a special price of £29.99 for OSC learners. To purchase the
+                    Career Kickstarter package at the discounted price please contact our learner
+                    services team via studentsupport@openstudycollege.com
+                </p>
+            </CalloutContentGroup>
+        </CalloutBanner>
+    );
+
+    const calloutBannerElement = screen.getByRole('complementary');
+    const calloutBannerTitleElement = screen.getByRole('heading', {
+        name: /OSC STUDENT DISCOUNT/i,
+    });
+    const calloutContentGroupElement = document.querySelector('.c-callout-banner__content-group');
+
+    expect(calloutBannerElement).toHaveClass('c-callout-banner');
+    expect(calloutBannerTitleElement).toHaveClass('c-callout-banner__ttl');
+    expect(calloutContentGroupElement).toBeInTheDocument();
+});
+
+test('renders the content group as child element', () => {
+    render(
+        <CalloutContentGroup asChild>
+            <p>Callout content group as child</p>
+        </CalloutContentGroup>
+    );
+
+    const calloutContent = screen.getByText('Callout content group as child');
+    expect(calloutContent.nodeName).toBe('P');
+});
+
+test('renders the callout footer as child element', () => {
+    render(
+        <CalloutFooter asChild>
+            <p>Callout footer as child</p>
+        </CalloutFooter>
+    );
+
+    const calloutContent = screen.getByText('Callout footer as child');
+    expect(calloutContent.nodeName).toBe('P');
 });

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -2,11 +2,17 @@ import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 import { Button } from '../Button/Button';
 import type { CalloutBannerProps } from './CalloutBanner';
-import { CalloutBanner } from './CalloutBanner';
+import {
+    CalloutBanner,
+    CalloutBannerTitle,
+    CalloutButtonGroup,
+    CalloutContentGroup,
+} from './CalloutBanner';
 
 export default {
     title: 'osc-ui/Callout Banner',
     component: CalloutBanner,
+    subcomponents: { CalloutBannerTitle, CalloutContentGroup, CalloutButtonGroup },
     parameters: {
         docs: {
             description: {
@@ -19,18 +25,20 @@ export default {
 const Template: Story<CalloutBannerProps> = ({ ...args }) => (
     <div className="o-container">
         <CalloutBanner {...args}>
-            <h2 className="c-callout-banner__ttl u-color-gradient-quaternary-90 t-font-secondary u-lh-1">
+            <CalloutBannerTitle className="u-color-gradient-quaternary-90">
                 OSC STUDENT DISCOUNT
-            </h2>
-            <div className="c-content">
-                <div className="c-content__inner c-content__inner--left">
-                    <p>
-                        We're offering a special price of £29.99 for OSC learners. To purchase the
-                        Career Kickstarter package at the discounted price please contact our
-                        learner services team via studentsupport@openstudycollege.com
-                    </p>
+            </CalloutBannerTitle>
+            <CalloutContentGroup>
+                <div className="c-content">
+                    <div className="c-content__inner c-content__inner--left">
+                        <p>
+                            We're offering a special price of £29.99 for OSC learners. To purchase
+                            the Career Kickstarter package at the discounted price please contact
+                            our learner services team via studentsupport@openstudycollege.com
+                        </p>
+                    </div>
                 </div>
-            </div>
+            </CalloutContentGroup>
         </CalloutBanner>
     </div>
 );
@@ -38,21 +46,23 @@ const Template: Story<CalloutBannerProps> = ({ ...args }) => (
 const TemplateHasButton: Story<CalloutBannerProps> = ({ ...args }) => (
     <div className="o-container">
         <CalloutBanner {...args}>
-            <h2 className="c-callout-banner__ttl u-color-gradient-quaternary-90 t-font-secondary u-lh-1">
+            <CalloutBannerTitle className="u-color-gradient-quaternary-90">
                 OSC STUDENT DISCOUNT
-            </h2>
-            <div className="c-content">
-                <div className="c-content__inner c-content__inner--left">
-                    <p>
-                        We're offering a special price of £29.99 for OSC learners. To purchase the
-                        Career Kickstarter package at the discounted price please contact our
-                        learner services team via studentsupport@openstudycollege.com
-                    </p>
+            </CalloutBannerTitle>
+            <CalloutContentGroup>
+                <div className="c-content">
+                    <div className="c-content__inner c-content__inner--left">
+                        <p>
+                            We're offering a special price of £29.99 for OSC learners. To purchase
+                            the Career Kickstarter package at the discounted price please contact
+                            our learner services team via studentsupport@openstudycollege.com
+                        </p>
+                    </div>
                 </div>
-            </div>
-            <div className="c-callout-banner__btn-group">
+            </CalloutContentGroup>
+            <CalloutButtonGroup>
                 <Button>Buy now</Button>
-            </div>
+            </CalloutButtonGroup>
         </CalloutBanner>
     </div>
 );

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+import type { CalloutBannerProps } from './CalloutBanner';
+import { CalloutBanner } from './CalloutBanner';
+
+export default {
+    title: 'osc-ui/Callout Banner',
+    component: CalloutBanner,
+    parameters: {
+        docs: {
+            description: {
+                component: '',
+            },
+        },
+    },
+} as Meta;
+
+const Template: Story<CalloutBannerProps> = ({ ...args }) => <CalloutBanner {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+    children: 'hello world',
+};

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -45,6 +45,30 @@ const Template: Story<CalloutBannerProps> = ({ ...args }) => (
     </div>
 );
 
+const TemplateHasButton: Story<CalloutBannerProps> = ({ ...args }) => (
+    <div className="o-container">
+        <CalloutBanner {...args}>
+            <CalloutBannerTitle className="u-color-gradient-quaternary-90">
+                OSC STUDENT DISCOUNT
+            </CalloutBannerTitle>
+            <CalloutContentGroup asChild>
+                <div className="c-content">
+                    <div className="c-content__inner c-content__inner--left">
+                        <p>
+                            We're offering a special price of £29.99 for OSC learners. To purchase
+                            the Career Kickstarter package at the discounted price please contact
+                            our learner services team via studentsupport@openstudycollege.com
+                        </p>
+                    </div>
+                </div>
+            </CalloutContentGroup>
+            <CalloutButtonGroup>
+                <Button>Buy now</Button>
+            </CalloutButtonGroup>
+        </CalloutBanner>
+    </div>
+);
+
 const HasImageTemplate: Story<CalloutBannerProps> = ({ ...args }) => (
     <div className="o-container">
         <CalloutBanner {...args}>
@@ -67,34 +91,38 @@ const HasImageTemplate: Story<CalloutBannerProps> = ({ ...args }) => (
                         </p>
                     </div>
                 </div>
-                <CalloutFooter asChild>
-                    <p className="u-color-tertiary">Offer ends 24.11.22!</p>
-                </CalloutFooter>
             </CalloutContentGroup>
         </CalloutBanner>
     </div>
 );
 
-const TemplateHasButton: Story<CalloutBannerProps> = ({ ...args }) => (
+const HasFooterTemplate: Story<CalloutBannerProps> = ({ ...args }) => (
     <div className="o-container">
         <CalloutBanner {...args}>
-            <CalloutBannerTitle className="u-color-gradient-quaternary-90">
-                OSC STUDENT DISCOUNT
-            </CalloutBannerTitle>
-            <CalloutContentGroup asChild>
+            <Image
+                src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1677081736/3fa07f2f2545b5f9918b2522e9b3eee4_snzqcg.png"
+                width={330}
+                height={74}
+                alt="Black Friday"
+                className="u-self-start"
+            />
+            <CalloutContentGroup>
                 <div className="c-content">
                     <div className="c-content__inner c-content__inner--left">
-                        <p>
-                            We're offering a special price of £29.99 for OSC learners. To purchase
-                            the Career Kickstarter package at the discounted price please contact
-                            our learner services team via studentsupport@openstudycollege.com
+                        <p className="u-color-tertiary u-text-bold t-font-m">
+                            Black Friday has arrived early!
+                        </p>
+                        <p className="u-color-tertiary">
+                            <span className="u-text-bold">Save £75</span> when you spend over{' '}
+                            <span className="u-text-bold">£400</span> on your course with code{' '}
+                            <span className="u-text-bold">BF75</span>.
                         </p>
                     </div>
                 </div>
+                <CalloutFooter asChild>
+                    <p className="u-color-tertiary">Offer ends 24.11.22!</p>
+                </CalloutFooter>
             </CalloutContentGroup>
-            <CalloutButtonGroup>
-                <Button>Buy now</Button>
-            </CalloutButtonGroup>
         </CalloutBanner>
     </div>
 );
@@ -123,6 +151,19 @@ HasImage.parameters = {
     docs: {
         description: {
             story: 'Instead of text, you can pass an image as the first child by omitting the `<CalloutBannerTitle>` and placing an `<Image>` there instead.',
+        },
+    },
+};
+
+export const HasFooter = HasFooterTemplate.bind({});
+HasFooter.args = {
+    ...Primary.args,
+    className: 'u-bg-color-neutral-0',
+};
+HasFooter.parameters = {
+    docs: {
+        description: {
+            story: 'You can add a `<CalloutFooter>` subcomponent inside `<CalloutContentGroup>` to add a little extra information such as an expiry date.<br>If you need to align your title or image you can use the `u-self-start` class to pull it up to the start of the flex container.',
         },
     },
 };

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
+import { Button } from '../Button/Button';
 import type { CalloutBannerProps } from './CalloutBanner';
 import { CalloutBanner } from './CalloutBanner';
 
@@ -15,9 +16,56 @@ export default {
     },
 } as Meta;
 
-const Template: Story<CalloutBannerProps> = ({ ...args }) => <CalloutBanner {...args} />;
+const Template: Story<CalloutBannerProps> = ({ ...args }) => (
+    <div className="o-container">
+        <CalloutBanner {...args}>
+            <h2 className="c-callout-banner__ttl u-color-gradient-quaternary-90 t-font-secondary u-lh-1">
+                OSC STUDENT DISCOUNT
+            </h2>
+            <div className="c-content">
+                <div className="c-content__inner c-content__inner--left">
+                    <p>
+                        We're offering a special price of £29.99 for OSC learners. To purchase the
+                        Career Kickstarter package at the discounted price please contact our
+                        learner services team via studentsupport@openstudycollege.com
+                    </p>
+                </div>
+            </div>
+        </CalloutBanner>
+    </div>
+);
+
+const TemplateHasButton: Story<CalloutBannerProps> = ({ ...args }) => (
+    <div className="o-container">
+        <CalloutBanner {...args}>
+            <h2 className="c-callout-banner__ttl u-color-gradient-quaternary-90 t-font-secondary u-lh-1">
+                OSC STUDENT DISCOUNT
+            </h2>
+            <div className="c-content">
+                <div className="c-content__inner c-content__inner--left">
+                    <p>
+                        We're offering a special price of £29.99 for OSC learners. To purchase the
+                        Career Kickstarter package at the discounted price please contact our
+                        learner services team via studentsupport@openstudycollege.com
+                    </p>
+                </div>
+            </div>
+            <div className="c-callout-banner__btn-group">
+                <Button>Buy now</Button>
+            </div>
+        </CalloutBanner>
+    </div>
+);
 
 export const Primary = Template.bind({});
-Primary.args = {
-    children: 'hello world',
+Primary.args = {};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+    ...Primary.args,
+};
+
+export const HasButton = TemplateHasButton.bind({});
+HasButton.args = {
+    ...Primary.args,
 };

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -28,7 +28,7 @@ const Template: Story<CalloutBannerProps> = ({ ...args }) => (
             <CalloutBannerTitle className="u-color-gradient-quaternary-90">
                 OSC STUDENT DISCOUNT
             </CalloutBannerTitle>
-            <CalloutContentGroup>
+            <CalloutContentGroup asChild>
                 <div className="c-content">
                     <div className="c-content__inner c-content__inner--left">
                         <p>
@@ -43,13 +43,43 @@ const Template: Story<CalloutBannerProps> = ({ ...args }) => (
     </div>
 );
 
+const HasImageTemplate: Story<CalloutBannerProps> = ({ ...args }) => (
+    <div className="o-container">
+        <CalloutBanner {...args}>
+            <Image
+                src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1677081736/3fa07f2f2545b5f9918b2522e9b3eee4_snzqcg.png"
+                width={330}
+                height={74}
+                alt="Black Friday"
+            />
+            <CalloutContentGroup asChild>
+                <div className="c-content">
+                    <div className="c-content__inner c-content__inner--left">
+                        <p className="u-color-tertiary u-text-bold t-font-m">
+                            Black Friday has arrived early!
+                        </p>
+                        <p className="u-color-tertiary">
+                            <span className="u-text-bold">Save £75</span> when you spend over{' '}
+                            <span className="u-text-bold">£400</span> on your course with code{' '}
+                            <span className="u-text-bold">BF75</span>.
+                        </p>
+                    </div>
+                </div>
+            </CalloutContentGroup>
+            <CalloutFooter asChild>
+                <p className="u-color-tertiary">Offer ends 24.11.22!</p>
+            </CalloutFooter>
+        </CalloutBanner>
+    </div>
+);
+
 const TemplateHasButton: Story<CalloutBannerProps> = ({ ...args }) => (
     <div className="o-container">
         <CalloutBanner {...args}>
             <CalloutBannerTitle className="u-color-gradient-quaternary-90">
                 OSC STUDENT DISCOUNT
             </CalloutBannerTitle>
-            <CalloutContentGroup>
+            <CalloutContentGroup asChild>
                 <div className="c-content">
                     <div className="c-content__inner c-content__inner--left">
                         <p>

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -100,12 +100,13 @@ const TemplateHasButton: Story<CalloutBannerProps> = ({ ...args }) => (
 export const Primary = Template.bind({});
 Primary.args = {};
 
-export const Secondary = Template.bind({});
-Secondary.args = {
-    ...Primary.args,
-};
-
 export const HasButton = TemplateHasButton.bind({});
 HasButton.args = {
     ...Primary.args,
+};
+
+export const HasImage = HasImageTemplate.bind({});
+HasImage.args = {
+    ...Primary.args,
+    className: 'u-bg-color-neutral-0',
 };

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -18,7 +18,7 @@ export default {
     parameters: {
         docs: {
             description: {
-                component: '',
+                component: 'A callout banner to highlight some content or an offer on the page.',
             },
         },
     },
@@ -106,9 +106,23 @@ export const HasButton = TemplateHasButton.bind({});
 HasButton.args = {
     ...Primary.args,
 };
+HasButton.parameters = {
+    docs: {
+        description: {
+            story: 'Pass a button using the `<CalloutButtonGroup>` subcomponent with a `<Button>` as a child.',
+        },
+    },
+};
 
 export const HasImage = HasImageTemplate.bind({});
 HasImage.args = {
     ...Primary.args,
     className: 'u-bg-color-neutral-0',
+};
+HasImage.parameters = {
+    docs: {
+        description: {
+            story: 'Instead of text, you can pass an image as the first child by omitting the `<CalloutBannerTitle>` and placing an `<Image>` there instead.',
+        },
+    },
 };

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -1,18 +1,20 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 import { Button } from '../Button/Button';
+import { Image } from '../Image/Image';
 import type { CalloutBannerProps } from './CalloutBanner';
 import {
     CalloutBanner,
     CalloutBannerTitle,
     CalloutButtonGroup,
     CalloutContentGroup,
+    CalloutFooter,
 } from './CalloutBanner';
 
 export default {
     title: 'osc-ui/Callout Banner',
     component: CalloutBanner,
-    subcomponents: { CalloutBannerTitle, CalloutContentGroup, CalloutButtonGroup },
+    subcomponents: { CalloutBannerTitle, CalloutContentGroup, CalloutButtonGroup, CalloutFooter },
     parameters: {
         docs: {
             description: {
@@ -52,7 +54,7 @@ const HasImageTemplate: Story<CalloutBannerProps> = ({ ...args }) => (
                 height={74}
                 alt="Black Friday"
             />
-            <CalloutContentGroup asChild>
+            <CalloutContentGroup>
                 <div className="c-content">
                     <div className="c-content__inner c-content__inner--left">
                         <p className="u-color-tertiary u-text-bold t-font-m">
@@ -65,10 +67,10 @@ const HasImageTemplate: Story<CalloutBannerProps> = ({ ...args }) => (
                         </p>
                     </div>
                 </div>
+                <CalloutFooter asChild>
+                    <p className="u-color-tertiary">Offer ends 24.11.22!</p>
+                </CalloutFooter>
             </CalloutContentGroup>
-            <CalloutFooter asChild>
-                <p className="u-color-tertiary">Offer ends 24.11.22!</p>
-            </CalloutFooter>
         </CalloutBanner>
     </div>
 );

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -44,13 +44,19 @@ export const CalloutBannerTitle = (props: CalloutBannerProps) => {
 /* -------------------------------------------------------------------------------------------------
  * CalloutContentGroup
  * -----------------------------------------------------------------------------------------------*/
-export interface CalloutContentGroupProps extends SharedProps, ComponentPropsWithoutRef<'div'> {}
+export interface CalloutContentGroupProps extends SharedProps, ComponentPropsWithoutRef<'div'> {
+    /**
+     * Merges its props onto its immediate child
+     */
+    asChild?: boolean;
+}
 
 export const CalloutContentGroup = (props: CalloutContentGroupProps) => {
-    const { children, className } = props;
+    const { asChild, children, className } = props;
     const classes = classNames('c-callout-banner__content-group', className);
+    const Component = asChild ? Slot : 'div';
 
-    return <Slot className={classes}>{children}</Slot>;
+    return <Component className={classes}>{children}</Component>;
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import { classNames } from '../../utils/classNames';
+
+import './callout-banner.scss';
+
+export interface CalloutBannerProps {
+    /**
+     * The content of the CalloutBanner
+     */
+    children: ReactNode;
+    /**
+     * Custom class
+     */
+    className?: string;
+}
+
+export const CalloutBanner = (props: CalloutBannerProps) => {
+    const { children, className } = props;
+
+    const classes = classNames('c-callout-banner', className);
+
+    return <div className={classes}>{children}</div>;
+};

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -70,3 +70,21 @@ export const CalloutButtonGroup = (props: CalloutButtonGroupProps) => {
 
     return <div className={classes}>{children}</div>;
 };
+
+/* -------------------------------------------------------------------------------------------------
+ * CalloutFooter
+ * -----------------------------------------------------------------------------------------------*/
+export interface CalloutFooterProps extends SharedProps, ComponentPropsWithoutRef<'div'> {
+    /**
+     * Merges its props onto its immediate child
+     */
+    asChild?: boolean;
+}
+
+export const CalloutFooter = (props: CalloutFooterProps) => {
+    const { asChild, children, className } = props;
+    const classes = classNames('c-callout-banner__footer', className);
+    const Component = asChild ? Slot : 'div';
+
+    return <Component className={classes}>{children}</Component>;
+};

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -1,3 +1,4 @@
+import { Slot } from '@radix-ui/react-slot';
 import type { ComponentPropsWithoutRef } from 'react';
 import React from 'react';
 import { classNames } from '../../utils/classNames';
@@ -49,7 +50,7 @@ export const CalloutContentGroup = (props: CalloutContentGroupProps) => {
     const { children, className } = props;
     const classes = classNames('c-callout-banner__content-group', className);
 
-    return <div className={classes}>{children}</div>;
+    return <Slot className={classes}>{children}</Slot>;
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -1,24 +1,65 @@
-import type { ReactNode } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import React from 'react';
 import { classNames } from '../../utils/classNames';
 
 import './callout-banner.scss';
 
-export interface CalloutBannerProps {
-    /**
-     * The content of the CalloutBanner
-     */
-    children: ReactNode;
+interface SharedProps {
     /**
      * Custom class
      */
     className?: string;
 }
 
+/* -------------------------------------------------------------------------------------------------
+ * CalloutBanner
+ * -----------------------------------------------------------------------------------------------*/
+export interface CalloutBannerProps extends SharedProps, ComponentPropsWithoutRef<'aside'> {}
+
 export const CalloutBanner = (props: CalloutBannerProps) => {
-    const { children, className } = props;
+    const { children, className, ...rest } = props;
 
     const classes = classNames('c-callout-banner', className);
+
+    return (
+        <aside className={classes} {...rest}>
+            {children}
+        </aside>
+    );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * CalloutBannerTitle
+ * -----------------------------------------------------------------------------------------------*/
+export interface CalloutBannerTitleProps extends SharedProps, ComponentPropsWithoutRef<'h2'> {}
+
+export const CalloutBannerTitle = (props: CalloutBannerProps) => {
+    const { children, className } = props;
+    const classes = classNames('c-callout-banner__ttl', 't-font-secondary', 'u-lh-1', className);
+
+    return <h2 className={classes}>{children}</h2>;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * CalloutContentGroup
+ * -----------------------------------------------------------------------------------------------*/
+export interface CalloutContentGroupProps extends SharedProps, ComponentPropsWithoutRef<'div'> {}
+
+export const CalloutContentGroup = (props: CalloutContentGroupProps) => {
+    const { children, className } = props;
+    const classes = classNames('c-callout-banner__content-group', className);
+
+    return <div className={classes}>{children}</div>;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * CalloutButtonGroup
+ * -----------------------------------------------------------------------------------------------*/
+export interface CalloutButtonGroupProps extends SharedProps, ComponentPropsWithoutRef<'div'> {}
+
+export const CalloutButtonGroup = (props: CalloutButtonGroupProps) => {
+    const { children, className } = props;
+    const classes = classNames('c-callout-banner__btn-group', className);
 
     return <div className={classes}>{children}</div>;
 };

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -1,86 +1,88 @@
 @import "../../styles/settings";
 @import "../../styles/tools";
 
-$banner-bg: var(--color-neutral-300);
-$banner-fg: var(--color-nonary);
-$banner-py: $space-xl;
-$banner-py-s: $space-s;
-$banner-px: $space-m;
-$banner-px-l: $space-xl;
-$banner-content-max-w: 40ch;
-$banner-breakpoint: 1137;
+@layer components {
+    $banner-bg: var(--color-neutral-300);
+    $banner-fg: var(--color-nonary);
+    $banner-py: $space-xl;
+    $banner-py-s: $space-s;
+    $banner-px: $space-m;
+    $banner-px-l: $space-xl;
+    $banner-content-max-w: 40ch;
+    $banner-breakpoint: 1137;
 
-.c-callout-banner {
-    display: flex;
-    flex-direction: column;
-    max-width: 100%;
-    padding: $banner-py $banner-px;
-    background-color: $banner-bg;
-    color: $banner-fg;
-    margin-inline: auto;
-    gap: $space-m;
-
-    @include mq($mq-tab-l) {
-        flex-flow: row wrap;
-        align-items: center;
-        width: fit-content; // make sure banner is constrained to the width of it's children
-        padding: $banner-py-s $banner-px-l;
-    }
-
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    p,
-    li {
-        margin-block-end: 0;
-    }
-
-    &__ttl {
-        font-size: $fs-7xl;
-        padding-inline-end: $space-m;
-        margin-block-end: 0;
-
-        @include mq($mq-mob-l) {
-            font-size: $fs-6xl;
-        }
+    .c-callout-banner {
+        display: flex;
+        flex-direction: column;
+        max-width: 100%;
+        padding: $banner-py $banner-px;
+        background-color: $banner-bg;
+        color: $banner-fg;
+        margin-inline: auto;
+        gap: $space-m;
 
         @include mq($mq-tab-l) {
-            font-size: $fs-5xl;
+            flex-flow: row wrap;
+            align-items: center;
+            width: fit-content; // make sure banner is constrained to the width of it's children
+            padding: $banner-py-s $banner-px-l;
         }
 
-        @include mq(($mq-desk, $banner-breakpoint)) {
-            // One off breakpoint to stretch the title across the width of the flex-container
-            // Without this the button wraps onto it's own line and looks odd
-            flex: 100%;
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        p,
+        li {
+            margin-block-end: 0;
         }
-    }
 
-    &__content-group {
-        flex: 1;
+        &__ttl {
+            font-size: $fs-7xl;
+            padding-inline-end: $space-m;
+            margin-block-end: 0;
 
-        @include mq($mq-desk-m) {
-            max-width: $banner-content-max-w;
-        }
-    }
+            @include mq($mq-mob-l) {
+                font-size: $fs-6xl;
+            }
 
-    &__btn-group {
-        .c-btn {
-            @include mq($mq-tab, max) {
-                width: 100%;
+            @include mq($mq-tab-l) {
+                font-size: $fs-5xl;
+            }
+
+            @include mq(($mq-desk, $banner-breakpoint)) {
+                // One off breakpoint to stretch the title across the width of the flex-container
+                // Without this the button wraps onto it's own line and looks odd
+                flex: 100%;
             }
         }
-    }
 
-    &__footer {
-        margin-block-start: $space-xs;
-        flex: 100%;
-        font-size: $fs-s;
+        &__content-group {
+            flex: 1;
 
-        @include mq($mq-tab-l) {
-            text-align: right;
+            @include mq($mq-desk-m) {
+                max-width: $banner-content-max-w;
+            }
         }
-    }
 
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    .o-img {
-        max-width: 330px;
+        &__btn-group {
+            .c-btn {
+                @include mq($mq-tab, max) {
+                    width: 100%;
+                }
+            }
+        }
+
+        &__footer {
+            margin-block-start: $space-xs;
+            flex: 100%;
+            font-size: $fs-s;
+
+            @include mq($mq-tab-l) {
+                text-align: right;
+            }
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        .o-img {
+            max-width: 330px;
+        }
     }
 }

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -1,3 +1,45 @@
+@import "../../styles/settings";
+@import "../../styles/tools";
+
+$banner-bg: var(--color-neutral-300);
+$banner-fg: var(--color-nonary);
+$banner-py: $space-xl;
+$banner-py-s: $space-s;
+$banner-px: $space-m;
+$banner-px-l: $space-xl;
+$banner-content-max-w: 40ch;
+
 .c-callout-banner {
-    // Styles go here
+    display: grid;
+    align-items: center;
+    max-width: 100%;
+    padding: $banner-py $banner-px;
+    background-color: $banner-bg;
+    color: $banner-fg;
+    margin-inline: auto;
+    gap: 0 $space-m;
+
+    @include mq($mq-tab-l) {
+        width: fit-content; // make sure banner is constrained to the width of it's children
+        grid-template-columns: minmax(21ch, 1fr) minmax(auto, $banner-content-max-w) auto;
+        padding: $banner-py-s $banner-px-l;
+    }
+
+    &__ttl {
+        font-size: $fs-7xl;
+
+        @include mq($mq-mob-l) {
+            font-size: $fs-6xl;
+        }
+
+        @include mq($mq-tab-l) {
+            font-size: $fs-5xl;
+        }
+    }
+
+    &__btn-group {
+        @include mq($mq-mob, max) {
+            width: 100%;
+        }
+    }
 }

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -7,6 +7,7 @@ $banner-py: $space-xl;
 $banner-py-s: $space-s;
 $banner-px: $space-m;
 $banner-px-l: $space-xl;
+$banner-content-max-w: 40ch;
 
 .c-callout-banner {
     display: flex;
@@ -16,7 +17,7 @@ $banner-px-l: $space-xl;
     background-color: $banner-bg;
     color: $banner-fg;
     margin-inline: auto;
-    gap: 0 $space-m;
+    gap: $space-m;
 
     @include mq($mq-tab-l) {
         flex-flow: row wrap;
@@ -25,8 +26,16 @@ $banner-px-l: $space-xl;
         padding: $banner-py-s $banner-px-l;
     }
 
+    /* stylelint-disable-next-line plugin/selector-bem-pattern */
+    p,
+    li {
+        margin-block-end: 0;
+    }
+
     &__ttl {
         font-size: $fs-7xl;
+        padding-inline-end: $space-m;
+        margin-block-end: 0;
 
         @include mq($mq-mob-l) {
             font-size: $fs-6xl;
@@ -36,7 +45,7 @@ $banner-px-l: $space-xl;
             font-size: $fs-5xl;
         }
 
-        @include mq(($mq-desk, 1108)) {
+        @include mq(($mq-desk, 1137)) {
             // One off breakpoint to stretch the title across the width of the flex-container
             // Without this the button wraps onto it's own line and looks odd
             flex: 100%;
@@ -55,5 +64,16 @@ $banner-px-l: $space-xl;
         @include mq($mq-mob, max) {
             width: 100%;
         }
+
+        .c-btn {
+            @include mq($mq-mob, max) {
+                width: 100%;
+            }
+        }
+    }
+
+    /* stylelint-disable-next-line plugin/selector-bem-pattern */
+    .o-img {
+        max-width: 330px;
     }
 }

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -7,11 +7,10 @@ $banner-py: $space-xl;
 $banner-py-s: $space-s;
 $banner-px: $space-m;
 $banner-px-l: $space-xl;
-$banner-content-max-w: 40ch;
 
 .c-callout-banner {
-    display: grid;
-    align-items: center;
+    display: flex;
+    flex-direction: column;
     max-width: 100%;
     padding: $banner-py $banner-px;
     background-color: $banner-bg;
@@ -20,8 +19,9 @@ $banner-content-max-w: 40ch;
     gap: 0 $space-m;
 
     @include mq($mq-tab-l) {
+        flex-flow: row wrap;
+        align-items: center;
         width: fit-content; // make sure banner is constrained to the width of it's children
-        grid-template-columns: minmax(21ch, 1fr) minmax(auto, $banner-content-max-w) auto;
         padding: $banner-py-s $banner-px-l;
     }
 
@@ -34,6 +34,20 @@ $banner-content-max-w: 40ch;
 
         @include mq($mq-tab-l) {
             font-size: $fs-5xl;
+        }
+
+        @include mq(($mq-desk, 1108)) {
+            // One off breakpoint to stretch the title across the width of the flex-container
+            // Without this the button wraps onto it's own line and looks odd
+            flex: 100%;
+        }
+    }
+
+    &__content-group {
+        flex: 1;
+
+        @include mq($mq-desk-m) {
+            max-width: $banner-content-max-w;
         }
     }
 

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -1,0 +1,3 @@
+.c-callout-banner {
+    // Styles go here
+}

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -61,12 +61,8 @@ $banner-content-max-w: 40ch;
     }
 
     &__btn-group {
-        @include mq($mq-mob, max) {
-            width: 100%;
-        }
-
         .c-btn {
-            @include mq($mq-mob, max) {
+            @include mq($mq-tab, max) {
                 width: 100%;
             }
         }

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -8,6 +8,7 @@ $banner-py-s: $space-s;
 $banner-px: $space-m;
 $banner-px-l: $space-xl;
 $banner-content-max-w: 40ch;
+$banner-breakpoint: 1137;
 
 .c-callout-banner {
     display: flex;
@@ -45,7 +46,7 @@ $banner-content-max-w: 40ch;
             font-size: $fs-5xl;
         }
 
-        @include mq(($mq-desk, 1137)) {
+        @include mq(($mq-desk, $banner-breakpoint)) {
             // One off breakpoint to stretch the title across the width of the flex-container
             // Without this the button wraps onto it's own line and looks odd
             flex: 100%;

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -72,6 +72,16 @@ $banner-content-max-w: 40ch;
         }
     }
 
+    &__footer {
+        margin-block-start: $space-xs;
+        flex: 100%;
+        font-size: $fs-s;
+
+        @include mq($mq-tab-l) {
+            text-align: right;
+        }
+    }
+
     /* stylelint-disable-next-line plugin/selector-bem-pattern */
     .o-img {
         max-width: 330px;

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -10,6 +10,7 @@
     $banner-px-l: $space-xl;
     $banner-content-max-w: 40ch;
     $banner-breakpoint: 1137;
+    $banner-img-width: 330px; // Set a fixed width so the image doesn't cause the banner to resize when loading
 
     .c-callout-banner {
         display: flex;
@@ -82,7 +83,8 @@
 
         /* stylelint-disable-next-line plugin/selector-bem-pattern */
         .o-img {
-            max-width: 330px;
+            width: $banner-img-width;
+            object-fit: contain;
         }
     }
 }

--- a/packages/osc-ui/src/styles/typography/_font.scss
+++ b/packages/osc-ui/src/styles/typography/_font.scss
@@ -158,9 +158,9 @@ h6,
 
     @each $class in $classes {
         .t-font-#{$class} {
-            @if $class == "2xl" or $class == "3xl" or $class == "4xl" or $class == "7xl" {
+            @if $class == "2xl" or $class == "3xl" or $class == "4xl" {
                 @include font-size(var(--font-scale-#{$class}), 1.2);
-            } @else if $class == "6xl" or $class == "5xl" {
+            } @else if $class == "7xl" or $class == "6xl" or $class == "5xl" {
                 @include font-size(var(--font-scale-#{$class}), 1);
             } @else {
                 @include font-size(var(--font-scale-#{$class}), $base-lh);

--- a/packages/osc-ui/src/styles/utilities/_util.scss
+++ b/packages/osc-ui/src/styles/utilities/_util.scss
@@ -262,9 +262,9 @@ $osc-config: (
     [data-bg-color="#{$name}"],
     .u-bg-color-#{$name} {
         @if (string.index($name, "gradient")) {
-            background-image: var(--color-#{$name});
+            background-image: var(--color-#{$name}) !important;
         } @else {
-            background-color: var(--color-#{$name});
+            background-color: var(--color-#{$name}) !important;
         }
     }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes https://github.com/Open-Study-College/osc/issues/737
- Closes #738 
- Closes #740 

## 📝 Description

Adds the callout banners to osc-ui

<img width="868" alt="image" src="https://user-images.githubusercontent.com/23461173/220882687-0d6524a1-b1ae-40dd-9fd2-61ff1cc0463f.png">

Hopefully a fairly simple component, it's built up of various subcomponents and mostly controlled by passing class names when we need to change a style (e.g. background colour).

To keep the DOM tree a bit flatter I've added an `asChild` class to `<CalloutContentGroup>` and `CalloutFooter`. This uses Radix's `<Slot>` component to pass the props through to the child, similar to a polymorphic component.

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

Adds the callout banner to osc-ui

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
Sanity ticket will be handled in a separate PR