### PR TITLE
Refactor/css layers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,9 +19,6 @@
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
   },
-  "[scss]": {
-    "editor.defaultFormatter": "stylelint.vscode-stylelint"
-  },
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "stylelint.enable": true,

--- a/packages/osc-ui/src/components/Accordion/accordion.scss
+++ b/packages/osc-ui/src/components/Accordion/accordion.scss
@@ -3,199 +3,90 @@
 
 /* stylelint-disable selector-class-pattern */
 
-// Colors
-$accordion-icon-color: var(--color-quaternary);
+@layer components {
+    // Colors
+    $accordion-icon-color: var(--color-quaternary);
 
-// Sizes
-$accordion-icon-base-size: 1em; // make sure the icon matches the height of the text
-$accordion-content-font-size: #{rem($base-fs)}; // design has this fixed across breakpoints
+    // Sizes
+    $accordion-icon-base-size: 1em; // make sure the icon matches the height of the text
+    $accordion-content-font-size: #{rem($base-fs)}; // design has this fixed across breakpoints
 
-// Layout
-$accordion-trigger-padding: $space-l; // design has this fixed across breakpoints
-$accordion-item-border: 1px solid var(--color-quinary);
+    // Layout
+    $accordion-trigger-padding: $space-l; // design has this fixed across breakpoints
+    $accordion-item-border: 1px solid var(--color-quinary);
 
-// Transitions
-$accordion-transition-duration: 0.3s;
-$accordion-transition-timing-func: cubic-bezier(0.87, 0, 0.13, 1);
+    // Transitions
+    $accordion-transition-duration: 0.3s;
+    $accordion-transition-timing-func: cubic-bezier(0.87, 0, 0.13, 1);
 
-.c-accordion {
-    --accordion-icon-size: 1.1rem;
-    --accordion-trigger-font-size: #{rem($base-fs * 1.25)}; // design has this fixed across breakpoints
-    --accordion-trigger-grid-columns: 1fr auto;
+    .c-accordion {
+        --accordion-icon-size: 1.1rem;
+        --accordion-trigger-font-size: #{rem($base-fs * 1.25)}; // design has this fixed across breakpoints
+        --accordion-trigger-grid-columns: 1fr auto;
 
-    &__item {
-        &:not(:last-child) {
-            padding-bottom: $accordion-trigger-padding;
-            border-bottom: $accordion-item-border;
-        }
-    }
-
-    &__header {
-        margin-bottom: 0;
-        font-weight: $fw-bold;
-    }
-
-    &__icon {
-        width: $accordion-icon-base-size;
-        height: $accordion-icon-base-size;
-        margin-top: 0.125em; // align the icon with the middle of the text
-        color: $accordion-icon-color;
-        font-size: var(--accordion-icon-size);
-
-        &--plusminus > :first-child {
-            transition:
-                opacity $accordion-transition-duration $accordion-transition-timing-func,
-                visibility $accordion-transition-duration $accordion-transition-timing-func;
-        }
-
-        &--chevron {
-            transition: transform $accordion-transition-duration $accordion-transition-timing-func;
-        }
-    }
-
-    &__trigger {
-        position: relative;
-        display: grid;
-        align-items: center;
-        box-sizing: border-box;
-        width: 100%;
-        padding: $accordion-trigger-padding 0 0;
-        font-size: var(--accordion-trigger-font-size);
-        font-weight: $fw-bold;
-        text-align: left;
-        transition: color $accordion-transition-duration $accordion-transition-timing-func;
-        cursor: pointer;
-        grid-template-columns: var(--accordion-trigger-grid-columns);
-
-        @include mq($mq-mob) {
-            gap: $space-2xl;
-        }
-
-        &:hover {
-            color: var(--color-quaternary);
-        }
-
-        &[data-state="open"] {
-            .c-accordion__icon {
-                &--plusminus > :first-child {
-                    opacity: 0;
-                    visibility: hidden;
-                }
-
-                &--chevron {
-                    transform: rotate(180deg);
-                }
-            }
-        }
-
-        /* stylelint-disable-next-line plugin/selector-bem-pattern */
-        > span {
-            grid-column: 1 / 2;
-        }
-    }
-
-    &__content {
-        max-width: 64ch;
-        overflow: hidden;
-        font-size: $accordion-content-font-size;
-        font-weight: $fw-light;
-
-        &[data-state="open"] {
-            animation: slide-down $accordion-transition-duration $accordion-transition-timing-func;
-        }
-
-        &[data-state="closed"] {
-            height: 0;
-            animation: slide-up $accordion-transition-duration $accordion-transition-timing-func;
-        }
-    }
-
-    &__text {
-        padding: $space-xs 0;
-    }
-
-    // *----------------------------------*/
-    //  Variants
-    // --primary not included as it would be the default
-    // *----------------------------------*/
-    &--secondary {
-        --accordion-icon-size: 1.6em;
-        --accordion-trigger-font-size: #{$fs-s};
-
-        // Add new column to the grid so we can centre the text accurately
-        --accordion-trigger-grid-columns: minmax(0, var(--accordion-icon-size)) 1fr auto;
-
-        .c-accordion__item {
-            border: $accordion-item-border;
-
+        &__item {
             &:not(:last-child) {
-                padding-bottom: 0;
-                border-bottom: none;
+                padding-bottom: $accordion-trigger-padding;
+                border-bottom: $accordion-item-border;
             }
         }
 
-        .c-accordion__trigger {
-            padding: $space-l $space-xl;
-            text-align: center;
-            text-transform: uppercase;
-            letter-spacing: $ls-s;
+        &__header {
+            margin-bottom: 0;
+            font-weight: $fw-bold;
+        }
 
-            /* stylelint-disable-next-line plugin/selector-bem-pattern */
-            > span {
-                grid-column: 2 / 3;
+        &__icon {
+            width: $accordion-icon-base-size;
+            height: $accordion-icon-base-size;
+            margin-top: 0.125em; // align the icon with the middle of the text
+            color: $accordion-icon-color;
+            font-size: var(--accordion-icon-size);
+
+            &--plusminus > :first-child {
+                transition:
+                    opacity $accordion-transition-duration $accordion-transition-timing-func,
+                    visibility $accordion-transition-duration $accordion-transition-timing-func;
             }
+
+            &--chevron {
+                transition: transform $accordion-transition-duration $accordion-transition-timing-func;
+            }
+        }
+
+        &__trigger {
+            position: relative;
+            display: grid;
+            align-items: center;
+            box-sizing: border-box;
+            width: 100%;
+            padding: $accordion-trigger-padding 0 0;
+            font-size: var(--accordion-trigger-font-size);
+            font-weight: $fw-bold;
+            text-align: left;
+            transition: color $accordion-transition-duration $accordion-transition-timing-func;
+            cursor: pointer;
+            grid-template-columns: var(--accordion-trigger-grid-columns);
 
             @include mq($mq-mob) {
-                gap: $space-m;
+                gap: $space-2xl;
+            }
+
+            &:hover {
+                color: var(--color-quaternary);
             }
 
             &[data-state="open"] {
-                color: var(--color-quaternary);
-            }
-        }
+                .c-accordion__icon {
+                    &--plusminus > :first-child {
+                        opacity: 0;
+                        visibility: hidden;
+                    }
 
-        /* stylelint-disable-next-line no-descending-specificity */
-        .c-accordion__icon {
-            grid-column: 3 / -1;
-            color: currentcolor;
-        }
-
-        .c-accordion__content {
-            max-width: 100%;
-        }
-
-        .c-accordion__text {
-            padding: 0 $space-xl $space-xl;
-        }
-    }
-
-    &--tertiary {
-        --accordion-trigger-font-size: #{rem($base-fs * 1.5)}; // design has this fixed across breakpoints
-        --accordion-trigger-grid-columns: 1fr auto;
-
-        /* stylelint-disable-next-line no-descending-specificity */
-        .c-accordion__item {
-            padding-bottom: 0;
-            border: $accordion-item-border;
-        }
-
-        .c-accordion__item + .c-accordion__item {
-            margin-top: $space-2xl;
-        }
-
-        .c-accordion__trigger {
-            padding: $space-2xs $space-l;
-            background-color: var(--color-neutral-200);
-            color: var(--color-quaternary);
-            text-align: left;
-            text-transform: none;
-            letter-spacing: normal;
-            transition:
-                background-color $accordion-transition-duration
-                $accordion-transition-timing-func;
-
-            &:hover {
-                background-color: var(--color-quinary);
+                    &--chevron {
+                        transform: rotate(180deg);
+                    }
+                }
             }
 
             /* stylelint-disable-next-line plugin/selector-bem-pattern */
@@ -204,41 +95,152 @@ $accordion-transition-timing-func: cubic-bezier(0.87, 0, 0.13, 1);
             }
         }
 
-        /* stylelint-disable-next-line no-descending-specificity */
-        .c-accordion__icon {
-            @include mq($mq-mob, max) {
-                display: none;
+        &__content {
+            max-width: 64ch;
+            overflow: hidden;
+            font-size: $accordion-content-font-size;
+            font-weight: $fw-light;
+
+            &[data-state="open"] {
+                animation: slide-down $accordion-transition-duration $accordion-transition-timing-func;
+            }
+
+            &[data-state="closed"] {
+                height: 0;
+                animation: slide-up $accordion-transition-duration $accordion-transition-timing-func;
             }
         }
 
-        .c-accordion__content {
-            max-width: 100%;
+        &__text {
+            padding: $space-xs 0;
         }
 
-        .c-accordion__text {
-            padding: $space-2xl;
+        // *----------------------------------*/
+        //  Variants
+        // --primary not included as it would be the default
+        // *----------------------------------*/
+        &--secondary {
+            --accordion-icon-size: 1.6em;
+            --accordion-trigger-font-size: #{$fs-s};
+
+            // Add new column to the grid so we can centre the text accurately
+            --accordion-trigger-grid-columns: minmax(0, var(--accordion-icon-size)) 1fr auto;
+
+            .c-accordion__item {
+                border: $accordion-item-border;
+
+                &:not(:last-child) {
+                    padding-bottom: 0;
+                    border-bottom: none;
+                }
+            }
+
+            .c-accordion__trigger {
+                padding: $space-l $space-xl;
+                text-align: center;
+                text-transform: uppercase;
+                letter-spacing: $ls-s;
+
+                /* stylelint-disable-next-line plugin/selector-bem-pattern */
+                > span {
+                    grid-column: 2 / 3;
+                }
+
+                @include mq($mq-mob) {
+                    gap: $space-m;
+                }
+
+                &[data-state="open"] {
+                    color: var(--color-quaternary);
+                }
+            }
+
+            /* stylelint-disable-next-line no-descending-specificity */
+            .c-accordion__icon {
+                grid-column: 3 / -1;
+                color: currentcolor;
+            }
+
+            .c-accordion__content {
+                max-width: 100%;
+            }
+
+            .c-accordion__text {
+                padding: 0 $space-xl $space-xl;
+            }
+        }
+
+        &--tertiary {
+            --accordion-trigger-font-size: #{rem($base-fs * 1.5)}; // design has this fixed across breakpoints
+            --accordion-trigger-grid-columns: 1fr auto;
+
+            /* stylelint-disable-next-line no-descending-specificity */
+            .c-accordion__item {
+                padding-bottom: 0;
+                border: $accordion-item-border;
+            }
+
+            .c-accordion__item + .c-accordion__item {
+                margin-top: $space-2xl;
+            }
+
+            .c-accordion__trigger {
+                padding: $space-2xs $space-l;
+                background-color: var(--color-neutral-200);
+                color: var(--color-quaternary);
+                text-align: left;
+                text-transform: none;
+                letter-spacing: normal;
+                transition:
+                    background-color $accordion-transition-duration
+                    $accordion-transition-timing-func;
+
+                &:hover {
+                    background-color: var(--color-quinary);
+                }
+
+                /* stylelint-disable-next-line plugin/selector-bem-pattern */
+                > span {
+                    grid-column: 1 / 2;
+                }
+            }
+
+            /* stylelint-disable-next-line no-descending-specificity */
+            .c-accordion__icon {
+                @include mq($mq-mob, max) {
+                    display: none;
+                }
+            }
+
+            .c-accordion__content {
+                max-width: 100%;
+            }
+
+            .c-accordion__text {
+                padding: $space-2xl;
+            }
         }
     }
-}
 
-@keyframes slide-down {
-    from {
-        height: 0;
+    @keyframes slide-down {
+        from {
+            height: 0;
+        }
+
+        to {
+            // Radix specific custom property
+            height: var(--radix-accordion-content-height);
+        }
     }
 
-    to {
-        // Radix specific custom property
-        height: var(--radix-accordion-content-height);
-    }
-}
+    @keyframes slide-up {
+        from {
+            // Radix specific custom property
+            height: var(--radix-accordion-content-height);
+        }
 
-@keyframes slide-up {
-    from {
-        // Radix specific custom property
-        height: var(--radix-accordion-content-height);
-    }
-
-    to {
-        height: 0;
+        to {
+            height: 0;
+        }
     }
 }

--- a/packages/osc-ui/src/components/Alert/alert.scss
+++ b/packages/osc-ui/src/components/Alert/alert.scss
@@ -1,62 +1,64 @@
 @import "../../styles/settings";
 
-.c-alert {
-    position: relative;
-    display: flex;
-    align-items: center;
-    padding: $space-xs;
-    border-radius: $rad-xs;
-    gap: 0.5em;
-
-    &--error {
-        background-color: #fed7d7;
-    }
-
-    &--info {
-        background-color: #bee3f8;
-    }
-
-    &--success {
-        background-color: #c6f6d5;
-    }
-
-    &--warning {
-        background-color: #feebc8;
-    }
-
-    &__button--right {
-        position: absolute;
-        top: 4px;
-        right: 4px;
-    }
-
-    &__icon {
+@layer components {
+    .c-alert {
+        position: relative;
         display: flex;
+        align-items: center;
+        padding: $space-xs;
+        border-radius: $rad-xs;
+        gap: 0.5em;
 
         &--error {
-            color: #e53e3e;
+            background-color: #fed7d7;
         }
 
         &--info {
-            color: #3182ce;
+            background-color: #bee3f8;
         }
 
         &--success {
-            color: #38a169;
+            background-color: #c6f6d5;
         }
 
         &--warning {
-            color: #dd6b20;
+            background-color: #feebc8;
         }
-    }
 
-    &__description {
-        font-style: italic;
-    }
+        &__button--right {
+            position: absolute;
+            top: 4px;
+            right: 4px;
+        }
 
-    &__title {
-        &--bold {
-            font-weight: $fw-bold;
+        &__icon {
+            display: flex;
+
+            &--error {
+                color: #e53e3e;
+            }
+
+            &--info {
+                color: #3182ce;
+            }
+
+            &--success {
+                color: #38a169;
+            }
+
+            &--warning {
+                color: #dd6b20;
+            }
+        }
+
+        &__description {
+            font-style: italic;
+        }
+
+        &__title {
+            &--bold {
+                font-weight: $fw-bold;
+            }
         }
     }
 }

--- a/packages/osc-ui/src/components/Avatar/avatar.scss
+++ b/packages/osc-ui/src/components/Avatar/avatar.scss
@@ -1,61 +1,63 @@
 @import "../../styles/settings";
 
-.c-avatar {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    vertical-align: middle;
-    width: 45px;
-    height: 45px;
-    border-radius: $rad;
-    user-select: none;
-
-    &__image {
+@layer components {
+    .c-avatar {
         position: relative;
-        width: 100%;
-        height: 100%;
-        border-radius: inherit;
-        object-fit: cover;
-    }
-
-    &__fallback {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         justify-content: center;
-        overflow: hidden;
-        background-color: var(--color-nonary);
-        color: var(--color-tertiary);
-        font-size: $fs-m;
-        font-weight: $fw-reg;
-        line-height: 1;
-
-        &--initials {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-        }
-    }
-
-    &__badge {
-        position: absolute;
-        right: 0;
-        bottom: -4px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 15px;
-        height: 15px;
-        background: var(--color-primary);
+        vertical-align: middle;
+        width: 45px;
+        height: 45px;
         border-radius: $rad;
-        outline: 2px solid var(--color-tertiary);
+        user-select: none;
 
-        &--count {
-            padding: $space-2xs;
+        &__image {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            border-radius: inherit;
+            object-fit: cover;
+        }
+
+        &__fallback {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+            background-color: var(--color-nonary);
             color: var(--color-tertiary);
-            font-size: 0.5em;
-            font-variant-numeric: tabular-nums;
+            font-size: $fs-m;
+            font-weight: $fw-reg;
+            line-height: 1;
+
+            &--initials {
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
+            }
+        }
+
+        &__badge {
+            position: absolute;
+            right: 0;
+            bottom: -4px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 15px;
+            height: 15px;
+            background: var(--color-primary);
+            border-radius: $rad;
+            outline: 2px solid var(--color-tertiary);
+
+            &--count {
+                padding: $space-2xs;
+                color: var(--color-tertiary);
+                font-size: 0.5em;
+                font-variant-numeric: tabular-nums;
+            }
         }
     }
 }

--- a/packages/osc-ui/src/components/Badge/badge.scss
+++ b/packages/osc-ui/src/components/Badge/badge.scss
@@ -1,15 +1,17 @@
-.c-badge {
-    background-color: var(--color-primary);
-    color: var(--color-tertiary);
-
-    &--subtle {
+@layer components {
+    .c-badge {
         background-color: var(--color-primary);
         color: var(--color-tertiary);
-    }
 
-    &--outline {
-        background-color: transparent;
-        border: 1px solid var(--color-primary);
-        color: var(--color-primary);
+        &--subtle {
+            background-color: var(--color-primary);
+            color: var(--color-tertiary);
+        }
+
+        &--outline {
+            background-color: transparent;
+            border: 1px solid var(--color-primary);
+            color: var(--color-primary);
+        }
     }
 }

--- a/packages/osc-ui/src/components/Breadcrumb/breadcrumb.scss
+++ b/packages/osc-ui/src/components/Breadcrumb/breadcrumb.scss
@@ -1,23 +1,25 @@
-.c-breadcrumb {
-    display: flex;
-    flex-wrap: wrap;
+@layer components {
+    .c-breadcrumb {
+        display: flex;
+        flex-wrap: wrap;
 
-    &__item {
-        display: inline-flex;
-        align-items: center;
+        &__item {
+            display: inline-flex;
+            align-items: center;
 
-        &:hover {
-            // standard link hover styles
-            [aria-current="page"] {
-                // non-standard link hover styles
-                text-decoration: none;
-                cursor: text;
+            &:hover {
+                // standard link hover styles
+                [aria-current="page"] {
+                    // non-standard link hover styles
+                    text-decoration: none;
+                    cursor: text;
+                }
             }
         }
-    }
 
-    &__separator {
-        margin-inline: 0.25em;
-        display: inline-block;
+        &__separator {
+            margin-inline: 0.25em;
+            display: inline-block;
+        }
     }
 }

--- a/packages/osc-ui/src/components/Burger/burger.scss
+++ b/packages/osc-ui/src/components/Burger/burger.scss
@@ -1,64 +1,66 @@
 @use "../../styles/settings" as *;
 @use "../../styles/tools" as *;
 
-$burger-size: $base-fs * 1.25px; // 20px
-$burger-bar-height: $base-fs * 0.25px; // 4px
-$burger-gap: $burger-bar-height;
+@layer components {
+    $burger-size: $base-fs * 1.25px; // 20px
+    $burger-bar-height: $base-fs * 0.25px; // 4px
+    $burger-gap: $burger-bar-height;
 
-.c-burger {
-    $self: &;
+    .c-burger {
+        $self: &;
 
-    position: relative;
-    display: block;
-    width: $burger-size;
-    height: $burger-size;
-    cursor: pointer;
+        position: relative;
+        display: block;
+        width: $burger-size;
+        height: $burger-size;
+        cursor: pointer;
 
-    @include z-index("hamburger");
+        @include z-index("hamburger");
 
-    &__bar {
-        position: absolute;
-        width: 100%;
-        height: $burger-bar-height;
-        background-color: var(--color-secondary);
-        transition:
-            transform $timing $ease-in-out,
-            width $timing $ease-in-out,
-            opacity $timing $ease-in-out-quart,
-            visibility $timing $ease-in-out-quart;
-
-        &:nth-child(1) {
-            top: 0;
-        }
-
-        &:nth-child(2) {
-            top: 50%;
-            width: $burger-size - 5;
-            transform: translateY(-50%);
-        }
-
-        &:nth-child(3) {
+        &__bar {
             position: absolute;
-            bottom: 0;
-            width: $burger-size - 9;
-        }
-    }
+            width: 100%;
+            height: $burger-bar-height;
+            background-color: var(--color-secondary);
+            transition:
+                transform $timing $ease-in-out,
+                width $timing $ease-in-out,
+                opacity $timing $ease-in-out-quart,
+                visibility $timing $ease-in-out-quart;
 
-    &[data-state="open"] {
-        #{$self}__bar {
             &:nth-child(1) {
-                transform: translateY($burger-bar-height * 2) rotate(45deg);
+                top: 0;
             }
 
             &:nth-child(2) {
-                transform: translateY(-50%) translateX($burger-size * -1);
-                opacity: 0;
-                visibility: hidden;
+                top: 50%;
+                width: $burger-size - 5;
+                transform: translateY(-50%);
             }
 
             &:nth-child(3) {
-                width: 100%;
-                transform: translateY($burger-bar-height * -2) rotate(-45deg);
+                position: absolute;
+                bottom: 0;
+                width: $burger-size - 9;
+            }
+        }
+
+        &[data-state="open"] {
+            #{$self}__bar {
+                &:nth-child(1) {
+                    transform: translateY($burger-bar-height * 2) rotate(45deg);
+                }
+
+                &:nth-child(2) {
+                    transform: translateY(-50%) translateX($burger-size * -1);
+                    opacity: 0;
+                    visibility: hidden;
+                }
+
+                &:nth-child(3) {
+                    width: 100%;
+                    transform: translateY($burger-bar-height * -2) rotate(-45deg);
+                }
             }
         }
     }

--- a/packages/osc-ui/src/components/Button/button.scss
+++ b/packages/osc-ui/src/components/Button/button.scss
@@ -4,495 +4,497 @@
 @import "../../styles/settings";
 @import "../../styles/tools";
 
-$btn-primary-border: solid 3px var(--color-secondary);
-$btn-primary-offset: 6px;
-$btn-radius: $rad-l;
-$btn-properties: (
-    primary: (
-        bg-color: var(--color-secondary),
-        bg-hover-color: var(--color-primary),
-        fg-color: var(--color-tertiary),
-        font-weight: $fw-bold,
-        letter-spacing: $ls-xs,
-        text-transform: uppercase,
-        border: $btn-primary-border,
-        offset: $btn-primary-offset,
-        inverse-bg-color: var(--color-tertiary),
-        inverse-bg-hover-color: var(--color-tertiary),
-        inverse-fg-color: var(--color-secondary),
-        after: (
-            position: absolute,
-            bottom: calc($btn-primary-offset * -1),
-            left: $btn-primary-offset,
-            width: 100%,
-            height: 100%,
-            background-color: transparent,
-            border-right: $btn-primary-border,
-            border-bottom: $btn-primary-border,
-            content: ""
+@layer components {
+    $btn-primary-border: solid 3px var(--color-secondary);
+    $btn-primary-offset: 6px;
+    $btn-radius: $rad-l;
+    $btn-properties: (
+        primary: (
+            bg-color: var(--color-secondary),
+            bg-hover-color: var(--color-primary),
+            fg-color: var(--color-tertiary),
+            font-weight: $fw-bold,
+            letter-spacing: $ls-xs,
+            text-transform: uppercase,
+            border: $btn-primary-border,
+            offset: $btn-primary-offset,
+            inverse-bg-color: var(--color-tertiary),
+            inverse-bg-hover-color: var(--color-tertiary),
+            inverse-fg-color: var(--color-secondary),
+            after: (
+                position: absolute,
+                bottom: calc($btn-primary-offset * -1),
+                left: $btn-primary-offset,
+                width: 100%,
+                height: 100%,
+                background-color: transparent,
+                border-right: $btn-primary-border,
+                border-bottom: $btn-primary-border,
+                content: ""
+            ),
+            sizes: (
+                sm: (
+                    padding: $space-xs $space-m,
+                    font-size: $fs-xs
+                ),
+                md: (
+                    padding: $space-s $space-xl,
+                    font-size: $fs-s
+                ),
+                lg: (
+                    padding: $space-m $space-5xl,
+                    font-size: $fs-m
+                )
+            )
         ),
-        sizes: (
-            sm: (
-                padding: $space-xs $space-m,
-                font-size: $fs-xs
-            ),
-            md: (
-                padding: $space-s $space-xl,
-                font-size: $fs-s
-            ),
-            lg: (
-                padding: $space-m $space-5xl,
-                font-size: $fs-m
+        secondary: (
+            bg-color: transparent,
+            bg-hover-color: var(--color-secondary),
+            fg-color: var(--color-secondary),
+            fg-hover-color: var(--color-tertiary),
+            font-weight: $fw-bold,
+            letter-spacing: $ls-xs,
+            text-transform: uppercase,
+            border: solid 1px var(--color-secondary),
+            inverse-bg-hover-color: var(--color-tertiary),
+            inverse-fg-color: var(--color-tertiary),
+            inverse-fg-hover-color: var(--color-secondary),
+            sizes: (
+                sm: (
+                    padding: $space-xs $space-m,
+                    font-size: $fs-xs
+                ),
+                md: (
+                    padding: $space-xs $space-m,
+                    font-size: $fs-s
+                ),
+                lg: (
+                    padding: $space-m $space-xl,
+                    font-size: $fs-m
+                )
+            )
+        ),
+        tertiary: (
+            bg-color: transparent,
+            bg-hover-color: var(--color-secondary),
+            fg-color: var(--color-neutral-600),
+            fg-hover-color: var(--color-tertiary),
+            font-weight: $fw-bold,
+            letter-spacing: $ls-xs,
+            text-transform: uppercase,
+            border: 1px solid var(--color-neutral-400),
+            inverse-bg-hover-color: var(--color-neutral-100),
+            inverse-fg-color: var(--color-neutral-100),
+            inverse-fg-hover-color: var(--color-secondary),
+            sizes: (
+                sm: (
+                    padding: $space-xs $space-m,
+                    font-size: $fs-xs
+                ),
+                md: (
+                    padding: $space-xs $space-m,
+                    font-size: $fs-s
+                ),
+                lg: (
+                    padding: $space-m $space-xl,
+                    font-size: $fs-m
+                )
+            )
+        ),
+        quaternary: (
+            bg-color: transparent,
+            bg-hover-color: transparent,
+            fg-color: var(--color-secondary),
+            fg-hover-color: var(--color-primary),
+            font-weight: $fw-reg,
+            gap: 0.8em,
+            inverse-fg-color: var(--color-tertiary),
+            sizes: (
+                sm: (
+                    font-size: $fs-xs
+                ),
+                md: (
+                    font-size: $fs-s
+                ),
+                lg: (
+                    font-size: $fs-m
+                )
+            )
+        ),
+        quinary: (
+            bg-color: var(--color-septenary),
+            bg-hover-color: var(--color-primary),
+            fg-color: var(--color-secondary),
+            fg-hover-color: var(--color-tertiary),
+            font-weight: $fw-bold,
+            letter-spacing: $ls-xs,
+            text-transform: uppercase,
+            sizes: (
+                sm: (
+                    padding: $space-xs $space-m,
+                    font-size: $fs-xs
+                ),
+                md: (
+                    padding: $space-xs $space-m,
+                    font-size: $fs-s
+                ),
+                lg: (
+                    padding: $space-m $space-xl,
+                    font-size: $fs-m
+                )
+            )
+        ),
+        primary-gradient: (
+            bg-image: var(--color-gradient-quaternary-90),
+            bg-hover-color: var(--color-nonary),
+            fg-color: var(--color-tertiary),
+            font-weight: $fw-bold,
+            letter-spacing: $ls-xs,
+            text-transform: uppercase,
+            inverse-bg-color: var(--color-tertiary),
+            inverse-bg-hover-color: transparent,
+            inverse-fg-color: var(--color-secondary),
+            inverse-fg-hover-color: var(--color-tertiary),
+            sizes: (
+                sm: (
+                    padding: $space-2xs $space-m,
+                    font-size: $fs-xs
+                ),
+                md: (
+                    padding: $space-xs $space-2xl,
+                    font-size: $fs-s
+                ),
+                lg: (
+                    padding: $space-m $space-3xl,
+                    font-size: $fs-m
+                )
+            )
+        ),
+        secondary-gradient: (
+            bg-image: var(--color-gradient-septenary-90),
+            bg-hover-color: var(--color-quaternary),
+            fg-color: var(--color-tertiary),
+            font-weight: $fw-bold,
+            font-size: $fs-s,
+            letter-spacing: $ls-xs,
+            text-transform: uppercase,
+            inverse-bg-color: var(--color-tertiary),
+            inverse-bg-hover-color: transparent,
+            inverse-fg-color: var(--color-secondary),
+            inverse-fg-hover-color: var(--color-tertiary),
+            sizes: (
+                sm: (
+                    padding: $space-2xs $space-m,
+                    font-size: $fs-xs
+                ),
+                md: (
+                    padding: $space-xs $space-2xl
+                ),
+                lg: (
+                    padding: $space-m $space-3xl,
+                    font-size: $fs-m
+                )
             )
         )
-    ),
-    secondary: (
-        bg-color: transparent,
-        bg-hover-color: var(--color-secondary),
-        fg-color: var(--color-secondary),
-        fg-hover-color: var(--color-tertiary),
-        font-weight: $fw-bold,
-        letter-spacing: $ls-xs,
-        text-transform: uppercase,
-        border: solid 1px var(--color-secondary),
-        inverse-bg-hover-color: var(--color-tertiary),
-        inverse-fg-color: var(--color-tertiary),
-        inverse-fg-hover-color: var(--color-secondary),
-        sizes: (
-            sm: (
-                padding: $space-xs $space-m,
-                font-size: $fs-xs
-            ),
-            md: (
-                padding: $space-xs $space-m,
-                font-size: $fs-s
-            ),
-            lg: (
-                padding: $space-m $space-xl,
-                font-size: $fs-m
-            )
-        )
-    ),
-    tertiary: (
-        bg-color: transparent,
-        bg-hover-color: var(--color-secondary),
-        fg-color: var(--color-neutral-600),
-        fg-hover-color: var(--color-tertiary),
-        font-weight: $fw-bold,
-        letter-spacing: $ls-xs,
-        text-transform: uppercase,
-        border: 1px solid var(--color-neutral-400),
-        inverse-bg-hover-color: var(--color-neutral-100),
-        inverse-fg-color: var(--color-neutral-100),
-        inverse-fg-hover-color: var(--color-secondary),
-        sizes: (
-            sm: (
-                padding: $space-xs $space-m,
-                font-size: $fs-xs
-            ),
-            md: (
-                padding: $space-xs $space-m,
-                font-size: $fs-s
-            ),
-            lg: (
-                padding: $space-m $space-xl,
-                font-size: $fs-m
-            )
-        )
-    ),
-    quaternary: (
-        bg-color: transparent,
-        bg-hover-color: transparent,
-        fg-color: var(--color-secondary),
-        fg-hover-color: var(--color-primary),
-        font-weight: $fw-reg,
-        gap: 0.8em,
-        inverse-fg-color: var(--color-tertiary),
-        sizes: (
-            sm: (
-                font-size: $fs-xs
-            ),
-            md: (
-                font-size: $fs-s
-            ),
-            lg: (
-                font-size: $fs-m
-            )
-        )
-    ),
-    quinary: (
-        bg-color: var(--color-septenary),
-        bg-hover-color: var(--color-primary),
-        fg-color: var(--color-secondary),
-        fg-hover-color: var(--color-tertiary),
-        font-weight: $fw-bold,
-        letter-spacing: $ls-xs,
-        text-transform: uppercase,
-        sizes: (
-            sm: (
-                padding: $space-xs $space-m,
-                font-size: $fs-xs
-            ),
-            md: (
-                padding: $space-xs $space-m,
-                font-size: $fs-s
-            ),
-            lg: (
-                padding: $space-m $space-xl,
-                font-size: $fs-m
-            )
-        )
-    ),
-    primary-gradient: (
-        bg-image: var(--color-gradient-quaternary-90),
-        bg-hover-color: var(--color-nonary),
-        fg-color: var(--color-tertiary),
-        font-weight: $fw-bold,
-        letter-spacing: $ls-xs,
-        text-transform: uppercase,
-        inverse-bg-color: var(--color-tertiary),
-        inverse-bg-hover-color: transparent,
-        inverse-fg-color: var(--color-secondary),
-        inverse-fg-hover-color: var(--color-tertiary),
-        sizes: (
-            sm: (
-                padding: $space-2xs $space-m,
-                font-size: $fs-xs
-            ),
-            md: (
-                padding: $space-xs $space-2xl,
-                font-size: $fs-s
-            ),
-            lg: (
-                padding: $space-m $space-3xl,
-                font-size: $fs-m
-            )
-        )
-    ),
-    secondary-gradient: (
-        bg-image: var(--color-gradient-septenary-90),
-        bg-hover-color: var(--color-quaternary),
-        fg-color: var(--color-tertiary),
-        font-weight: $fw-bold,
-        font-size: $fs-s,
-        letter-spacing: $ls-xs,
-        text-transform: uppercase,
-        inverse-bg-color: var(--color-tertiary),
-        inverse-bg-hover-color: transparent,
-        inverse-fg-color: var(--color-secondary),
-        inverse-fg-hover-color: var(--color-tertiary),
-        sizes: (
-            sm: (
-                padding: $space-2xs $space-m,
-                font-size: $fs-xs
-            ),
-            md: (
-                padding: $space-xs $space-2xl
-            ),
-            lg: (
-                padding: $space-m $space-3xl,
-                font-size: $fs-m
-            )
-        )
-    )
-);
+    );
 
-.c-btn {
-    $self: &;
+    .c-btn {
+        $self: &;
 
-    color: inherit;
-    font: inherit;
-    text-align: center;
-    text-decoration: none;
-    white-space: nowrap;
-    letter-spacing: normal;
-    transition: all $timing-s $ease-in;
-    cursor: pointer;
-    pointer-events: auto;
+        color: inherit;
+        font: inherit;
+        text-align: center;
+        text-decoration: none;
+        white-space: nowrap;
+        letter-spacing: normal;
+        transition: all $timing-s $ease-in;
+        cursor: pointer;
+        pointer-events: auto;
 
-    &,
-    &__inner {
-        position: relative;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        box-sizing: border-box;
-    }
-
-    &__inner {
-        width: 100%;
-        gap: 0.6em;
-        pointer-events: none; // We will want to prevent bubbling/capturing of events on the inner span
-    }
-
-    svg {
-        flex-shrink: 0;
-        width: 1em; // Make sure svg scales with the font-size
-        height: 1em; // Make sure svg scales with the font-size
-        font-size: 1.4em;
-    }
-
-    // *----------------------------------*/
-    //  Disabled
-    // *----------------------------------*/
-    &[data-disabled] {
-        cursor: not-allowed;
-    }
-
-    // *----------------------------------*/
-    //  Loading
-    // *----------------------------------*/
-    &.is-loading {
-        cursor: auto;
-        pointer-events: none;
-    }
-
-    // *----------------------------------*/
-    // Rounded borders
-    // *----------------------------------*/
-    &.is-pill {
         &,
-        #{$self}__inner,
-        &::before {
-            border-radius: $btn-radius;
+        &__inner {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            box-sizing: border-box;
         }
 
-        &::after,
-        > span::after {
-            display: none;
+        &__inner {
+            width: 100%;
+            gap: 0.6em;
+            pointer-events: none; // We will want to prevent bubbling/capturing of events on the inner span
         }
 
-        &:hover > span {
-            transform: none;
+        svg {
+            flex-shrink: 0;
+            width: 1em; // Make sure svg scales with the font-size
+            height: 1em; // Make sure svg scales with the font-size
+            font-size: 1.4em;
         }
-    }
 
-    // *----------------------------------*/
-    // Full width
-    // *----------------------------------*/
-    &.is-full {
-        width: 100%;
-    }
+        // *----------------------------------*/
+        //  Disabled
+        // *----------------------------------*/
+        &[data-disabled] {
+            cursor: not-allowed;
+        }
 
-    // *----------------------------------*/
-    //  Variants
-    // *----------------------------------*/
-    @each $class, $property in $btn-properties {
-        &--#{$class} {
-            color: map.get($property, fg-color);
-            font-size: map.get($property, font-size);
-            font-weight: map.get($property, font-weight);
-            text-transform: map.get($property, text-transform);
-            letter-spacing: map.get($property, letter-spacing);
+        // *----------------------------------*/
+        //  Loading
+        // *----------------------------------*/
+        &.is-loading {
+            cursor: auto;
+            pointer-events: none;
+        }
 
-            @if $class != "primary" {
-                background-color: map.get($property, bg-color);
-                border: map.get($property, border);
+        // *----------------------------------*/
+        // Rounded borders
+        // *----------------------------------*/
+        &.is-pill {
+            &,
+            #{$self}__inner,
+            &::before {
+                border-radius: $btn-radius;
             }
 
-            // If we're on a gradient modifier then set the background image
-            @if string.index($class, "-gradient") {
-                background-color: map.get($property, bg-color);
-                background-image: map.get($property, bg-image);
-
-                // Use a pseudo element to imitate changing the background-color as we
-                // can't transition a background-image into a color
-                &::before {
-                    position: absolute;
-                    content: "";
-                    inset: 0;
-                    transition: all $timing-m $ease-in-out;
-                }
+            &::after,
+            > span::after {
+                display: none;
             }
 
-            @if map.has-key($property, after) {
-                &::after {
-                    @each $key, $value in map.get($property, after) {
-                        #{$key}: $value;
-                    }
-                }
+            &:hover > span {
+                transform: none;
             }
+        }
 
-            #{$self}__inner {
-                gap: map.get($property, gap);
+        // *----------------------------------*/
+        // Full width
+        // *----------------------------------*/
+        &.is-full {
+            width: 100%;
+        }
 
-                @if $class == "primary" {
-                    background-color: map.get($property, bg-color);
-                    transition: all $timing-s $ease-in;
-                }
+        // *----------------------------------*/
+        //  Variants
+        // *----------------------------------*/
+        @each $class, $property in $btn-properties {
+            &--#{$class} {
+                color: map.get($property, fg-color);
+                font-size: map.get($property, font-size);
+                font-weight: map.get($property, font-weight);
+                text-transform: map.get($property, text-transform);
+                letter-spacing: map.get($property, letter-spacing);
 
-                @include z-index(button);
-            }
-
-            &:hover,
-            &:active {
                 @if $class != "primary" {
-                    background-color: map.get($property, bg-hover-color);
-                }
-
-                color: map.get($property, fg-hover-color);
-
-                @if map.get($property, offset) {
-                    > #{$self}__inner {
-                        background-color: map.get($property, bg-hover-color);
-                        transform: translate($btn-primary-offset, $btn-primary-offset);
-                    }
-                }
-
-                @if string.index($class, "-gradient") {
-                    &::before {
-                        background-color: map.get($property, bg-hover-color);
-                    }
-                }
-            }
-
-            &[data-disabled] {
-                opacity: 0.75;
-                &:hover > #{$self}__inner {
                     background-color: map.get($property, bg-color);
-                    color: map.get($property, fg-color);
-                    transform: none;
+                    border: map.get($property, border);
                 }
-            }
 
-            // *----------------------------------*/
-            //  Sizes
-            // *----------------------------------*/
-            @each $size, $properties in map.get($property, sizes) {
-                @if $class == "primary" {
-                    &#{$self}--#{$size} #{$self}__inner {
-                        @each $property, $value in $properties {
-                            #{$property}: $value;
-                        }
-                    }
-                } @else {
-                    &#{$self}--#{$size} {
-                        @each $property, $value in $properties {
-                            #{$property}: $value;
-                        }
+                // If we're on a gradient modifier then set the background image
+                @if string.index($class, "-gradient") {
+                    background-color: map.get($property, bg-color);
+                    background-image: map.get($property, bg-image);
+
+                    // Use a pseudo element to imitate changing the background-color as we
+                    // can't transition a background-image into a color
+                    &::before {
+                        position: absolute;
+                        content: "";
+                        inset: 0;
+                        transition: all $timing-m $ease-in-out;
                     }
                 }
-            }
-        }
 
-        // *----------------------------------*/
-        //  Dark mode / inverse overrides
-        // *----------------------------------*/
-        &.is-inversed {
-            @each $class, $property in $btn-properties {
-                &#{$self}--#{$class} {
-                    @if $class != "primary" {
-                        background-color: map.get($property, inverse-bg-color);
-                    }
-
-                    @if string.index($class, "-gradient") {
-                        background-color: map.get($property, inverse-bg-color);
-                        background-image: none;
-
-                        &::before {
-                            display: none;
-                        }
-                    }
-
-                    border-color: map.get($property, inverse-fg-color);
-                    color: map.get($property, inverse-fg-color);
-
-                    @if map.has-key($property, after) {
-                        &::after {
-                            border-color: map.get($property, inverse-bg-color);
-                        }
-                    }
-
-                    &:hover,
-                    &:active {
-                        @if $class != "primary" {
-                            background-color: map.get($property, inverse-bg-hover-color);
-                        }
-
-                        color: map.get($property, inverse-fg-hover-color);
-                    }
-
-                    #{$self}__inner {
-                        @if $class == "primary" {
-                            background-color: map.get($property, inverse-bg-color);
+                @if map.has-key($property, after) {
+                    &::after {
+                        @each $key, $value in map.get($property, after) {
+                            #{$key}: $value;
                         }
                     }
                 }
-            }
-        }
 
-        @if string.index($class, "-gradient") {
-            .theme--dark &--#{$class} {
-                background-color: var(--color-secondary);
-                background-image: none;
+                #{$self}__inner {
+                    gap: map.get($property, gap);
 
-                &::before {
-                    display: none;
+                    @if $class == "primary" {
+                        background-color: map.get($property, bg-color);
+                        transition: all $timing-s $ease-in;
+                    }
+
+                    @include z-index(button);
                 }
 
                 &:hover,
                 &:active {
-                    background-color: transparent;
-                    color: var(--color-secondary);
+                    @if $class != "primary" {
+                        background-color: map.get($property, bg-hover-color);
+                    }
+
+                    color: map.get($property, fg-hover-color);
+
+                    @if map.get($property, offset) {
+                        > #{$self}__inner {
+                            background-color: map.get($property, bg-hover-color);
+                            transform: translate($btn-primary-offset, $btn-primary-offset);
+                        }
+                    }
+
+                    @if string.index($class, "-gradient") {
+                        &::before {
+                            background-color: map.get($property, bg-hover-color);
+                        }
+                    }
+                }
+
+                &[data-disabled] {
+                    opacity: 0.75;
+                    &:hover > #{$self}__inner {
+                        background-color: map.get($property, bg-color);
+                        color: map.get($property, fg-color);
+                        transform: none;
+                    }
+                }
+
+                // *----------------------------------*/
+                //  Sizes
+                // *----------------------------------*/
+                @each $size, $properties in map.get($property, sizes) {
+                    @if $class == "primary" {
+                        &#{$self}--#{$size} #{$self}__inner {
+                            @each $property, $value in $properties {
+                                #{$property}: $value;
+                            }
+                        }
+                    } @else {
+                        &#{$self}--#{$size} {
+                            @each $property, $value in $properties {
+                                #{$property}: $value;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // *----------------------------------*/
+            //  Dark mode / inverse overrides
+            // *----------------------------------*/
+            &.is-inversed {
+                @each $class, $property in $btn-properties {
+                    &#{$self}--#{$class} {
+                        @if $class != "primary" {
+                            background-color: map.get($property, inverse-bg-color);
+                        }
+
+                        @if string.index($class, "-gradient") {
+                            background-color: map.get($property, inverse-bg-color);
+                            background-image: none;
+
+                            &::before {
+                                display: none;
+                            }
+                        }
+
+                        border-color: map.get($property, inverse-fg-color);
+                        color: map.get($property, inverse-fg-color);
+
+                        @if map.has-key($property, after) {
+                            &::after {
+                                border-color: map.get($property, inverse-bg-color);
+                            }
+                        }
+
+                        &:hover,
+                        &:active {
+                            @if $class != "primary" {
+                                background-color: map.get($property, inverse-bg-hover-color);
+                            }
+
+                            color: map.get($property, inverse-fg-hover-color);
+                        }
+
+                        #{$self}__inner {
+                            @if $class == "primary" {
+                                background-color: map.get($property, inverse-bg-color);
+                            }
+                        }
+                    }
+                }
+            }
+
+            @if string.index($class, "-gradient") {
+                .theme--dark &--#{$class} {
+                    background-color: var(--color-secondary);
+                    background-image: none;
+
+                    &::before {
+                        display: none;
+                    }
+
+                    &:hover,
+                    &:active {
+                        background-color: transparent;
+                        color: var(--color-secondary);
+                    }
                 }
             }
         }
     }
-}
 
-// *----------------------------------*/
-//  Button Group
-// *----------------------------------*/
-.c-btn-group {
-    display: flex;
-    gap: $space-m;
-    flex-wrap: wrap;
-    align-items: center;
+    // *----------------------------------*/
+    //  Button Group
+    // *----------------------------------*/
+    .c-btn-group {
+        display: flex;
+        gap: $space-m;
+        flex-wrap: wrap;
+        align-items: center;
 
-    &--column {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-}
-
-// *----------------------------------*/
-//  Button Loader
-// *----------------------------------*/
-.c-btn-loader {
-    display: flex;
-    gap: 0.25em;
-
-    &__dot {
-        width: 2px;
-        height: 2px;
-        background-color: currentcolor;
-        border-radius: $rad;
-
-        // Start here so we have a smoother transition when switching the loading state on
-        transform: translateY(0.2em);
-        animation: bounce 1s ease-in-out infinite;
-
-        &:nth-child(1) {
-            animation-delay: 0s;
-        }
-
-        &:nth-child(2) {
-            animation-delay: 0.1s;
-        }
-
-        &:nth-child(3) {
-            animation-delay: 0.2s;
+        &--column {
+            flex-direction: column;
+            align-items: flex-start;
         }
     }
-}
 
-@keyframes bounce {
-    0%,
-    100% {
-        transform: translateY(0.2em);
+    // *----------------------------------*/
+    //  Button Loader
+    // *----------------------------------*/
+    .c-btn-loader {
+        display: flex;
+        gap: 0.25em;
+
+        &__dot {
+            width: 2px;
+            height: 2px;
+            background-color: currentcolor;
+            border-radius: $rad;
+
+            // Start here so we have a smoother transition when switching the loading state on
+            transform: translateY(0.2em);
+            animation: bounce 1s ease-in-out infinite;
+
+            &:nth-child(1) {
+                animation-delay: 0s;
+            }
+
+            &:nth-child(2) {
+                animation-delay: 0.1s;
+            }
+
+            &:nth-child(3) {
+                animation-delay: 0.2s;
+            }
+        }
     }
 
-    50% {
-        transform: translateY(-0.2em);
+    @keyframes bounce {
+        0%,
+        100% {
+            transform: translateY(0.2em);
+        }
+
+        50% {
+            transform: translateY(-0.2em);
+        }
     }
 }

--- a/packages/osc-ui/src/components/Carousel/carousel.scss
+++ b/packages/osc-ui/src/components/Carousel/carousel.scss
@@ -1,123 +1,125 @@
 @import "../../styles/settings";
 
-$carousel-control-color: var(--color-neutral-400);
-$carousel-dot-dimensions: ($base-fs * 0.75);
-$carousel-arrow-dimensions: ($base-fs * 1.875);
+@layer components {
+    $carousel-control-color: var(--color-neutral-400);
+    $carousel-dot-dimensions: ($base-fs * 0.75);
+    $carousel-arrow-dimensions: ($base-fs * 1.875);
 
-/* stylelint-disable selector-class-pattern */
-.c-carousel {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr;
+    /* stylelint-disable selector-class-pattern */
+    .c-carousel {
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr;
 
-    &__inner {
-        grid-column: 1 / -1;
+        &__inner {
+            grid-column: 1 / -1;
 
-        // Required Keen styles
-        &:not([data-keen-slider-disabled]) {
-            position: relative;
-            display: flex;
-            align-content: flex-start;
-            width: 100%;
-            overflow: hidden;
-            -webkit-touch-callout: none;
-            touch-action: pan-y;
-            -webkit-tap-highlight-color: transparent;
+            // Required Keen styles
+            &:not([data-keen-slider-disabled]) {
+                position: relative;
+                display: flex;
+                align-content: flex-start;
+                width: 100%;
+                overflow: hidden;
+                -webkit-touch-callout: none;
+                touch-action: pan-y;
+                -webkit-tap-highlight-color: transparent;
+            }
+
+            &:not([data-keen-slider-disabled]) .keen-slider__slide {
+                position: relative;
+                width: 100%;
+                min-height: 100%;
+                overflow: hidden;
+            }
+
+            &:not([data-keen-slider-disabled])[data-keen-slider-reverse] {
+                flex-direction: row-reverse;
+            }
+
+            &:not([data-keen-slider-disabled])[data-keen-slider-v] {
+                flex-wrap: wrap;
+            }
+
+            // End required Keen styles
         }
 
-        &:not([data-keen-slider-disabled]) .keen-slider__slide {
-            position: relative;
-            width: 100%;
-            min-height: 100%;
-            overflow: hidden;
-        }
-
-        &:not([data-keen-slider-disabled])[data-keen-slider-reverse] {
-            flex-direction: row-reverse;
-        }
-
-        &:not([data-keen-slider-disabled])[data-keen-slider-v] {
-            flex-wrap: wrap;
-        }
-
-        // End required Keen styles
-    }
-
-    // Arrows
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &.has-adaptive-height .c-carousel__slide {
-        min-height: auto;
-    }
-
-    &__arrow {
-        width: $carousel-arrow-dimensions;
-        height: $carousel-arrow-dimensions;
-        color: $carousel-control-color;
-        cursor: pointer;
-
-        &--left {
-            grid-column: 1 / 2;
-        }
-
-        &--right {
-            grid-column: 3 / 4;
-        }
-
+        // Arrows
         /* stylelint-disable-next-line plugin/selector-bem-pattern */
-        &[disabled] {
-            opacity: 0.5;
-            cursor: auto;
-        }
-    }
-
-    // DotNav
-    &__dots {
-        display: flex;
-        padding: $space-xs 0;
-
-        &--start {
-            justify-content: flex-start;
+        &.has-adaptive-height .c-carousel__slide {
+            min-height: auto;
         }
 
-        &--end {
-            justify-content: flex-end;
+        &__arrow {
+            width: $carousel-arrow-dimensions;
+            height: $carousel-arrow-dimensions;
+            color: $carousel-control-color;
+            cursor: pointer;
+
+            &--left {
+                grid-column: 1 / 2;
+            }
+
+            &--right {
+                grid-column: 3 / 4;
+            }
+
+            /* stylelint-disable-next-line plugin/selector-bem-pattern */
+            &[disabled] {
+                opacity: 0.5;
+                cursor: auto;
+            }
         }
 
-        &--center {
-            justify-content: center;
-        }
-    }
+        // DotNav
+        &__dots {
+            display: flex;
+            padding: $space-xs 0;
 
-    &__dot {
-        width: $carousel-dot-dimensions;
-        height: $carousel-dot-dimensions;
-        margin: 0 2px;
-        background: var(--color-tertiary);
-        border: 1px solid $carousel-control-color;
-        border-radius: $rad;
-        cursor: pointer;
+            &--start {
+                justify-content: flex-start;
+            }
 
-        &:focus {
-            outline: none;
-        }
+            &--end {
+                justify-content: flex-end;
+            }
 
-        &.is-active {
-            background: $carousel-control-color;
-        }
-    }
-
-    &.has-arrows {
-        grid-template-columns: auto 1fr auto;
-        align-items: center;
-
-        .c-carousel__inner,
-        .c-carousel__dots {
-            grid-column: 2 / 3;
+            &--center {
+                justify-content: center;
+            }
         }
 
-        .c-carousel__inner,
-        .c-carousel__arrow {
-            grid-row: 1;
+        &__dot {
+            width: $carousel-dot-dimensions;
+            height: $carousel-dot-dimensions;
+            margin: 0 2px;
+            background: var(--color-tertiary);
+            border: 1px solid $carousel-control-color;
+            border-radius: $rad;
+            cursor: pointer;
+
+            &:focus {
+                outline: none;
+            }
+
+            &.is-active {
+                background: $carousel-control-color;
+            }
+        }
+
+        &.has-arrows {
+            grid-template-columns: auto 1fr auto;
+            align-items: center;
+
+            .c-carousel__inner,
+            .c-carousel__dots {
+                grid-column: 2 / 3;
+            }
+
+            .c-carousel__inner,
+            .c-carousel__arrow {
+                grid-row: 1;
+            }
         }
     }
 }

--- a/packages/osc-ui/src/components/Checkbox/checkbox.scss
+++ b/packages/osc-ui/src/components/Checkbox/checkbox.scss
@@ -3,95 +3,97 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-// Sizes
-$checkbox-width: 1.25;
-$checkbox-height: 1.25;
+@layer components {
+    // Sizes
+    $checkbox-width: 1.25;
+    $checkbox-height: 1.25;
 
-.c-checkbox {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: #{$checkbox-width}rem;
-    height: #{$checkbox-height}rem;
-    background-color: var(--color-tertiary);
-    border: 1px solid var(--color-quinary);
-    cursor: pointer;
-
-    &__description {
-        flex: 1 100%;
-        font-size: $fs-s;
-    }
-
-    &__indicator {
+    .c-checkbox {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: #{math.div(1, $checkbox-width)}rem;
-        height: #{math.div(1, $checkbox-height)}rem;
-        background: var(--color-primary);
-        color: var(--color-tertiary);
-    }
+        width: #{$checkbox-width}rem;
+        height: #{$checkbox-height}rem;
+        background-color: var(--color-tertiary);
+        border: 1px solid var(--color-quinary);
+        cursor: pointer;
 
-    &__container {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
+        &__description {
+            flex: 1 100%;
+            font-size: $fs-s;
+        }
 
-        &--secondary {
-            .c-checkbox {
-                &[data-state="checked"] {
-                    border: none;
+        &__indicator {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: #{math.div(1, $checkbox-width)}rem;
+            height: #{math.div(1, $checkbox-height)}rem;
+            background: var(--color-primary);
+            color: var(--color-tertiary);
+        }
 
-                    &:focus {
-                        box-shadow: $shadow-focus-s;
+        &__container {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+
+            &--secondary {
+                .c-checkbox {
+                    &[data-state="checked"] {
+                        border: none;
+
+                        &:focus {
+                            box-shadow: $shadow-focus-s;
+                        }
+                    }
+
+                    &__indicator {
+                        width: 100%;
+                        height: 100%;
                     }
                 }
+            }
 
-                &__indicator {
-                    width: 100%;
-                    height: 100%;
+            &--error {
+                .c-checkbox {
+                    background-color: var(--color-error-20);
+                    border: 1px solid var(--color-error);
+                }
+
+                .c-checkbox__error-message {
+                    flex: 1 100%;
+                    padding-top: $space-xs;
+                    color: var(--color-error);
+                    font-size: $fs-s;
                 }
             }
-        }
 
-        &--error {
-            .c-checkbox {
-                background-color: var(--color-error-20);
-                border: 1px solid var(--color-error);
-            }
-
-            .c-checkbox__error-message {
-                flex: 1 100%;
-                padding-top: $space-xs;
-                color: var(--color-error);
-                font-size: $fs-s;
+            .c-label {
+                padding-left: $space-xs;
             }
         }
 
-        .c-label {
-            padding-left: $space-xs;
+        &:hover {
+            background-color: var(--color-neutral-300);
         }
-    }
 
-    &:hover {
-        background-color: var(--color-neutral-300);
-    }
+        &:focus {
+            box-shadow: $shadow-focus-s;
+        }
 
-    &:focus {
-        box-shadow: $shadow-focus-s;
-    }
-
-    &[data-disabled] {
-        background-color: var(--color-quinary);
-        pointer-events: none;
-
-        + .c-label {
-            color: var(--color-neutral-500);
+        &[data-disabled] {
+            background-color: var(--color-quinary);
             pointer-events: none;
-        }
-    }
 
-    &__is-checked {
-        --icon-size: 0.625em;
+            + .c-label {
+                color: var(--color-neutral-500);
+                pointer-events: none;
+            }
+        }
+
+        &__is-checked {
+            --icon-size: 0.625em;
+        }
     }
 }

--- a/packages/osc-ui/src/components/Content/content.scss
+++ b/packages/osc-ui/src/components/Content/content.scss
@@ -1,58 +1,60 @@
 @import "../../styles/settings";
 
-.c-content {
-    --content-decoration-color: var(--color-quaternary);
-    --content-decoration-size: 0.1em;
+@layer components {
+    .c-content {
+        --content-decoration-color: var(--color-quaternary);
+        --content-decoration-size: 0.1em;
 
-    display: flex;
-    flex-grow: 1;
-    flex-direction: column;
-    width: 100%;
-
-    // Ensure the links are underlined unless they are buttons or has been specifically reset
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    a[href]:not(.c-btn):not(.u-text-reset) {
-        text-decoration: underline solid currentcolor var(--content-decoration-size);
-        transition: text-decoration $timing-s $ease-out;
-
-        /* stylelint-disable-next-line plugin/selector-bem-pattern */
-        &:hover {
-            text-decoration:
-                underline solid var(--content-decoration-color)
-                var(--content-decoration-size);
-        }
-    }
-
-    &__inner {
         display: flex;
+        flex-grow: 1;
         flex-direction: column;
-        align-items: flex-start;
         width: 100%;
-        max-width: #{$container-xs}px;
-        margin: auto;
 
-        // Horizontal Alignments
-        &--left {
-            text-align: left;
+        // Ensure the links are underlined unless they are buttons or has been specifically reset
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        a[href]:not(.c-btn):not(.u-text-reset) {
+            text-decoration: underline solid currentcolor var(--content-decoration-size);
+            transition: text-decoration $timing-s $ease-out;
+
+            /* stylelint-disable-next-line plugin/selector-bem-pattern */
+            &:hover {
+                text-decoration:
+                    underline solid var(--content-decoration-color)
+                    var(--content-decoration-size);
+            }
         }
 
-        &--centre {
-            align-items: center;
-            text-align: center;
-        }
-
-        &--right {
-            align-items: flex-end;
-            text-align: right;
-        }
-
-        // Vertical Alignments
-        &--top {
+        &__inner {
+            display: flex;
+            flex-direction: column;
             align-items: flex-start;
-        }
+            width: 100%;
+            max-width: #{$container-xs}px;
+            margin: auto;
 
-        &--bottom {
-            align-items: flex-end;
+            // Horizontal Alignments
+            &--left {
+                text-align: left;
+            }
+
+            &--centre {
+                align-items: center;
+                text-align: center;
+            }
+
+            &--right {
+                align-items: flex-end;
+                text-align: right;
+            }
+
+            // Vertical Alignments
+            &--top {
+                align-items: flex-start;
+            }
+
+            &--bottom {
+                align-items: flex-end;
+            }
         }
     }
 }

--- a/packages/osc-ui/src/components/CountdownClock/countdownClock.scss
+++ b/packages/osc-ui/src/components/CountdownClock/countdownClock.scss
@@ -1,37 +1,39 @@
 @import "../../styles/settings";
 
-.c-countdown-clock {
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &__container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    }
-
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &__section {
-        padding: 0 calc($space-2xs / 2);
-    }
-
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &__digits {
-        font-feature-settings: "tnum";
-        font-variant-numeric: tabular-nums;
-    }
-
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &__icon {
-        display: flex;
-        padding: 0 $space-2xs;
-    }
-
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &__timer {
-        display: flex;
-        align-items: center;
+@layer components {
+    .c-countdown-clock {
         /* stylelint-disable-next-line plugin/selector-bem-pattern */
-        &--inner {
+        &__container {
             display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        &__section {
+            padding: 0 calc($space-2xs / 2);
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        &__digits {
+            font-feature-settings: "tnum";
+            font-variant-numeric: tabular-nums;
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        &__icon {
+            display: flex;
+            padding: 0 $space-2xs;
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        &__timer {
+            display: flex;
+            align-items: center;
+            /* stylelint-disable-next-line plugin/selector-bem-pattern */
+            &--inner {
+                display: flex;
+            }
         }
     }
 }

--- a/packages/osc-ui/src/components/DropdownMenu/dropdown-menu.scss
+++ b/packages/osc-ui/src/components/DropdownMenu/dropdown-menu.scss
@@ -1,110 +1,112 @@
 @import "../../styles/settings";
 
-.c-dropdown-menu {
-    &__content,
-    &__sub-content {
-        min-width: 220px;
-        padding: calc($space-2xs / 2);
-        background-color: var(--color-tertiary);
-        border-radius: $rad-xs;
-        box-shadow: $shadow-l;
-        animation-duration: 400ms;
-        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-        will-change: transform, opacity;
-    }
+@layer components {
+    .c-dropdown-menu {
+        &__content,
+        &__sub-content {
+            min-width: 220px;
+            padding: calc($space-2xs / 2);
+            background-color: var(--color-tertiary);
+            border-radius: $rad-xs;
+            box-shadow: $shadow-l;
+            animation-duration: 400ms;
+            animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+            will-change: transform, opacity;
+        }
 
-    &__item,
-    &__checkbox-item,
-    &__radio-item,
-    &__sub-trigger {
-        position: relative;
-        display: flex;
-        align-items: center;
-        height: 25px;
-        padding: 0 calc($space-2xs / 2) 0 $space-l;
-        border-radius: $rad-xs;
-        outline: none;
-        font-size: $fs-xs;
-        user-select: none;
+        &__item,
+        &__checkbox-item,
+        &__radio-item,
+        &__sub-trigger {
+            position: relative;
+            display: flex;
+            align-items: center;
+            height: 25px;
+            padding: 0 calc($space-2xs / 2) 0 $space-l;
+            border-radius: $rad-xs;
+            outline: none;
+            font-size: $fs-xs;
+            user-select: none;
 
-        /* stylelint-disable-next-line plugin/selector-bem-pattern */
-        &[data-disabled] {
-            color: var(--color-neutral-300);
-            pointer-events: none;
+            /* stylelint-disable-next-line plugin/selector-bem-pattern */
+            &[data-disabled] {
+                color: var(--color-neutral-300);
+                pointer-events: none;
+            }
+
+            /* stylelint-disable-next-line plugin/selector-bem-pattern */
+            &[data-highlighted] {
+                background-color: var(--color-neutral-400);
+                color: var(--color-neutral-100);
+            }
         }
 
         /* stylelint-disable-next-line plugin/selector-bem-pattern */
-        &[data-highlighted] {
+        &__sub-trigger[data-state="open"] {
             background-color: var(--color-neutral-400);
             color: var(--color-neutral-100);
         }
-    }
 
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &__sub-trigger[data-state="open"] {
-        background-color: var(--color-neutral-400);
-        color: var(--color-neutral-100);
-    }
-
-    &__label {
-        padding-left: $space-l;
-        color: var(--color-neutral-600);
-        font-size: $fs-xs;
-        text-transform: uppercase;
-    }
-
-    &__separator {
-        height: 1px;
-        margin: 5px;
-        background-color: var(--color-neutral-500);
-    }
-
-    &__indicator {
-        position: absolute;
-        left: 0;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 25px;
-    }
-
-    &__arrow {
-        fill: var(--color-tertiary);
-    }
-
-    &__icon-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 35px;
-        height: 35px;
-        background-color: var(--color-tertiary);
-        border-radius: $rad;
-        box-shadow: $shadow-m;
-        font-family: inherit;
-
-        &:hover {
-            background-color: var(--color-neutral-300);
+        &__label {
+            padding-left: $space-l;
+            color: var(--color-neutral-600);
+            font-size: $fs-xs;
+            text-transform: uppercase;
         }
 
-        &:focus {
-            box-shadow: 0 0 0 2px var(--color-primary);
+        &__separator {
+            height: 1px;
+            margin: 5px;
+            background-color: var(--color-neutral-500);
         }
-    }
 
-    &__icon--right-slot {
-        margin-left: auto;
-        padding-left: $space-m;
-        color: var(--color-neutral-500);
-    }
+        &__indicator {
+            position: absolute;
+            left: 0;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 25px;
+        }
 
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    [data-highlighted] > &__icon--right-slot {
-        color: var(--color-tertiary);
-    }
+        &__arrow {
+            fill: var(--color-tertiary);
+        }
 
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    [data-disabled] &__icon--right-slot {
-        color: var(--color-neutral-400);
+        &__icon-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 35px;
+            height: 35px;
+            background-color: var(--color-tertiary);
+            border-radius: $rad;
+            box-shadow: $shadow-m;
+            font-family: inherit;
+
+            &:hover {
+                background-color: var(--color-neutral-300);
+            }
+
+            &:focus {
+                box-shadow: 0 0 0 2px var(--color-primary);
+            }
+        }
+
+        &__icon--right-slot {
+            margin-left: auto;
+            padding-left: $space-m;
+            color: var(--color-neutral-500);
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        [data-highlighted] > &__icon--right-slot {
+            color: var(--color-tertiary);
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        [data-disabled] &__icon--right-slot {
+            color: var(--color-neutral-400);
+        }
     }
 }

--- a/packages/osc-ui/src/components/Footer/footer.scss
+++ b/packages/osc-ui/src/components/Footer/footer.scss
@@ -1,9 +1,11 @@
-.o-footer {
-    width: 50%;
-    background-color: rgb(23 222 219);
+@layer components {
+    .c-footer {
+        width: 50%;
+        background-color: rgb(23 222 219);
 
-    &--full {
-        width: 40%;
-        background-color: rgb(117 2 2);
+        &--full {
+            width: 40%;
+            background-color: rgb(117 2 2);
+        }
     }
 }

--- a/packages/osc-ui/src/components/Header/header.scss
+++ b/packages/osc-ui/src/components/Header/header.scss
@@ -2,46 +2,47 @@
 @use "../../styles/tools/" as *;
 @use "../../styles/settings/" as *;
 
-$logo-size-s: 192px;
-$logo-size-l: 277px;
+@layer components {
+    $logo-size-s: 192px;
+    $logo-size-l: 277px;
 
-.c-header {
-    $self: &;
+    .c-header {
+        $self: &;
 
-    position: relative;
-    display: grid;
-    align-items: center;
-    grid-template-columns: repeat(3, auto);
-    padding-block: $space-xl;
+        position: relative;
+        display: grid;
+        align-items: center;
+        grid-template-columns: repeat(3, auto);
+        padding-block: $space-xl;
 
-    @include z-index("header");
-
-    @include mq($mq-desk) {
-        grid-template-columns: repeat(2, auto);
-        grid-template-rows: repeat(2, 1fr);
-        gap: $space-2xs;
-    }
-
-    &__logo {
-        margin-inline: auto;
-        grid-column: 2 / 3;
+        @include z-index("header");
 
         @include mq($mq-desk) {
-            margin-inline: 0;
-            grid-column: 1 / 2;
-            grid-row: 2;
+            grid-template-columns: repeat(2, auto);
+            grid-template-rows: repeat(2, 1fr);
+            gap: $space-2xs;
         }
 
-        > svg {
-            max-width: $logo-size-s;
+        &__logo {
+            margin-inline: auto;
+            grid-column: 2 / 3;
 
-            @include mq($mq-tab) {
-                max-width: $logo-size-l;
+            @include mq($mq-desk) {
+                margin-inline: 0;
+                grid-column: 1 / 2;
+                grid-row: 2;
+            }
+
+            > svg {
+                max-width: $logo-size-s;
+
+                @include mq($mq-tab) {
+                    max-width: $logo-size-l;
+                }
             }
         }
-    }
 
-    /*
+        /*
      * Fix overflow issue on IOS devices
      *
      * On IOS there is an issue where if you set the body and html elements to have overflow hidden
@@ -52,97 +53,98 @@ $logo-size-l: 277px;
      * [1] Set the initial position of the __nav to fixed
      * [2] Set the overflow-x to hidden to hide any children
      */
-    &__nav {
-        position: fixed; /* [1] */
-        top: var(--header-height, 0);
-        right: 0;
-        bottom: 0;
-        left: 0;
-        transition: transform $timing $ease-out-sine;
-        overflow-x: hidden; /* [2] */
-
-        @include mq($mq-desk) {
-            position: static;
-            display: flex;
-            justify-content: flex-end;
-            grid-column: 2 / -1;
-            grid-row: 2;
-            overflow-x: initial;
-        }
-
-        &[data-state="closed"] {
-            @include mq($mq-desk, max) {
-                transform: translateX(100vw);
-            }
-        }
-
-        &[data-state="open"] {
-            @include mq($mq-desk, max) {
-                transform: translateX(0);
-            }
-        }
-
-        .c-nav {
-            @include mq($mq-desk, max) {
-                border-top: 1px solid var(--color-secondary);
-            }
-        }
-
-        /* stylelint-disable-next-line selector-class-pattern */
-        .c-nav__content[data-level="0"] {
+        &__nav {
+            position: fixed; /* [1] */
+            top: var(--header-height, 0);
+            right: 0;
+            bottom: 0;
             left: 0;
+            transition: transform $timing $ease-out-sine;
+            overflow-x: hidden; /* [2] */
 
             @include mq($mq-desk) {
-                top: var(--header-height, 0);
-            }
-        }
-    }
-
-    &__action-bar {
-        display: flex;
-        justify-content: flex-end;
-        gap: $space-xl;
-        font-weight: $fw-light;
-
-        @include mq($mq-desk) {
-            padding-inline-end: $space-2xs;
-            grid-column: 2 / -1;
-            grid-row: 1;
-        }
-
-        /* stylelint-disable-next-line no-descending-specificity */
-        #{$self}__action-item {
-            display: block;
-            cursor: pointer;
-
-            .o-icon {
-                --icon-size: 20px;
-
-                flex-shrink: 0;
-            }
-        }
-
-        #{$self}__nav & {
-            background-color: var(--color-secondary);
-            color: var(--color-tertiary);
-            gap: 0;
-
-            #{$self}__action-item {
+                position: static;
                 display: flex;
-                flex: 0 1 50%;
-                align-items: center;
-                justify-content: center;
-                padding: $space-s $space-m;
-                gap: $space-xs;
+                justify-content: flex-end;
+                grid-column: 2 / -1;
+                grid-row: 2;
+                overflow-x: initial;
+            }
 
-                &:not(:last-child) {
-                    border-right: 1px solid var(--color-tertiary);
+            &[data-state="closed"] {
+                @include mq($mq-desk, max) {
+                    transform: translateX(100vw);
+                }
+            }
+
+            &[data-state="open"] {
+                @include mq($mq-desk, max) {
+                    transform: translateX(0);
+                }
+            }
+
+            .c-nav {
+                @include mq($mq-desk, max) {
+                    border-top: 1px solid var(--color-secondary);
+                }
+            }
+
+            /* stylelint-disable-next-line selector-class-pattern */
+            .c-nav__content[data-level="0"] {
+                left: 0;
+
+                @include mq($mq-desk) {
+                    top: var(--header-height, 0);
                 }
             }
         }
-    }
 
-    > .c-burger {
-        grid-column: 1 / 2;
+        &__action-bar {
+            display: flex;
+            justify-content: flex-end;
+            gap: $space-xl;
+            font-weight: $fw-light;
+
+            @include mq($mq-desk) {
+                padding-inline-end: $space-2xs;
+                grid-column: 2 / -1;
+                grid-row: 1;
+            }
+
+            /* stylelint-disable-next-line no-descending-specificity */
+            #{$self}__action-item {
+                display: block;
+                cursor: pointer;
+
+                .o-icon {
+                    --icon-size: 20px;
+
+                    flex-shrink: 0;
+                }
+            }
+
+            #{$self}__nav & {
+                background-color: var(--color-secondary);
+                color: var(--color-tertiary);
+                gap: 0;
+
+                #{$self}__action-item {
+                    display: flex;
+                    flex: 0 1 50%;
+                    align-items: center;
+                    justify-content: center;
+                    padding: $space-s $space-m;
+                    gap: $space-xs;
+
+                    &:not(:last-child) {
+                        border-right: 1px solid var(--color-tertiary);
+                    }
+                }
+            }
+        }
+
+        > .c-burger {
+            grid-column: 1 / 2;
+        }
     }
 }

--- a/packages/osc-ui/src/components/IslandGrid/island-grid.scss
+++ b/packages/osc-ui/src/components/IslandGrid/island-grid.scss
@@ -2,23 +2,26 @@
 @import "../../styles/settings";
 @import "../../styles/tools";
 
-$island-cols: 2;
-$max-islands: 4;
+@layer components {
+    $island-cols: 2;
+    $max-islands: 4;
 
-.c-island-grid {
-    @include mq($mq-tab) {
-        grid-template-rows: repeat($island-cols, minmax(0, 1fr));
-    }
-
-    &__island {
+    .c-island-grid {
         @include mq($mq-tab) {
-            &:nth-child(1) {
-                grid-row: list.slash(1, $max-islands);
-            }
+            grid-template-rows: repeat($island-cols, minmax(0, 1fr));
+        }
 
-            @for $i from 2 through $max-islands {
-                &:nth-child(#{$i}) {
-                    grid-row: #{$i - 1}; // Position the island in the row minus 1 place from it's index
+        &__island {
+            @include mq($mq-tab) {
+                &:nth-child(1) {
+                    grid-row: list.slash(1, $max-islands);
+                }
+
+                @for $i from 2 through $max-islands {
+                    &:nth-child(#{$i}) {
+                        // Position the island in the row minus 1 place from it's index
+                        grid-row: #{$i - 1};
+                    }
                 }
             }
         }

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -3,15 +3,18 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-.c-label {
-    color: var(--color-neutral-700);
-    cursor: pointer;
+@layer components {
+    .c-label {
+        color: var(--color-neutral-700);
+        font-weight: $fw-reg;
+        cursor: pointer;
 
-    &__required {
-        padding-inline-start: #{math.div(1, $base-fs)}em;
-    }
+        &__required {
+            padding-inline-start: #{math.div(1, $base-fs)}em;
+        }
 
-    &--bold {
-        font-weight: $fw-bold;
+        &--bold {
+            font-weight: $fw-bold;
+        }
     }
 }

--- a/packages/osc-ui/src/components/Logo/logo.scss
+++ b/packages/osc-ui/src/components/Logo/logo.scss
@@ -1,8 +1,10 @@
 /* stylelint-disable plugin/selector-bem-pattern */
-.c-logo {
-    display: block;
+@layer components {
+    .c-logo {
+        display: block;
 
-    .o-icon {
-        --icon-size: auto;
+        .o-icon {
+            --icon-size: auto;
+        }
     }
 }

--- a/packages/osc-ui/src/components/Modal/modal.scss
+++ b/packages/osc-ui/src/components/Modal/modal.scss
@@ -3,76 +3,78 @@
 
 // TODO: sb - we should probably set these as variables
 
-.c-modal {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    width: 100%;
-    padding: 25px;
-    background-color: var(--color-tertiary);
-    box-shadow: $shadow-l;
-    transform: translate(-50%, -50%);
-    animation: content-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
-
-    &:focus {
-        outline: none;
-    }
-
-    &__header {
-        display: flex;
-        justify-content: space-between;
-    }
-
-    &__overlay {
+@layer components {
+    .c-modal {
         position: fixed;
-        background-color: var(--color-neutral-200);
-        animation: overlay-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
-        inset: 0;
+        top: 50%;
+        left: 50%;
+        width: 100%;
+        padding: 25px;
+        background-color: var(--color-tertiary);
+        box-shadow: $shadow-l;
+        transform: translate(-50%, -50%);
+        animation: content-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+        &:focus {
+            outline: none;
+        }
+
+        &__header {
+            display: flex;
+            justify-content: space-between;
+        }
+
+        &__overlay {
+            position: fixed;
+            background-color: var(--color-neutral-200);
+            animation: overlay-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+            inset: 0;
+        }
+
+        &--xs {
+            max-width: 360px;
+        }
+
+        &--sm {
+            max-width: #{calc($container-3xs / 2)}px;
+        }
+
+        &--md {
+            max-width: 768px;
+        }
+
+        &--lg {
+            max-width: #{$container-2xs}px;
+        }
+
+        &--xl {
+            max-width: #{$container-m}px;
+        }
+
+        &--full {
+            max-width: 100%;
+        }
     }
 
-    &--xs {
-        max-width: 360px;
+    @keyframes overlay-show {
+        from {
+            opacity: 0;
+        }
+
+        to {
+            opacity: 1;
+        }
     }
 
-    &--sm {
-        max-width: #{calc($container-3xs / 2)}px;
-    }
+    @keyframes content-show {
+        from {
+            opacity: 0;
+            opacity: translate(-0.5, -0.48) scale(0.96);
+        }
 
-    &--md {
-        max-width: 768px;
-    }
-
-    &--lg {
-        max-width: #{$container-2xs}px;
-    }
-
-    &--xl {
-        max-width: #{$container-m}px;
-    }
-
-    &--full {
-        max-width: 100%;
-    }
-}
-
-@keyframes overlay-show {
-    from {
-        opacity: 0;
-    }
-
-    to {
-        opacity: 1;
-    }
-}
-
-@keyframes content-show {
-    from {
-        opacity: 0;
-        opacity: translate(-0.5, -0.48) scale(0.96);
-    }
-
-    to {
-        transform: translate(-50%, -50%) scale(1);
-        opacity: 1;
+        to {
+            transform: translate(-50%, -50%) scale(1);
+            opacity: 1;
+        }
     }
 }

--- a/packages/osc-ui/src/components/Navbar/navbar.scss
+++ b/packages/osc-ui/src/components/Navbar/navbar.scss
@@ -3,277 +3,280 @@
 
 /* stylelint-disable plugin/selector-bem-pattern */
 
-$simple-nav-width: 250px;
+@layer components {
+    $simple-nav-width: 250px;
 
-.c-nav {
-    $self: &;
+    .c-nav {
+        $self: &;
 
-    font-size: rem($base-fs);
-    font-weight: $fw-bold;
+        font-size: rem($base-fs);
+        font-weight: $fw-bold;
 
-    @include z-index("navigation");
+        @include z-index("navigation");
 
-    @include mq($mq-desk) {
-        font-weight: $fw-reg;
-    }
-
-    &--simple {
-        #{$self}__content {
-            @include mq($mq-desk) {
-                max-width: $simple-nav-width;
-            }
-
-            &[data-level="0"] #{$self}__list {
-                @include mq($mq-desk) {
-                    padding-inline: 0;
-                }
-            }
-
-            &[data-state="closed"] {
-                @include mq($mq-desk) {
-                    grid-template-rows: 1fr;
-                }
-            }
-
-            #{$self}__trigger--close {
-                @include mq($mq-desk) {
-                    display: none;
-                }
-            }
+        @include mq($mq-desk) {
+            font-weight: $fw-reg;
         }
 
-        #{$self}__submenu #{$self}__list {
-            @include mq($mq-desk) {
-                flex-flow: column nowrap;
+        &--simple {
+            #{$self}__content {
+                @include mq($mq-desk) {
+                    max-width: $simple-nav-width;
+                }
+
+                &[data-level="0"] #{$self}__list {
+                    @include mq($mq-desk) {
+                        padding-inline: 0;
+                    }
+                }
+
+                &[data-state="closed"] {
+                    @include mq($mq-desk) {
+                        grid-template-rows: 1fr;
+                    }
+                }
+
+                #{$self}__trigger--close {
+                    @include mq($mq-desk) {
+                        display: none;
+                    }
+                }
             }
 
-            #{$self}__item {
-                > a {
-                    @include mq($mq-desk) {
-                        padding-block-start: $space-s;
+            #{$self}__submenu #{$self}__list {
+                @include mq($mq-desk) {
+                    flex-flow: column nowrap;
+                }
+
+                #{$self}__item {
+                    > a {
+                        @include mq($mq-desk) {
+                            padding-block-start: $space-s;
+                        }
                     }
                 }
             }
         }
-    }
 
-    &__trigger,
-    &__link {
-        padding: $space-2xl $space-m;
-        border-block-end: solid 1px var(--color-quinary);
-
-        @include mq($mq-desk) {
-            padding: 0;
-            border-block-end: none;
-        }
-
-        // Style triggers and links within the content block
-        #{$self}__content & {
-            padding-block: $space-l;
+        &__trigger,
+        &__link {
+            padding: $space-2xl $space-m;
+            border-block-end: solid 1px var(--color-quinary);
 
             @include mq($mq-desk) {
-                padding-block: 0;
-            }
-        }
-
-        // Style triggers and links within the content block where they are not the top level
-        #{$self}__content:where([data-level="0"]) & {
-            @include mq($mq-desk) {
-                $bg-height: 1px;
-
-                display: flex;
-                background:
-                    linear-gradient(
-                        0deg,
-                        var(--color-secondary),
-                        var(--color-secondary)
-                    ) no-repeat right bottom / 0 $bg-height;
-                font-weight: $fw-bold;
-                transition: background-size $timing $ease-in-out;
-                padding-block: $space-xl $space-2xs;
-                border-block-end: solid $bg-height var(--color-quinary);
-
-                &[data-state="open"],
-                &:hover {
-                    background-size: 100% $bg-height;
-                    background-position-x: left;
-                }
-            }
-
-            &--close {
-                @include mq($mq-desk) {
-                    padding-block: 0;
-                    background: none;
-                }
-
+                padding: 0;
                 border-block-end: none;
             }
-        }
-    }
 
-    &__trigger {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        width: 100%;
-        cursor: pointer;
+            // Style triggers and links within the content block
+            #{$self}__content & {
+                padding-block: $space-l;
 
-        &--close {
-            background-color: var(--color-neutral-200);
-
-            @include mq($mq-desk) {
-                width: auto;
-                justify-self: flex-end;
-            }
-
-            > span {
-                margin-inline: auto;
-            }
-
-            #{$self}__trigger-icon {
-                transform: rotate(90deg);
-            }
-        }
-    }
-
-    &__trigger-icon {
-        transition: transform $timing $ease-in-out;
-
-        @include mq($mq-desk, max) {
-            transform: rotate(-90deg);
-        }
-
-        #{$self}__trigger[data-state="open"] & {
-            @include mq($mq-desk) {
-                transform: rotate(180deg);
-            }
-        }
-    }
-
-    &__link {
-        display: flex;
-
-        @include mq($mq-desk) {
-            display: inline-block;
-        }
-    }
-
-    &,
-    &__list {
-        display: flex;
-        flex-direction: column;
-
-        @include mq($mq-desk) {
-            flex-direction: row;
-        }
-    }
-
-    > #{$self}__list {
-        @include mq($mq-desk) {
-            align-items: center;
-        }
-
-        // Select only the top level of items without cascading the styles down
-        > #{$self}__item {
-            > #{$self}__submenu > #{$self}__trigger,
-            > #{$self}__link {
                 @include mq($mq-desk) {
-                    $bg-height: 4px;
+                    padding-block: 0;
+                }
+            }
 
-                    padding-block-end: $bg-height;
+            // Style triggers and links within the content block where they are not the top level
+            #{$self}__content:where([data-level="0"]) & {
+                @include mq($mq-desk) {
+                    $bg-height: 1px;
+
+                    display: flex;
                     background:
                         linear-gradient(
                             0deg,
                             var(--color-secondary),
                             var(--color-secondary)
-                        ) no-repeat right bottom / 0 $bg-height;
-                    line-height: $base-lh;
+                        )
+                        no-repeat right bottom / 0 $bg-height;
+                    font-weight: $fw-bold;
                     transition: background-size $timing $ease-in-out;
+                    padding-block: $space-xl $space-2xs;
+                    border-block-end: solid $bg-height var(--color-quinary);
 
-                    &:hover,
-                    &.active, // active is auto applied by the Remix NavLink component
-                    &[data-state="open"] {
+                    &[data-state="open"],
+                    &:hover {
                         background-size: 100% $bg-height;
                         background-position-x: left;
                     }
                 }
-            }
-        }
-    }
 
-    &__list {
-        --navbar-list-gap: #{$space-xl};
+                &--close {
+                    @include mq($mq-desk) {
+                        padding-block: 0;
+                        background: none;
+                    }
 
-        @include mq($mq-desk) {
-            column-gap: var(--navbar-list-gap);
-        }
-
-        // Style the list when the content block isn't the top level
-        #{$self}__content:not([data-level="0"]) & {
-            @include mq($mq-desk) {
-                flex-direction: column;
-                column-gap: var(--navbar-list-gap);
+                    border-block-end: none;
+                }
             }
         }
 
-        // Lists within the columns
-        #{$self}__item--column & {
+        &__trigger {
             display: flex;
-            flex-direction: column;
-        }
-    }
+            align-items: center;
+            justify-content: space-between;
+            width: 100%;
+            cursor: pointer;
 
-    &__item {
-        @include mq($mq-desk) {
-            flex: 0 1 calc(25% - var(--navbar-list-gap));
+            &--close {
+                background-color: var(--color-neutral-200);
+
+                @include mq($mq-desk) {
+                    width: auto;
+                    justify-self: flex-end;
+                }
+
+                > span {
+                    margin-inline: auto;
+                }
+
+                #{$self}__trigger-icon {
+                    transform: rotate(90deg);
+                }
+            }
         }
 
-        // Reset the flex value on the very top level list items
-        #{$self} > #{$self}__list > & {
-            flex: auto;
-        }
-
-        &--feature {
-            border-block-end: solid 1px var(--color-quinary);
-            font-size: $fs-xl;
-            padding-block: $space-m;
+        &__trigger-icon {
+            transition: transform $timing $ease-in-out;
 
             @include mq($mq-desk, max) {
-                order: 0;
+                transform: rotate(-90deg);
             }
+
+            #{$self}__trigger[data-state="open"] & {
+                @include mq($mq-desk) {
+                    transform: rotate(180deg);
+                }
+            }
+        }
+
+        &__link {
+            display: flex;
 
             @include mq($mq-desk) {
-                flex: 1 1 100%;
-                border-block-end: none;
+                display: inline-block;
+            }
+        }
+
+        &,
+        &__list {
+            display: flex;
+            flex-direction: column;
+
+            @include mq($mq-desk) {
+                flex-direction: row;
+            }
+        }
+
+        > #{$self}__list {
+            @include mq($mq-desk) {
+                align-items: center;
             }
 
-            #{$self}__list {
+            // Select only the top level of items without cascading the styles down
+            > #{$self}__item {
+                > #{$self}__submenu > #{$self}__trigger,
+                > #{$self}__link {
+                    @include mq($mq-desk) {
+                        $bg-height: 4px;
+
+                        padding-block-end: $bg-height;
+                        background:
+                            linear-gradient(
+                                0deg,
+                                var(--color-secondary),
+                                var(--color-secondary)
+                            )
+                            no-repeat right bottom / 0 $bg-height;
+                        line-height: $base-lh;
+                        transition: background-size $timing $ease-in-out;
+
+                        &:hover,
+                        &.active, 
+                        &[data-state="open"] {
+                            background-size: 100% $bg-height;
+                            background-position-x: left;
+                        }
+                    }
+                }
+            }
+        }
+
+        &__list {
+            --navbar-list-gap: #{$space-xl};
+
+            @include mq($mq-desk) {
+                column-gap: var(--navbar-list-gap);
+            }
+
+            // Style the list when the content block isn't the top level
+            #{$self}__content:not([data-level="0"]) & {
                 @include mq($mq-desk) {
                     flex-direction: column;
+                    column-gap: var(--navbar-list-gap);
                 }
             }
 
-            #{$self}__link {
-                padding-block: 0;
-                border-block-end: none;
-                background: none;
+            // Lists within the columns
+            #{$self}__item--column & {
+                display: flex;
+                flex-direction: column;
             }
         }
 
-        &--column {
-            @include mq($mq-desk, max) {
-                order: 1;
-            }
-        }
-
-        [data-level="0"] & {
+        &__item {
             @include mq($mq-desk) {
-                padding-left: 0;
+                flex: 0 1 calc(25% - var(--navbar-list-gap));
+            }
+
+            // Reset the flex value on the very top level list items
+            #{$self} > #{$self}__list > & {
+                flex: auto;
+            }
+
+            &--feature {
+                border-block-end: solid 1px var(--color-quinary);
+                font-size: $fs-xl;
+                padding-block: $space-m;
+
+                @include mq($mq-desk, max) {
+                    order: 0;
+                }
+
+                @include mq($mq-desk) {
+                    flex: 1 1 100%;
+                    border-block-end: none;
+                }
+
+                #{$self}__list {
+                    @include mq($mq-desk) {
+                        flex-direction: column;
+                    }
+                }
+
+                #{$self}__link {
+                    padding-block: 0;
+                    border-block-end: none;
+                    background: none;
+                }
+            }
+
+            &--column {
+                @include mq($mq-desk, max) {
+                    order: 1;
+                }
+            }
+
+            [data-level="0"] & {
+                @include mq($mq-desk) {
+                    padding-left: 0;
+                }
             }
         }
-    }
 
-    /*
+        /*
      * CSS trick to animate the height to "auto"
      * https://chriscoyier.net/2022/12/21/things-css-could-still-use-heading-into-2023/#animate-to-auto
      *
@@ -284,135 +287,136 @@ $simple-nav-width: 250px;
      * [5] When the state is open set the template rows to 1fr
      *
      */
-    &__content {
-        position: fixed;
-        top: var(--nav-trigger-distance, 0);
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        background-color: var(--color-tertiary);
-        transition:
-            transform $timing $ease-out-sine,
-            grid-template-rows $timing $ease-out-sine,
-            opacity $timing-s $ease-out,
-            visibility $timing-s $ease-out;
-        overflow-x: hidden;
+        &__content {
+            position: fixed;
+            top: var(--nav-trigger-distance, 0);
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            background-color: var(--color-tertiary);
+            transition:
+                transform $timing $ease-out-sine,
+                grid-template-rows $timing $ease-out-sine,
+                opacity $timing-s $ease-out,
+                visibility $timing-s $ease-out;
+            overflow-x: hidden;
 
-        @include z-index("sub-navigation");
+            @include z-index("sub-navigation");
 
-        @include mq($mq-desk) {
-            position: absolute;
-            display: grid; /* [1]  */
-        }
-
-        #{$self}__list {
             @include mq($mq-desk) {
-                min-height: 0; /* [3] */
-            }
-        }
-
-        #{$self}__item--feature #{$self}__link {
-            align-items: center;
-            font-weight: $fw-bold;
-
-            .o-icon {
-                transform: translateX(-5px);
-                transition: transform $timing $ease-in-out, opacity $timing $ease-in-out;
-                opacity: 0;
+                position: absolute;
+                display: grid; /* [1]  */
             }
 
-            &:hover {
-                .o-icon {
-                    transform: translateX(5px);
-                    opacity: 1;
+            #{$self}__list {
+                @include mq($mq-desk) {
+                    min-height: 0; /* [3] */
                 }
             }
-        }
 
-        // If menu has no further children
-        &:where(#{$self}__content #{$self}__content:last-of-type) {
-            min-height: 100vh;
+            #{$self}__item--feature #{$self}__link {
+                align-items: center;
+                font-weight: $fw-bold;
 
-            #{$self}__item:last-child {
+                .o-icon {
+                    transform: translateX(-5px);
+                    transition: transform $timing $ease-in-out, opacity $timing $ease-in-out;
+                    opacity: 0;
+                }
+
+                &:hover {
+                    .o-icon {
+                        transform: translateX(5px);
+                        opacity: 1;
+                    }
+                }
+            }
+
+            // If menu has no further children
+            &:where(#{$self}__content #{$self}__content:last-of-type) {
+                min-height: 100vh;
+
+                #{$self}__item:last-child {
+                    #{$self}__link,
+                    #{$self}__trigger {
+                        font-weight: $fw-med;
+                    }
+                }
 
                 #{$self}__link,
-                #{$self}__trigger {
-                    font-weight: $fw-med;
+                #{$self}__trigger:not(#{$self}__trigger--close) {
+                    font-weight: $fw-light;
+                    border-block-end: none;
+                    transition: font-weight $timing $ease-in-out;
+
+                    @include mq($mq-desk) {
+                        background: none;
+                        padding-block: 6px;
+                    }
+
+                    &:hover,
+                    .active {
+                        // active is auto applied by the Remix NavLink component
+                        font-weight: $fw-reg;
+                    }
                 }
             }
 
-            #{$self}__link,
-            #{$self}__trigger:not(#{$self}__trigger--close) {
-                font-weight: $fw-light;
-                border-block-end: none;
-                transition: font-weight $timing $ease-in-out;
-
-                @include mq($mq-desk) {
-                    background: none;
-                    padding-block: 6px;
-                }
-
-                &:hover,
-                .active { // active is auto applied by the Remix NavLink component
-                    font-weight: $fw-reg;
-                }
-            }
-        }
-
-        @include mq($mq-desk) {
-            inset-block-start: 0;
-            min-height: unset;
-            background-color: var(--color-neutral-200);
-            inset: unset;
-
-            #{$self}__content {
-                position: relative;
-                overflow: hidden; /* [4] */
-            }
-        }
-
-        &[data-level="0"] {
             @include mq($mq-desk) {
-                padding-block: $space-l $space-2xl;
-                padding-inline: $space-l;
+                inset-block-start: 0;
+                min-height: unset;
+                background-color: var(--color-neutral-200);
+                inset: unset;
+
+                #{$self}__content {
+                    position: relative;
+                    overflow: hidden; /* [4] */
+                }
             }
 
-            > #{$self}__list {
+            &[data-level="0"] {
                 @include mq($mq-desk) {
-                    padding-inline: $space-3xl $space-xl;
-                    flex-wrap: wrap;
+                    padding-block: $space-l $space-2xl;
+                    padding-inline: $space-l;
+                }
+
+                > #{$self}__list {
+                    @include mq($mq-desk) {
+                        padding-inline: $space-3xl $space-xl;
+                        flex-wrap: wrap;
+                    }
+                }
+
+                &[data-state="closed"] {
+                    @include mq($mq-desk) {
+                        opacity: 0;
+                        visibility: hidden;
+                    }
+                }
+
+                &[data-state="open"] {
+                    @include mq($mq-desk) {
+                        opacity: 1;
+                        visibility: visible;
+                    }
                 }
             }
 
             &[data-state="closed"] {
+                transform: translateX(100vw);
+
                 @include mq($mq-desk) {
-                    opacity: 0;
-                    visibility: hidden;
+                    transform: translateX(0);
+                    grid-template-rows: 0fr; /* [2] */
                 }
             }
 
             &[data-state="open"] {
-                @include mq($mq-desk) {
-                    opacity: 1;
-                    visibility: visible;
-                }
-            }
-        }
-
-        &[data-state="closed"] {
-            transform: translateX(100vw);
-
-            @include mq($mq-desk) {
                 transform: translateX(0);
-                grid-template-rows: 0fr; /* [2] */
-            }
-        }
 
-        &[data-state="open"] {
-            transform: translateX(0);
-
-            @include mq($mq-desk) {
-                grid-template-rows: 1fr; /* [5] */
+                @include mq($mq-desk) {
+                    grid-template-rows: 1fr; /* [5] */
+                }
             }
         }
     }

--- a/packages/osc-ui/src/components/Popover/popover.scss
+++ b/packages/osc-ui/src/components/Popover/popover.scss
@@ -1,51 +1,53 @@
 @import "../../styles/settings";
 
-.c-popover {
-    &__content {
-        width: 260px;
-        padding: $space-m;
-        background-color: var(--color-tertiary);
-        border-radius: $rad-xs;
-        box-shadow: $shadow-l;
-        animation-duration: $timing;
-        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-        will-change: transform, opacity;
+@layer components {
+    .c-popover {
+        &__content {
+            width: 260px;
+            padding: $space-m;
+            background-color: var(--color-tertiary);
+            border-radius: $rad-xs;
+            box-shadow: $shadow-l;
+            animation-duration: $timing;
+            animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+            will-change: transform, opacity;
 
-        &:focus {
-            box-shadow: $shadow-focus-s;
+            &:focus {
+                box-shadow: $shadow-focus-s;
+            }
         }
-    }
 
-    &__close {
-        position: absolute;
-        top: 5px;
-        right: 5px;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 25px;
-        height: 25px;
-        border-radius: $rad;
-        font-family: inherit;
+        &__close {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 25px;
+            height: 25px;
+            border-radius: $rad;
+            font-family: inherit;
 
-        &:hover {
-            background-color: var(--color-neutral-200);
+            &:hover {
+                background-color: var(--color-neutral-200);
+            }
         }
-    }
 
-    &__icon-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 35px;
-        height: 35px;
-        background-color: var(--color-tertiary);
-        border-radius: $rad;
-        color: var(--color-secondary);
-        font-family: inherit;
+        &__icon-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 35px;
+            height: 35px;
+            background-color: var(--color-tertiary);
+            border-radius: $rad;
+            color: var(--color-secondary);
+            font-family: inherit;
 
-        &:hover {
-            background-color: var(--color-neutral-200);
+            &:hover {
+                background-color: var(--color-neutral-200);
+            }
         }
     }
 }

--- a/packages/osc-ui/src/components/RadioGroup/radio-group.scss
+++ b/packages/osc-ui/src/components/RadioGroup/radio-group.scss
@@ -3,93 +3,95 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-$radio-size: rem(($base-fs * 1.25)); // 20px
-$radio-indicator-diff: 0.7;
+@layer components {
+    $radio-size: rem(($base-fs * 1.25)); // 20px
+    $radio-indicator-diff: 0.7;
 
-.c-radio-group {
-    display: flex;
-    flex-direction: column;
-    gap: $space-xs;
-
-    &__item-container {
+    .c-radio-group {
         display: flex;
-        align-items: center;
-    }
+        flex-direction: column;
+        gap: $space-xs;
 
-    &__item {
-        width: $radio-size;
-        height: $radio-size;
-        background-color: var(--color-tertiary);
-        border: solid 1px var(--color-quinary);
-        border-radius: $rad;
-        cursor: pointer;
-
-        &:hover {
-            background-color: var(--color-neutral-300);
+        &__item-container {
+            display: flex;
+            align-items: center;
         }
 
-        &:focus {
-            box-shadow: $shadow-focus-s;
-        }
-    }
-
-    &__indicator {
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-
-        &::after {
-            display: block;
-            width: calc($radio-size * $radio-indicator-diff);
-            height: calc($radio-size * $radio-indicator-diff);
-            background-color: var(--color-quaternary);
+        &__item {
+            width: $radio-size;
+            height: $radio-size;
+            background-color: var(--color-tertiary);
+            border: solid 1px var(--color-quinary);
             border-radius: $rad;
-            content: "";
-        }
-    }
+            cursor: pointer;
 
-    &--error {
-        .c-radio-group__item {
-            background-color: var(--color-error-20);
-            border: solid 1px var(--color-error);
-        }
+            &:hover {
+                background-color: var(--color-neutral-300);
+            }
 
-        .c-radio-group__error-message {
-            color: var(--color-error);
-        }
-    }
-
-    &--secondary {
-        .c-radio-group__item {
-            border: solid 1px var(--color-secondary);
+            &:focus {
+                box-shadow: $shadow-focus-s;
+            }
         }
 
-        .c-radio-group__indicator {
+        &__indicator {
+            position: relative;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+
             &::after {
-                background-color: var(--color-secondary);
+                display: block;
+                width: calc($radio-size * $radio-indicator-diff);
+                height: calc($radio-size * $radio-indicator-diff);
+                background-color: var(--color-quaternary);
+                border-radius: $rad;
+                content: "";
+            }
+        }
+
+        &--error {
+            .c-radio-group__item {
+                background-color: var(--color-error-20);
+                border: solid 1px var(--color-error);
+            }
+
+            .c-radio-group__error-message {
+                color: var(--color-error);
+            }
+        }
+
+        &--secondary {
+            .c-radio-group__item {
+                border: solid 1px var(--color-secondary);
+            }
+
+            .c-radio-group__indicator {
+                &::after {
+                    background-color: var(--color-secondary);
+                }
+            }
+
+            .c-label {
+                font-weight: $fw-bold;
+            }
+
+            &[data-disabled] {
+                .c-radio-group__item {
+                    border: solid 1px var(--color-quinary);
+                }
             }
         }
 
         .c-label {
-            font-weight: $fw-bold;
+            padding-left: $space-xs;
         }
 
         &[data-disabled] {
-            .c-radio-group__item {
-                border: solid 1px var(--color-quinary);
-            }
+            color: var(--color-neutral-500);
+            pointer-events: none;
         }
-    }
-
-    .c-label {
-        padding-left: $space-xs;
-    }
-
-    &[data-disabled] {
-        color: var(--color-neutral-500);
-        pointer-events: none;
     }
 }

--- a/packages/osc-ui/src/components/Select/select.scss
+++ b/packages/osc-ui/src/components/Select/select.scss
@@ -3,163 +3,165 @@
 @use "../../styles/tools" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-.c-select {
-    --secondary-background-color: var(--color-quinary);
+@layer components {
+    .c-select {
+        --secondary-background-color: var(--color-quinary);
 
-    width: inherit;
-
-    .c-label {
-        cursor: pointer;
-    }
-
-    &__trigger {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
         width: inherit;
-        height: $space-2xl;
-        padding: 0 $space-s;
-        background-color: var(--color-tertiary);
-        border: 1px solid var(--color-quinary);
-        cursor: pointer;
 
-        &:hover {
-            background-color: var(--color-neutral-300);
+        .c-label {
+            cursor: pointer;
         }
 
-        &:focus {
-            box-shadow: $shadow-focus-s;
-        }
-
-        &[data-placeholder] {
-            color: var(--color-secondary);
-        }
-
-        &[data-disabled] {
-            background-color: var(--color-neutral-200);
-            color: var(--color-neutral-500);
-            pointer-events: none;
-        }
-    }
-
-    &__content {
-        overflow: hidden;
-        background-color: var(--color-tertiary);
-        box-shadow: $shadow-l, $shadow-s;
-
-        @include z-index(select);
-
-        .c-select__scroll-button {
+        &__trigger {
             display: flex;
             align-items: center;
-            justify-content: center;
-            height: $space-l;
+            justify-content: space-between;
+            width: inherit;
+            height: $space-2xl;
+            padding: 0 $space-s;
             background-color: var(--color-tertiary);
-            cursor: default;
+            border: 1px solid var(--color-quinary);
+            cursor: pointer;
+
+            &:hover {
+                background-color: var(--color-neutral-300);
+            }
+
+            &:focus {
+                box-shadow: $shadow-focus-s;
+            }
+
+            &[data-placeholder] {
+                color: var(--color-secondary);
+            }
+
+            &[data-disabled] {
+                background-color: var(--color-neutral-200);
+                color: var(--color-neutral-500);
+                pointer-events: none;
+            }
         }
 
-        .c-select__viewport {
-            padding: $space-2xs;
-        }
-    }
+        &__content {
+            overflow: hidden;
+            background-color: var(--color-tertiary);
+            box-shadow: $shadow-l, $shadow-s;
 
-    &__item {
-        position: relative;
-        display: flex;
-        align-items: center;
-        min-height: $space-xl;
-        padding: 0 $space-xl 0 $space-xl;
-        user-select: none;
-
-        &[data-highlighted] {
-            background-color: var(--color-neutral-300);
-        }
-
-        &[data-disabled] {
-            color: var(--color-neutral-500);
-        }
-
-        .c-select__item-indicator {
-            position: absolute;
-            left: 0;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            width: 2rem;
-        }
-    }
-
-    &--inline {
-        display: flex;
-        align-items: center;
-        gap: $space-s;
-    }
-
-    &--bold {
-        .c-label {
-            font-weight: $fw-bold;
-        }
-    }
-
-    &--secondary {
-        .c-select__trigger {
-            background-color: var(--secondary-background-color);
-        }
-
-        .c-select__content {
-            background-color: var(--secondary-background-color);
+            @include z-index(select);
 
             .c-select__scroll-button {
-                background-color: var(--secondary-background-color);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                height: $space-l;
+                background-color: var(--color-tertiary);
+                cursor: default;
+            }
+
+            .c-select__viewport {
+                padding: $space-2xs;
             }
         }
 
-        .c-select__item[data-highlighted] {
-            background-color: var(--color-neutral-200);
-        }
-
-        .c-label {
-            font-weight: $fw-bold;
-        }
-    }
-
-    &--tertiary {
-        .c-select__trigger {
-            flex: 1;
-            padding: 0;
-            background: none;
-            border: none;
+        &__item {
+            position: relative;
+            display: flex;
+            align-items: center;
+            min-height: $space-xl;
+            padding: 0 $space-xl 0 $space-xl;
+            user-select: none;
 
             &[data-highlighted] {
-                background: none;
+                background-color: var(--color-neutral-300);
+            }
+
+            &[data-disabled] {
+                color: var(--color-neutral-500);
+            }
+
+            .c-select__item-indicator {
+                position: absolute;
+                left: 0;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 2rem;
             }
         }
-    }
 
-    &--error {
-        .c-select__trigger {
-            background-color: var(--color-error-20);
-            border: 1px solid var(--color-error);
+        &--inline {
+            display: flex;
+            align-items: center;
+            gap: $space-s;
         }
 
-        .c-select__icon {
-            color: var(--color-error);
+        &--bold {
+            .c-label {
+                font-weight: $fw-bold;
+            }
         }
 
-        .c-select__error-message {
-            color: var(--color-error);
-            font-size: var(--select-font-size);
-        }
-
-        &.c-select--tertiary {
+        &--secondary {
             .c-select__trigger {
+                background-color: var(--secondary-background-color);
+            }
+
+            .c-select__content {
+                background-color: var(--secondary-background-color);
+
+                .c-select__scroll-button {
+                    background-color: var(--secondary-background-color);
+                }
+            }
+
+            .c-select__item[data-highlighted] {
+                background-color: var(--color-neutral-200);
+            }
+
+            .c-label {
+                font-weight: $fw-bold;
+            }
+        }
+
+        &--tertiary {
+            .c-select__trigger {
+                flex: 1;
+                padding: 0;
                 background: none;
                 border: none;
+
+                &[data-highlighted] {
+                    background: none;
+                }
+            }
+        }
+
+        &--error {
+            .c-select__trigger {
+                background-color: var(--color-error-20);
+                border: 1px solid var(--color-error);
+            }
+
+            .c-select__icon {
                 color: var(--color-error);
             }
 
-            .c-select--error {
-                display: none;
+            .c-select__error-message {
+                color: var(--color-error);
+                font-size: var(--select-font-size);
+            }
+
+            &.c-select--tertiary {
+                .c-select__trigger {
+                    background: none;
+                    border: none;
+                    color: var(--color-error);
+                }
+
+                .c-select--error {
+                    display: none;
+                }
             }
         }
     }

--- a/packages/osc-ui/src/components/SkipLink/skip-link.scss
+++ b/packages/osc-ui/src/components/SkipLink/skip-link.scss
@@ -1,21 +1,23 @@
 @import "../../styles/settings";
 @import "../../styles/tools";
 
-.c-skip-link {
-    position: absolute;
-    top: -100%;
-    left: -100%;
+@layer components {
+    .c-skip-link {
+        position: absolute;
+        top: -100%;
+        left: -100%;
 
-    @include z-index("skip-link");
+        @include z-index("skip-link");
 
-    padding: $space-s $space-m;
-    background-color: var(--color-duodenary);
-    border: 5px solid currentcolor;
-    color: var(--color-secondary);
+        padding: $space-s $space-m;
+        background-color: var(--color-duodenary);
+        border: 5px solid currentcolor;
+        color: var(--color-secondary);
 
-    &:focus {
-        position: static;
-        display: block;
-        text-decoration: underline;
+        &:focus {
+            position: static;
+            display: block;
+            text-decoration: underline;
+        }
     }
 }

--- a/packages/osc-ui/src/components/Slider/slider.scss
+++ b/packages/osc-ui/src/components/Slider/slider.scss
@@ -3,83 +3,108 @@
 @import "../../styles/settings";
 /* stylelint-disable plugin/selector-bem-pattern */
 
-.c-slider {
-    position: relative;
-    display: flex;
-    align-items: center;
-    width: 100%;
-    cursor: pointer;
-    user-select: none;
-    touch-action: none;
-
-    &[data-orientation="horizontal"] {
-        height: 20px;
-    }
-
-    &[data-disabled] {
-        .c-slider__range {
-            background-color: var(--color-neutral-600);
-        }
-
-        .c-slider__thumb {
-            border: solid 2px var(--color-neutral-400);
-        }
-    }
-
-    &__track {
+@layer components {
+    .c-slider {
         position: relative;
-        flex-grow: 1;
-        background-color: var(--color-neutral-400);
-        border-radius: $rad-l;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        cursor: pointer;
+        user-select: none;
+        touch-action: none;
 
         &[data-orientation="horizontal"] {
-            height: 6px;
+            height: 20px;
         }
-    }
 
-    &__range {
-        position: absolute;
-        height: 100%;
-        background-color: var(--color-primary);
-        border-radius: $rad-l;
-    }
+        &[data-disabled] {
+            .c-slider__range {
+                background-color: var(--color-neutral-600);
+            }
 
-    &__thumb {
-        display: block;
-        width: 1em;
-        height: 1em;
-        background-color: var(--color-tertiary);
-        border: solid 2px var(--color-primary);
-        border-radius: $rad;
-        box-shadow: $shadow-xs;
+            .c-slider__thumb {
+                border: solid 2px var(--color-neutral-400);
+            }
+        }
+
+        &__track {
+            position: relative;
+            flex-grow: 1;
+            background-color: var(--color-neutral-400);
+            border-radius: $rad-l;
+
+            &[data-orientation="horizontal"] {
+                height: 6px;
+            }
+        }
+
+        &__range {
+            position: absolute;
+            height: 100%;
+            background-color: var(--color-primary);
+            border-radius: $rad-l;
+        }
+
+        &__thumb {
+            display: block;
+            width: 1em;
+            height: 1em;
+            background-color: var(--color-tertiary);
+            border: solid 2px var(--color-primary);
+            border-radius: $rad;
+            box-shadow: $shadow-xs;
+
+            &:hover {
+                background-color: var(--color-neutral-200);
+            }
+
+            &:focus {
+                outline: none;
+                box-shadow: $shadow-focus-s;
+
+                .c-slider__value {
+                    transform: scale(1);
+                    transition: $timing-s ease-in-out;
+                }
+            }
+        }
+
+        &__value {
+            position: relative;
+            top: -42px;
+            display: flex;
+            justify-content: center;
+            width: max-content;
+            padding: 0.25em 0.375em;
+            background-color: var(--color-secondary);
+            color: var(--color-tertiary);
+            font-size: $fs-s;
+            transform: scale(0);
+            transition: $timing-s ease-in-out;
+
+            &--arrow {
+                position: absolute;
+                bottom: -8px;
+                width: 0;
+                height: 0;
+                border-top: 8px solid var(--color-secondary);
+                border-right: 8px solid transparent;
+                border-left: 8px solid transparent;
+            }
+        }
 
         &:hover {
-            background-color: var(--color-neutral-200);
-        }
-
-        &:focus {
-            outline: none;
-            box-shadow: $shadow-focus-s;
-
             .c-slider__value {
                 transform: scale(1);
                 transition: $timing-s ease-in-out;
             }
         }
-    }
 
-    &__value {
-        position: relative;
-        top: -42px;
-        display: flex;
-        justify-content: center;
-        width: max-content;
-        padding: 0.25em 0.375em;
-        background-color: var(--color-secondary);
-        color: var(--color-tertiary);
-        font-size: $fs-s;
-        transform: scale(0);
-        transition: $timing-s ease-in-out;
+        .c-slider__value-container {
+            display: flex;
+            justify-content: center;
+            cursor: pointer;
+        }
 
         &--arrow {
             position: absolute;
@@ -90,28 +115,5 @@
             border-right: 8px solid transparent;
             border-left: 8px solid transparent;
         }
-    }
-
-    &:hover {
-        .c-slider__value {
-            transform: scale(1);
-            transition: $timing-s ease-in-out;
-        }
-    }
-
-    .c-slider__value-container {
-        display: flex;
-        justify-content: center;
-        cursor: pointer;
-    }
-
-    &--arrow {
-        position: absolute;
-        bottom: -8px;
-        width: 0;
-        height: 0;
-        border-top: 8px solid var(--color-secondary);
-        border-right: 8px solid transparent;
-        border-left: 8px solid transparent;
     }
 }

--- a/packages/osc-ui/src/components/Switch/switch.scss
+++ b/packages/osc-ui/src/components/Switch/switch.scss
@@ -2,142 +2,147 @@
 @import "../../styles/tools";
 @import "../../styles/settings";
 
-$switch-radius: $rad-l;
-$switch-thumb-offset: 1px;
-$switch-border-width: 1px;
-$switch-transition-duration: 0.2s;
+@layer components {
+    $switch-radius: $rad-l;
+    $switch-thumb-offset: 1px;
+    $switch-border-width: 1px;
+    $switch-transition-duration: 0.2s;
 
-.c-switch {
-    --switch-background-color: transparent;
-    --switch-thumb-color: var(--color-secondary);
-    --switch-width: #{rem($base-fs * 3.125)};
-    --switch-height: #{rem($base-fs * 1.75)};
-    --switch-thumb-size: #{rem($base-fs * 1.5)};
+    .c-switch {
+        --switch-background-color: transparent;
+        --switch-thumb-color: var(--color-secondary);
+        --switch-width: #{rem($base-fs * 3.125)};
+        --switch-height: #{rem($base-fs * 1.75)};
+        --switch-thumb-size: #{rem($base-fs * 1.5)};
 
-    position: relative;
-    width: var(--switch-width);
-    height: var(--switch-height);
-    background-color: var(--switch-background-color);
-    border: $switch-border-width solid var(--switch-thumb-color);
-    border-radius: $switch-radius;
-    transition: filter $switch-transition-duration;
-    cursor: pointer;
-
-    &:not([data-disabled]):hover {
-        filter: brightness(0.95);
-    }
-
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    &[data-disabled] {
-        --switch-thumb-color: var(--color-tertiary);
-        --switch-background-color: var(--color-quinary);
-
-        border-color: var(--switch-background-color);
-        cursor: not-allowed;
-    }
-
-    &[data-state="checked"] {
-        --switch-thumb-color: var(--color-primary);
-    }
-
-    &__thumb {
-        display: block;
-        width: var(--switch-thumb-size);
-        height: var(--switch-thumb-size);
-        background-color: var(--switch-thumb-color);
+        position: relative;
+        width: var(--switch-width);
+        height: var(--switch-height);
+        background-color: var(--switch-background-color);
+        border: $switch-border-width solid var(--switch-thumb-color);
         border-radius: $switch-radius;
-        transform: translateX($switch-thumb-offset);
-        transition: transform $switch-transition-duration;
-        will-change: transform;
+        transition: filter $switch-transition-duration;
+        cursor: pointer;
+
+        &:not([data-disabled]):hover {
+            filter: brightness(0.95);
+        }
+
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        &[data-disabled] {
+            --switch-thumb-color: var(--color-tertiary);
+            --switch-background-color: var(--color-quinary);
+
+            border-color: var(--switch-background-color);
+            cursor: not-allowed;
+        }
 
         &[data-state="checked"] {
-            transform:
-                // width of the switch minus the width of the thumb size minus the border plus the offset
-                // we multiply the border by 2 because we have a border on the left and right
-                translateX(
-                    calc(var(--switch-width) - var(--switch-thumb-size) - (($switch-border-width * 2) + $switch-thumb-offset))
-                );
+            --switch-thumb-color: var(--color-primary);
+        }
+
+        &__thumb {
+            display: block;
+            width: var(--switch-thumb-size);
+            height: var(--switch-thumb-size);
+            background-color: var(--switch-thumb-color);
+            border-radius: $switch-radius;
+            transform: translateX($switch-thumb-offset);
+            transition: transform $switch-transition-duration;
+            will-change: transform;
+
+            &[data-state="checked"] {
+                // prettier-ignore
+                transform:
+                    // width of the switch minus the width of the thumb size minus the border plus the offset
+                    // we multiply the border by 2 because we have a border on the left and right
+                    translateX(
+                        calc(var(--switch-width) - var(--switch-thumb-size) - (($switch-border-width * 2) + $switch-thumb-offset))
+                    );
+            }
+        }
+
+        // *----------------------------------*/
+        //  Variants
+        // --primary is the default
+        // *----------------------------------*/
+        &--secondary {
+            /* stylelint-disable-next-line selector-class-pattern */
+            .c-switch__thumb {
+                display: grid;
+                place-items: center;
+                color: var(--color-tertiary);
+            }
+
+            /* stylelint-disable-next-line selector-class-pattern */
+            .c-switch__thumb-icon {
+                width: 1em;
+                height: 1em;
+                font-size: $fs-m;
+                transition:
+                    opacity $switch-transition-duration,
+                    visibility $switch-transition-duration;
+                opacity: 0;
+                visibility: hidden;
+            }
+
+            &[data-state="checked"] {
+                /* stylelint-disable-next-line selector-class-pattern */
+                .c-switch__thumb-icon {
+                    opacity: 1;
+                    visibility: visible;
+                }
+            }
+        }
+
+        &--error {
+            background-color: var(--color-error-20);
+            border-color: var(--color-error);
+            /* stylelint-disable-next-line selector-class-pattern */
+            .c-switch__thumb {
+                background-color: var(--color-error);
+            }
+        }
+
+        // *----------------------------------*/
+        //  Sizes
+        // --large is the default
+        // *----------------------------------*/
+        &--small {
+            --switch-width: #{rem($base-fs * 2.125)};
+            --switch-height: #{rem($base-fs)};
+            --switch-thumb-size: #{rem($base-fs * 0.75)};
+        }
+
+        &--medium {
+            --switch-width: #{rem($base-fs * 2.125)};
+            --switch-height: #{rem($base-fs * 1.25)};
+            --switch-thumb-size: #{rem($base-fs)};
         }
     }
 
     // *----------------------------------*/
-    //  Variants
-    // --primary is the default
+    //  Switch group
     // *----------------------------------*/
-    &--secondary {
-        /* stylelint-disable-next-line selector-class-pattern */
-        .c-switch__thumb {
-            display: grid;
-            place-items: center;
-            color: var(--color-tertiary);
-        }
+    .c-switch-group {
+        display: flex;
+        align-items: center;
+        gap: $space-2xs;
 
-        /* stylelint-disable-next-line selector-class-pattern */
-        .c-switch__thumb-icon {
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        > svg {
             width: 1em;
             height: 1em;
             font-size: $fs-m;
-            transition: opacity $switch-transition-duration, visibility $switch-transition-duration;
-            opacity: 0;
-            visibility: hidden;
+            transition: color $switch-transition-duration;
         }
 
-        &[data-state="checked"] {
-            /* stylelint-disable-next-line selector-class-pattern */
-            .c-switch__thumb-icon {
-                opacity: 1;
-                visibility: visible;
+        /* stylelint-disable-next-line no-descending-specificity */
+        .c-switch {
+            /* stylelint-disable-next-line plugin/selector-bem-pattern */
+            &[data-state="checked"] + svg {
+                color: var(--color-primary);
             }
-        }
-    }
-
-    &--error {
-        background-color: var(--color-error-20);
-        border-color: var(--color-error);
-        /* stylelint-disable-next-line selector-class-pattern */
-        .c-switch__thumb {
-            background-color: var(--color-error);
-        }
-    }
-
-    // *----------------------------------*/
-    //  Sizes
-    // --large is the default
-    // *----------------------------------*/
-    &--small {
-        --switch-width: #{rem($base-fs * 2.125)};
-        --switch-height: #{rem($base-fs)};
-        --switch-thumb-size: #{rem($base-fs * 0.75)};
-    }
-
-    &--medium {
-        --switch-width: #{rem($base-fs * 2.125)};
-        --switch-height: #{rem($base-fs * 1.25)};
-        --switch-thumb-size: #{rem($base-fs)};
-    }
-}
-
-// *----------------------------------*/
-//  Switch group
-// *----------------------------------*/
-.c-switch-group {
-    display: flex;
-    align-items: center;
-    gap: $space-2xs;
-
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    > svg {
-        width: 1em;
-        height: 1em;
-        font-size: $fs-m;
-        transition: color $switch-transition-duration;
-    }
-
-    /* stylelint-disable-next-line no-descending-specificity */
-    .c-switch {
-        /* stylelint-disable-next-line plugin/selector-bem-pattern */
-        &[data-state="checked"] + svg {
-            color: var(--color-primary);
         }
     }
 }

--- a/packages/osc-ui/src/components/Tabs/tabs.scss
+++ b/packages/osc-ui/src/components/Tabs/tabs.scss
@@ -1,5 +1,7 @@
 @import "../../styles/settings";
 
-.c-tabs {
-    background-color: var(--color-tertiary);
+@layer components {
+    .c-tabs {
+        background-color: var(--color-tertiary);
+    }
 }

--- a/packages/osc-ui/src/components/Tag/tag.scss
+++ b/packages/osc-ui/src/components/Tag/tag.scss
@@ -1,14 +1,16 @@
 @import "../../styles/settings";
 
-.c-tag {
-    display: flex;
-    align-items: center;
-    background-color: var(--colour-primary);
-    color: var(--colour-tertiary);
+@layer components {
+    .c-tag {
+        display: flex;
+        align-items: center;
+        background-color: var(--colour-primary);
+        color: var(--colour-tertiary);
 
-    /* stylelint-disable-next-line plugin/selector-bem-pattern */
-    * + &__content,
-    &__content + * {
-        margin-inline-start: 0.5em;
+        /* stylelint-disable-next-line plugin/selector-bem-pattern */
+        * + &__content,
+        &__content + * {
+            margin-inline-start: 0.5em;
+        }
     }
 }

--- a/packages/osc-ui/src/components/TextArea/text-area.scss
+++ b/packages/osc-ui/src/components/TextArea/text-area.scss
@@ -1,5 +1,8 @@
 /* stylelint-disable plugin/selector-bem-pattern */
-.c-textarea {
-    resize: vertical;
-    scrollbar-gutter: stable;
+
+@layer components {
+    .c-textarea {
+        resize: vertical;
+        scrollbar-gutter: stable;
+    }
 }

--- a/packages/osc-ui/src/components/TextInput/text-input.scss
+++ b/packages/osc-ui/src/components/TextInput/text-input.scss
@@ -3,153 +3,155 @@
 @use "../../styles/settings" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
-$input-py: calc($space-2xs - 3px);
-$input-pr: $space-xl;
-$input-pl: $space-l;
-$label-transform-up: translate(0, -1.25em) scale(0.8);
+@layer component {
+    $input-py: calc($space-2xs - 3px);
+    $input-pr: $space-xl;
+    $input-pl: $space-l;
+    $label-transform-up: translate(0, -1.25em) scale(0.8);
 
-.c-input {
-    display: flex;
-    order: 1;
-    padding: $input-py $input-pr $input-py $input-pl;
-    border: solid 1px var(--color-quinary);
-    cursor: text;
-    grid-column: 1;
-    grid-row: 2;
-
-    &__icon {
-        justify-self: end;
-        align-self: center;
-        grid-row: 2;
-        grid-column: 1;
-        padding-right: $space-xs;
-    }
-
-    &:focus {
-        box-shadow: $shadow-focus-s;
-    }
-
-    &[disabled] {
-        background-color: var(--color-neutral-100);
-        color: var(--color-neutral-500);
-
-        & + .c-label {
-            pointer-events: none;
-        }
-    }
-
-    &__outer-container {
+    .c-input {
         display: flex;
-    }
+        order: 1;
+        padding: $input-py $input-pr $input-py $input-pl;
+        border: solid 1px var(--color-quinary);
+        cursor: text;
+        grid-column: 1;
+        grid-row: 2;
 
-    &__container {
-        display: grid;
-        width: 100%;
-
-        .c-label {
-            grid-row: 1;
+        &__icon {
+            justify-self: end;
+            align-self: center;
+            grid-row: 2;
             grid-column: 1;
+            padding-right: $space-xs;
         }
 
-        &--secondary {
-            .c-input {
-                border-radius: $rad-xs;
+        &:focus {
+            box-shadow: $shadow-focus-s;
+        }
+
+        &[disabled] {
+            background-color: var(--color-neutral-100);
+            color: var(--color-neutral-500);
+
+            & + .c-label {
+                pointer-events: none;
             }
         }
 
-        &--tertiary,
-        &--quaternary {
-            position: relative;
+        &__outer-container {
+            display: flex;
+        }
+
+        &__container {
+            display: grid;
+            width: 100%;
 
             .c-label {
-                display: flex;
-                align-items: center;
-                grid-row: 2;
-                transform-origin: top left;
-                transition: $timing-s ease-in-out;
-                pointer-events: none;
+                grid-row: 1;
+                grid-column: 1;
+            }
 
-                &.c-label--filled {
-                    top: 10px;
+            &--secondary {
+                .c-input {
+                    border-radius: $rad-xs;
+                }
+            }
+
+            &--tertiary,
+            &--quaternary {
+                position: relative;
+
+                .c-label {
+                    display: flex;
+                    align-items: center;
+                    grid-row: 2;
+                    transform-origin: top left;
+                    transition: $timing-s ease-in-out;
+                    pointer-events: none;
+
+                    &.c-label--filled {
+                        top: 10px;
+                        transform: $label-transform-up;
+                    }
+                }
+
+                .c-input {
+                    &__text {
+                        border: none;
+                        border-bottom: solid 2px var(--color-secondary);
+                    }
+
+                    &[disabled] {
+                        background: none;
+                        pointer-events: cursor;
+                        border-bottom: solid 2px var(--color-neutral-500);
+
+                        + .c-label {
+                            color: var(--color-neutral-500);
+                        }
+                    }
+                }
+
+                .c-input:focus {
+                    box-shadow: none;
+                }
+
+                .c-input:focus + .c-label {
                     transform: $label-transform-up;
                 }
             }
 
-            .c-input {
-                &__text {
-                    border: none;
-                    border-bottom: solid 2px var(--color-secondary);
-                }
-
-                &[disabled] {
-                    background: none;
-                    pointer-events: cursor;
-                    border-bottom: solid 2px var(--color-neutral-500);
-
-                    + .c-label {
-                        color: var(--color-neutral-500);
-                    }
-                }
-            }
-
-            .c-input:focus {
-                box-shadow: none;
-            }
-
-            .c-input:focus + .c-label {
-                transform: $label-transform-up;
-            }
-        }
-
-        &--quaternary {
-            .c-input {
-                padding: $input-py $input-pr $input-py 0;
-                color: var(--color-neutral-600);
-            }
-        }
-
-        &--quaternary + .c-input__button {
-            cursor: pointer;
-
-            svg {
-                width: 2em;
-                height: 2em;
-            }
-        }
-
-        &--error {
-            .c-input {
-                background-color: var(--color-error-20);
-                border: 1px solid var(--color-error);
-                box-shadow: $shadow-error;
-
-                &__error-message {
-                    display: flex;
-                    order: 2;
-                    color: var(--color-error);
-                    grid-row: 3;
-                    grid-column: 1;
-                }
-
-                &__icon {
-                    &--error {
-                        color: var(--color-error);
-                    }
-                }
-            }
-
-            &.c-input__container--tertiary {
+            &--quaternary {
                 .c-input {
-                    background: none;
-                    border: none;
-                    border-bottom: solid 0.125em var(--color-error);
-                    box-shadow: none;
+                    padding: $input-py $input-pr $input-py 0;
+                    color: var(--color-neutral-600);
+                }
+            }
+
+            &--quaternary + .c-input__button {
+                cursor: pointer;
+
+                svg {
+                    width: 2em;
+                    height: 2em;
+                }
+            }
+
+            &--error {
+                .c-input {
+                    background-color: var(--color-error-20);
+                    border: 1px solid var(--color-error);
+                    box-shadow: $shadow-error;
+
+                    &__error-message {
+                        display: flex;
+                        order: 2;
+                        color: var(--color-error);
+                        grid-row: 3;
+                        grid-column: 1;
+                    }
+
+                    &__icon {
+                        &--error {
+                            color: var(--color-error);
+                        }
+                    }
+                }
+
+                &.c-input__container--tertiary {
+                    .c-input {
+                        background: none;
+                        border: none;
+                        border-bottom: solid 0.125em var(--color-error);
+                        box-shadow: none;
+                    }
                 }
             }
         }
-    }
 
-    .c-label {
-        cursor: text;
+        .c-label {
+            cursor: text;
+        }
     }
 }

--- a/packages/osc-ui/src/components/VideoPlayer/video-player.scss
+++ b/packages/osc-ui/src/components/VideoPlayer/video-player.scss
@@ -3,124 +3,126 @@
 @use "../../styles/settings" as *;
 @use "../../styles/tools" as *;
 
-$play-btn-size: $base-fs * 5px;
-$play-btn-color: var(--color-tertiary);
-$play-btn-radius: $rad-l;
-$play-btn-icon-size: rem($base-fs * 2);
+@layer components {
+    $play-btn-size: $base-fs * 5px;
+    $play-btn-color: var(--color-tertiary);
+    $play-btn-radius: $rad-l;
+    $play-btn-icon-size: rem($base-fs * 2);
 
-/* stylelint-disable-next-line selector-class-pattern */
-.react-player__preview {
-    &:focus {
-        box-shadow: $shadow-focus;
+    /* stylelint-disable-next-line selector-class-pattern */
+    .react-player__preview {
+        &:focus {
+            box-shadow: $shadow-focus;
 
-        &:not(:focus-visible) {
-            box-shadow: none;
-        }
-    }
-}
-
-.c-video-player {
-    $self: &;
-
-    position: relative;
-    display: grid;
-    grid-template-rows: repeat(3, minmax(0, 1fr));
-    max-width: 100%;
-
-    &__wrapper,
-    &__btn,
-    &__content {
-        grid-column: 1;
-    }
-
-    &__btn,
-    &__content,
-    &__overlay {
-        transition: opacity $timing-s $ease-in;
-        opacity: 1;
-
-        &,
-        & * {
-            // make sure we can click through overlaying content and still control the video
-            pointer-events: none;
+            &:not(:focus-visible) {
+                box-shadow: none;
+            }
         }
     }
 
-    &__btn,
-    &__overlay {
-        &.is-hidden {
-            opacity: 0;
-        }
-    }
+    .c-video-player {
+        $self: &;
 
-    &__wrapper {
         position: relative;
-        width: 100%;
-        min-height: 200px;
-        max-height: 600px;
-        background-color: var(--color-secondary);
-        grid-row: 1 / -1;
-
-        @include mq($mq-tab) {
-            @include ratio(16 9);
-        }
-    }
-
-    &__btn {
         display: grid;
-        grid-row: 2;
-        place-self: center;
-        width: $play-btn-size;
-        height: $play-btn-size;
-        border: 2px solid $play-btn-color;
-        border-radius: $play-btn-radius;
-        color: $play-btn-color;
-        font-size: $play-btn-icon-size;
-        place-items: center;
-        cursor: pointer;
+        grid-template-rows: repeat(3, minmax(0, 1fr));
+        max-width: 100%;
 
-        @include z-index("button");
-
-        > .o-icon {
-            position: relative;
-            left: 3px; // offset the position to make it more visually aligned
-        }
-    }
-
-    &__content {
-        background-color: var(--color-quinary);
-        color: var(--color-secondary);
-
-        @include z-index("button");
-
-        @include mq($mq-tab) {
-            align-self: end;
-            background-color: transparent;
-            color: var(--color-tertiary);
-            grid-row: 3;
+        &__wrapper,
+        &__btn,
+        &__content {
+            grid-column: 1;
         }
 
-        // Only hide content on larger screens
-        &.is-hidden {
-            @include mq($mq-tab) {
+        &__btn,
+        &__content,
+        &__overlay {
+            transition: opacity $timing-s $ease-in;
+            opacity: 1;
+
+            &,
+            & * {
+                // make sure we can click through overlaying content and still control the video
+                pointer-events: none;
+            }
+        }
+
+        &__btn,
+        &__overlay {
+            &.is-hidden {
                 opacity: 0;
             }
         }
-    }
 
-    &__overlay {
-        grid-row: 1 / -1;
-        grid-column: 1 / -1;
-        z-index: 1;
+        &__wrapper {
+            position: relative;
+            width: 100%;
+            min-height: 200px;
+            max-height: 600px;
+            background-color: var(--color-secondary);
+            grid-row: 1 / -1;
 
-        &.has-content {
             @include mq($mq-tab) {
-                opacity: 1;
+                @include ratio(16 9);
             }
         }
-    }
 
-    .o-img {
-        object-fit: cover;
+        &__btn {
+            display: grid;
+            grid-row: 2;
+            place-self: center;
+            width: $play-btn-size;
+            height: $play-btn-size;
+            border: 2px solid $play-btn-color;
+            border-radius: $play-btn-radius;
+            color: $play-btn-color;
+            font-size: $play-btn-icon-size;
+            place-items: center;
+            cursor: pointer;
+
+            @include z-index("button");
+
+            > .o-icon {
+                position: relative;
+                left: 3px; // offset the position to make it more visually aligned
+            }
+        }
+
+        &__content {
+            background-color: var(--color-quinary);
+            color: var(--color-secondary);
+
+            @include z-index("button");
+
+            @include mq($mq-tab) {
+                align-self: end;
+                background-color: transparent;
+                color: var(--color-tertiary);
+                grid-row: 3;
+            }
+
+            // Only hide content on larger screens
+            &.is-hidden {
+                @include mq($mq-tab) {
+                    opacity: 0;
+                }
+            }
+        }
+
+        &__overlay {
+            grid-row: 1 / -1;
+            grid-column: 1 / -1;
+            z-index: 1;
+
+            &.has-content {
+                @include mq($mq-tab) {
+                    opacity: 1;
+                }
+            }
+        }
+
+        .o-img {
+            object-fit: cover;
+        }
     }
 }

--- a/packages/osc-ui/src/styles/main.scss
+++ b/packages/osc-ui/src/styles/main.scss
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+@use "sass:meta";
 
 /* =============================================================================
    Primary styles
@@ -16,32 +17,50 @@
 	6 	$UTILITIES
 */
 
+@layer
+    generics,
+    theme,
+    elements,
+    objects,
+    typography,
+    components,
+    utilities;
+
 /* ============================
 // $GENERIC
 // High Level Styles i.e. Normalize//CSS Resets
 // --- Can be employed across multiple sites without the need to edit or adjust
 */
-@use "generic/reset";
-@use "generic/normalize";
+
+@layer generics {
+    @include meta.load-css("generic/reset");
+    @include meta.load-css("generic/normalize");
+}
 
 /* ============================
 // $THEME
 // Define your colour themes
 */
-@use "theme/theme";
+
+@layer theme {
+    @include meta.load-css("theme/theme");
+}
 
 /* ============================
 // $ELEMENTS
 // Single HTML element selectors without classes
 */
-@use "elements/address";
-@use "elements/iframe";
-@use "elements/image";
-@use "elements/input";
-@use "elements/list";
-@use "elements/page";
-@use "elements/table";
-@use "elements/type";
+
+@layer elements {
+    @include meta.load-css("elements/address");
+    @include meta.load-css("elements/iframe");
+    @include meta.load-css("elements/image");
+    @include meta.load-css("elements/input");
+    @include meta.load-css("elements/list");
+    @include meta.load-css("elements/page");
+    @include meta.load-css("elements/table");
+    @include meta.load-css("elements/type");
+}
 
 /* ============================
 // $OBJECTS
@@ -49,31 +68,37 @@
 // The first layer in which we find class-level specificity
 */
 
-@use "objects/ar";
-@use "objects/container";
-@use "objects/flex";
-@use "objects/img";
-@use "objects/media";
-@use "objects/row";
-@use "objects/grid";
-@use "objects/bg";
-@use "objects/list" as objects-list;
-@use "objects/main";
-@use "objects/icon";
+@layer objects {
+    @include meta.load-css("objects/ar");
+    @include meta.load-css("objects/container");
+    @include meta.load-css("objects/flex");
+    @include meta.load-css("objects/img");
+    @include meta.load-css("objects/media");
+    @include meta.load-css("objects/row");
+    @include meta.load-css("objects/grid");
+    @include meta.load-css("objects/bg");
+    @include meta.load-css("objects/list");
+    @include meta.load-css("objects/main");
+    @include meta.load-css("objects/icon");
+}
 
 /* ============================
 // $TYPOGRAPHY
 // Classes for the display and control of your typography.
 // These elements sit loosely between objects and components and in turn can be overridden on a piece of UI
 */
-@use "typography/font";
+
+@layer typography {
+    @include meta.load-css("typography/font");
+}
 
 /* ============================
 //	$COMPONENTS
 //  Classes for styling any & all UI elements (often combined with the structure of object classes)
 //  Keep to DRY principles  ( [D]ont [R]epeat [Y]ourself )
 */
-@use "components/spinner";
+
+// OUR SCSS COMPONENT STYLES ARE LOADED VIA OUR UI LIBRARY, @OSC-UI //
 
 /* ============================
 // $UTILITIES
@@ -81,5 +106,8 @@
 // Eliminates the need to create specific classes to perform simple tasks
 // NOTE: Use sparingly
 */
-@use "utilities/util";
-@use "utilities/anim";
+
+@layer utilities {
+    @include meta.load-css("utilities/util");
+    @include meta.load-css("utilities/anim");
+}

--- a/packages/osc-ui/src/styles/utilities/_util.scss
+++ b/packages/osc-ui/src/styles/utilities/_util.scss
@@ -4,6 +4,7 @@
 @use "../tools" as *;
 @use "../tools/functions" as *;
 
+
 ///*----------------------------------*\
 //  #UTILITIES
 //\*----------------------------------*/
@@ -183,7 +184,7 @@ $osc-config: (
 
 [hidden] {
     // stylelint-disable-next-line declaration-no-important
-    display: none !important;
+    display: none;
 }
 
 .u-hidden {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Introduces the new `@layer` CSS at-rule to help combat the cascade problems caused by OSC UI

## ⛳️ Current behavior (updates)

Currently, all of our Component's `scss` sit outside of our sass styles structure. This means if we attempt to override a component style using a utility class it is unable to do so due to the component scss being further in the cascade and therefore taking a higher specificity/priority resulting in the use of `!important` which goes against our coding standards.

## 🚀 New behavior

By wrapping `@layer components` around our components styles we are now able to control the order of the cascade which is defined in the `/styles/main.scss` in osc-ui.
Example the below layer stack is order by lowest > highest specificity:
```
@layer
    generics,
    theme,
    elements,
    objects,
    typography,
    components,
    utilities;
```

## 💣 Is this a breaking change (Yes/No):

Where the use of `!important` was utilised to override visual styles on components, components created outside of this PR will require the `@layer components` at-rule to reinstate their priority and fix any breakges in visuals.

## 📝 Additional Information
To implement this simplay wrap your scss with the `@layer components` at-rule as below:

Before:
```
.c-tag {
    display: flex;
}
```

After:
```
@layer components {
    .c-tag {
        display: flex;
    }
}
```