### PR TITLE
Feature/react testing library custom renderer utility

### DIFF
--- a/packages/osc-ui/__test__/test-utils.tsx
+++ b/packages/osc-ui/__test__/test-utils.tsx
@@ -1,0 +1,20 @@
+import type { RenderOptions } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { SpritesheetProvider } from '../src/components/Icon/Icon';
+
+const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
+    return (
+        <MemoryRouter>
+            <SpritesheetProvider>{children}</SpritesheetProvider>
+        </MemoryRouter>
+    );
+};
+
+const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+    render(ui, { wrapper: AllTheProviders, ...options });
+
+export * from '@testing-library/react';
+export { customRender as render };

--- a/packages/osc-ui/src/components/Accordion/Accordion.spec.tsx
+++ b/packages/osc-ui/src/components/Accordion/Accordion.spec.tsx
@@ -1,11 +1,7 @@
-/**
- * @vitest-environment jsdom
- */
-
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { render } from 'test-utils';
 import { Content } from '../Content/Content';
 import { textContent } from '../Content/textContent';
 import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from './Accordion';
@@ -80,16 +76,14 @@ test('accepts content component as child', async () => {
     const user = userEvent.setup();
 
     render(
-        <MemoryRouter>
-            <Accordion type="single" className="accordion-classname">
-                <AccordionItem value="0" className="item-classname">
-                    <AccordionHeader className="heading-classname">Heading level 2</AccordionHeader>
-                    <AccordionPanel className="panel-classname">
-                        <Content value={textContent} align="left" />
-                    </AccordionPanel>
-                </AccordionItem>
-            </Accordion>
-        </MemoryRouter>
+        <Accordion type="single" className="accordion-classname">
+            <AccordionItem value="0" className="item-classname">
+                <AccordionHeader className="heading-classname">Heading level 2</AccordionHeader>
+                <AccordionPanel className="panel-classname">
+                    <Content value={textContent} align="left" />
+                </AccordionPanel>
+            </AccordionItem>
+        </Accordion>
     );
 
     await user.click(screen.getByRole('button', { name: 'Heading level 2' }));

--- a/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/packages/osc-ui/src/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -1,26 +1,25 @@
+import { render } from 'test-utils';
+
 import { ChevronRightIcon } from '@radix-ui/react-icons';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import type { Props } from './Breadcrumb';
 import { Breadcrumb } from './Breadcrumb';
 
 describe('Breadcrumb component', () => {
     const setup = ({ className, matches, separator }: Props) =>
-        render(<Breadcrumb className={className} matches={matches} separator={separator} />, {
-            wrapper: MemoryRouter
-        });
+        render(<Breadcrumb className={className} matches={matches} separator={separator} />);
 
     const links = [
         { pathname: '/courses', title: 'courses' },
         { pathname: '/courses/biology', title: 'biology' },
-        { pathname: '/courses/biology/module-1', title: 'module 1' }
+        { pathname: '/courses/biology/module-1', title: 'module 1' },
     ];
 
     test('renders breadcrumbs with the correct titles', () => {
         setup({
             matches: links,
-            separator: '/'
+            separator: '/',
         });
         links.forEach((link) => {
             expect(screen.getByText(`${link.title}`)).toHaveTextContent(`${link.title}`);
@@ -30,7 +29,7 @@ describe('Breadcrumb component', () => {
     test('renders breadcrumbs with anchor tag and correct pathnames', () => {
         setup({
             matches: links,
-            separator: '/'
+            separator: '/',
         });
         expect(screen.getByRole('link', { name: `${links[0].title}` })).toHaveAttribute(
             'href',
@@ -42,7 +41,7 @@ describe('Breadcrumb component', () => {
     test('renders a breadcrumb without an anchor tag or pathname when it is the last breadcrumb', () => {
         setup({
             matches: links,
-            separator: '/'
+            separator: '/',
         });
         expect(screen.getByText(`${links[2].title}`)).not.toHaveAttribute(
             'href',
@@ -54,7 +53,7 @@ describe('Breadcrumb component', () => {
     test('renders a string separator that is passed in', () => {
         setup({
             matches: links,
-            separator: '/'
+            separator: '/',
         });
         expect(screen.getAllByRole('listitem')[0]).toHaveTextContent('/');
         expect(screen.getAllByRole('listitem')[1]).toHaveTextContent('/');
@@ -63,7 +62,7 @@ describe('Breadcrumb component', () => {
     test('renders an icon separator that is passed in', () => {
         setup({
             matches: links,
-            separator: <ChevronRightIcon />
+            separator: <ChevronRightIcon />,
         });
 
         expect(screen.getAllByRole('listitem')[0].childNodes[1].childNodes[0].nodeName).toBe('svg');

--- a/packages/osc-ui/src/components/Button/Button.spec.tsx
+++ b/packages/osc-ui/src/components/Button/Button.spec.tsx
@@ -1,11 +1,8 @@
-/**
- * @vitest-environment jsdom
- */
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { MouseEvent } from 'react';
 import React, { useState } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { render } from 'test-utils';
 import { Button, ButtonGroup, CopyButton } from './Button';
 
 describe('default button', () => {
@@ -110,11 +107,9 @@ describe('anchor button', () => {
 describe('link button', () => {
     test('has a href attribute', () => {
         render(
-            <MemoryRouter>
-                <Button as="link" to="/blog">
-                    Test Button
-                </Button>
-            </MemoryRouter>
+            <Button as="link" to="/blog">
+                Test Button
+            </Button>
         );
 
         expect(screen.getByRole('link')).toHaveAttribute('href', '/blog');
@@ -122,10 +117,10 @@ describe('link button', () => {
 
     test('href falls back to homepage url if `to` prop is missing', () => {
         render(
-            <MemoryRouter>
+            <>
                 {/* @ts-ignore -- we want to test that the to prop is missing, even though ts will shout */}
                 <Button as="link">Test Button</Button>
-            </MemoryRouter>
+            </>
         );
 
         expect(screen.getByRole('link')).toHaveAttribute('href', '/');

--- a/packages/osc-ui/src/components/Content/Content.spec.tsx
+++ b/packages/osc-ui/src/components/Content/Content.spec.tsx
@@ -1,15 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { render } from 'test-utils';
 import { Content } from './Content';
 import { textContent, textContentHasButtons } from './textContent';
 // TODO: sb - test background color -- think we need theme setup in storybook?
 test('renders the correct elements', () => {
-    render(
-        <MemoryRouter>
-            <Content value={textContent.body} />
-        </MemoryRouter>
-    );
+    render(<Content value={textContent.body} />);
 
     const h1 = screen.getByRole('heading', { level: 1 });
     const h2 = screen.getByRole('heading', { level: 2 });
@@ -46,73 +42,43 @@ test('renders the correct elements', () => {
 });
 
 test('renders the correct alignment class', () => {
-    const { rerender } = render(
-        <MemoryRouter>
-            <Content value={textContent.body} align="left" />
-        </MemoryRouter>
-    );
+    const { rerender } = render(<Content value={textContent.body} align="left" />);
     const contentInner = document.querySelector('.c-content__inner');
     expect(contentInner).toHaveClass('c-content__inner--left');
 
-    rerender(
-        <MemoryRouter>
-            <Content value={textContent.body} align="centre" />
-        </MemoryRouter>
-    );
+    rerender(<Content value={textContent.body} align="centre" />);
     expect(contentInner).toHaveClass('c-content__inner--centre');
 
-    rerender(
-        <MemoryRouter>
-            <Content value={textContent.body} align="right" />
-        </MemoryRouter>
-    );
+    rerender(<Content value={textContent.body} align="right" />);
     expect(contentInner).toHaveClass('c-content__inner--right');
 });
 
 test('renders a custom classname', () => {
-    render(
-        <MemoryRouter>
-            <Content value={textContent.body} className="test-class" />
-        </MemoryRouter>
-    );
+    render(<Content value={textContent.body} className="test-class" />);
     const content = document.querySelector('.c-content');
     expect(content).toHaveClass('test-class');
 });
 
 test('renders the correct padding class', () => {
     const { rerender } = render(
-        <MemoryRouter>
-            <Content value={textContent.body} paddingTop={10} paddingBottom={10} />
-        </MemoryRouter>
+        <Content value={textContent.body} paddingTop={10} paddingBottom={10} />
     );
     const content = document.querySelector('.c-content');
     expect(content).toHaveClass('u-pt-10 u-pb-10');
 
-    rerender(
-        <MemoryRouter>
-            <Content value={textContent.body} paddingTop={50} paddingBottom={110} />
-        </MemoryRouter>
-    );
+    rerender(<Content value={textContent.body} paddingTop={50} paddingBottom={110} />);
 
     expect(content).toHaveClass('u-pt-50 u-pb-110');
 });
 
 test('renders the correct margin class', () => {
-    render(
-        <MemoryRouter>
-            <Content value={textContent.body} marginBottom={10} />
-        </MemoryRouter>
-    );
+    render(<Content value={textContent.body} marginBottom={10} />);
     const content = document.querySelector('.c-content');
     expect(content).toHaveClass('u-mb-10');
 });
 
 test('renders the correct buttons', () => {
-    render(
-        <MemoryRouter>
-            <Content value={textContentHasButtons.body} buttons={textContentHasButtons.buttons} />
-        </MemoryRouter>
-    );
+    render(<Content value={textContentHasButtons.body} buttons={textContentHasButtons.buttons} />);
 
     const buttons = document.querySelectorAll('.c-btn');
     expect(buttons).toHaveLength(6);

--- a/packages/osc-ui/src/components/DatePicker/DatePicker/DatePicker.spec.tsx
+++ b/packages/osc-ui/src/components/DatePicker/DatePicker/DatePicker.spec.tsx
@@ -1,16 +1,13 @@
-import { render, screen } from '@testing-library/react';
-import { SpritesheetProvider } from '../../Icon/Icon';
+import { screen } from '@testing-library/react';
+import { render } from 'test-utils';
+
+import { parseDate } from '@internationalized/date';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DatePicker } from './DatePicker';
-import userEvent from '@testing-library/user-event';
-import { parseDate } from '@internationalized/date';
 
 test('should render the DateField with SpinButtons for a DatePicker, a button for the Calendar and a Label', () => {
-    render(
-        <SpritesheetProvider>
-            <DatePicker type="month" label="Date" />
-        </SpritesheetProvider>
-    );
+    render(<DatePicker type="month" label="Date" />);
     expect(screen.getByRole('group', { name: 'Date' })).toBeInTheDocument();
     expect(screen.getByRole('presentation')).toBeInTheDocument();
     expect(screen.getByRole('spinbutton', { name: 'Date month' })).toBeInTheDocument();
@@ -20,11 +17,7 @@ test('should render the DateField with SpinButtons for a DatePicker, a button fo
 });
 test('should open the calendar when the calendar button is clicked', async () => {
     const user = userEvent.setup();
-    render(
-        <SpritesheetProvider>
-            <DatePicker type="month" label="Date" defaultValue={parseDate('2023-02-01')} />
-        </SpritesheetProvider>
-    );
+    render(<DatePicker type="month" label="Date" defaultValue={parseDate('2023-02-01')} />);
     const button = screen.getByRole('button');
     await user.click(button);
 
@@ -38,14 +31,12 @@ test('should disable out of range dates when min/max values are passed in', asyn
     const maxDate = 20;
 
     render(
-        <SpritesheetProvider>
-            <DatePicker
-                type="month"
-                label="Date"
-                minValue={parseDate(`2023-01-${minDate}`)}
-                maxValue={parseDate(`2023-01-${maxDate}`)}
-            />
-        </SpritesheetProvider>
+        <DatePicker
+            type="month"
+            label="Date"
+            minValue={parseDate(`2023-01-${minDate}`)}
+            maxValue={parseDate(`2023-01-${maxDate}`)}
+        />
     );
     const button = screen.getByRole('button');
     await user.click(button);
@@ -79,11 +70,7 @@ test('should disable out of range dates when min/max values are passed in', asyn
 test('should open the year and decade calendars and set the correct date', async () => {
     const finalSelectedDate = 'Selected Date: December 5, 2024';
     const user = userEvent.setup();
-    render(
-        <SpritesheetProvider>
-            <DatePicker type="month" label="Date" defaultValue={parseDate('2023-02-01')} />
-        </SpritesheetProvider>
-    );
+    render(<DatePicker type="month" label="Date" defaultValue={parseDate('2023-02-01')} />);
 
     const button = screen.getByRole('button');
     await user.click(button);

--- a/packages/osc-ui/src/components/DatePicker/DateRangePicker/DateRangePicker.spec.tsx
+++ b/packages/osc-ui/src/components/DatePicker/DateRangePicker/DateRangePicker.spec.tsx
@@ -1,8 +1,9 @@
 import { parseDate } from '@internationalized/date';
-import { render, screen } from '@testing-library/react';
+import { render } from 'test-utils';
+
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { SpritesheetProvider } from '../../Icon/Icon';
 import { DateRangePickerContainer } from './DateRangePicker';
 
 const TODAY = 'Today';
@@ -29,11 +30,7 @@ const presets = [
 // });
 
 test('should render the DateField with SpinButtons for a DatePicker, a button for the Calendar and a Label', () => {
-    render(
-        <SpritesheetProvider>
-            <DateRangePickerContainer label="Date Range" />
-        </SpritesheetProvider>
-    );
+    render(<DateRangePickerContainer label="Date Range" />);
     const dateRange = ['Start', 'End'];
 
     expect(screen.getByRole('group', { name: 'Date Range' })).toBeInTheDocument();
@@ -54,11 +51,7 @@ test('should render the DateField with SpinButtons for a DatePicker, a button fo
 test('should open the calendar when the calendar button is clicked', async () => {
     const dates = { start: parseDate('2023-02-04'), end: parseDate('2023-02-20') };
     const user = userEvent.setup();
-    render(
-        <SpritesheetProvider>
-            <DateRangePickerContainer defaultValue={dates} label="Date Range" />
-        </SpritesheetProvider>
-    );
+    render(<DateRangePickerContainer defaultValue={dates} label="Date Range" />);
     const button = screen.getAllByRole('button')[0];
     await user.click(button);
 
@@ -74,14 +67,12 @@ test('should disable out of range dates when min/max values are passed in', asyn
     const maxDate = 29;
 
     render(
-        <SpritesheetProvider>
-            <DateRangePickerContainer
-                defaultValue={dates}
-                label="Date Range"
-                minValue={parseDate(`2023-01-${minDate}`)}
-                maxValue={parseDate(`2023-01-${maxDate}`)}
-            />
-        </SpritesheetProvider>
+        <DateRangePickerContainer
+            defaultValue={dates}
+            label="Date Range"
+            minValue={parseDate(`2023-01-${minDate}`)}
+            maxValue={parseDate(`2023-01-${maxDate}`)}
+        />
     );
     const button = screen.getAllByRole('button')[0];
     await user.click(button);
@@ -108,11 +99,7 @@ test('should disable out of range dates when min/max values are passed in', asyn
 test('should render time presets when pass in as a prop', async () => {
     const user = userEvent.setup();
 
-    render(
-        <SpritesheetProvider>
-            <DateRangePickerContainer label="Date Range" presets={presets} />
-        </SpritesheetProvider>
-    );
+    render(<DateRangePickerContainer label="Date Range" presets={presets} />);
     const button = screen.getAllByRole('button')[0];
     await user.click(button);
     expect(screen.getByRole('group', { name: 'Time Presets' })).toBeInTheDocument();
@@ -124,11 +111,7 @@ test('should select the correct range when a time present is selected', async ()
     const user = userEvent.setup();
     const today = new Date().toISOString().split('T')[0];
 
-    render(
-        <SpritesheetProvider>
-            <DateRangePickerContainer label="Date Range" presets={presets} />
-        </SpritesheetProvider>
-    );
+    render(<DateRangePickerContainer label="Date Range" presets={presets} />);
     const button = screen.getAllByRole('button')[0];
     await user.click(button);
     const timePresetButton = screen.getByRole('button', { name: THREE_DAYS });
@@ -155,11 +138,7 @@ test('should remove hidden class from "Now select end date" prompt when first da
     }));
     const user = userEvent.setup();
 
-    render(
-        <SpritesheetProvider>
-            <DateRangePickerContainer label="Date Range" />
-        </SpritesheetProvider>
-    );
+    render(<DateRangePickerContainer label="Date Range" />);
     const button = screen.getAllByRole('button')[0];
     await user.click(button);
 
@@ -172,11 +151,7 @@ test('should remove hidden class from "Now select end date" prompt when first da
 test('should clear selection if the Clear Selection button is selected', async () => {
     const user = userEvent.setup();
 
-    render(
-        <SpritesheetProvider>
-            <DateRangePickerContainer label="Date Range" />
-        </SpritesheetProvider>
-    );
+    render(<DateRangePickerContainer label="Date Range" />);
     const button = screen.getAllByRole('button')[0];
     await user.click(button);
 

--- a/packages/osc-ui/src/components/Header/Header.spec.tsx
+++ b/packages/osc-ui/src/components/Header/Header.spec.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { SpritesheetProvider } from '../Icon/Icon';
+import { render } from 'test-utils';
 import { Logo } from '../Logo/Logo';
 import { Navbar, NavItem, NavLink, NavList } from '../Navbar/Navbar';
 import { simpleNav } from '../Navbar/navContent';
@@ -10,13 +9,9 @@ import { Header, HeaderActionBar, HeaderNav } from './Header';
 describe('header', () => {
     test('renders header component with logo', () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Header>
-                        <Logo />
-                    </Header>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Header>
+                <Logo />
+            </Header>
         );
 
         const header = screen.getByRole('banner');
@@ -28,13 +23,7 @@ describe('header', () => {
     });
 
     test('successfully adds custom class to header', () => {
-        render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Header className="test-class" />
-                </SpritesheetProvider>
-            </MemoryRouter>
-        );
+        render(<Header className="test-class" />);
 
         const header = screen.getByRole('banner');
         // eslint-disable-next-line jest-dom/prefer-to-have-class
@@ -43,13 +32,9 @@ describe('header', () => {
 
     test('adds a --header-height custom property to the style attribute', () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Header>
-                        <Logo />
-                    </Header>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Header>
+                <Logo />
+            </Header>
         );
 
         const header = screen.getByRole('banner');
@@ -61,23 +46,19 @@ describe('header', () => {
 describe('headerNav', () => {
     test('renders headerNav component with a simple nav', () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Header>
-                        <HeaderNav isOpen={false}>
-                            <Navbar>
-                                <NavList>
-                                    {simpleNav.map((item, index) => (
-                                        <NavItem key={index}>
-                                            <NavLink href={item.href}>{item.label}</NavLink>
-                                        </NavItem>
-                                    ))}
-                                </NavList>
-                            </Navbar>
-                        </HeaderNav>
-                    </Header>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Header>
+                <HeaderNav isOpen={false}>
+                    <Navbar>
+                        <NavList>
+                            {simpleNav.map((item, index) => (
+                                <NavItem key={index}>
+                                    <NavLink href={item.href}>{item.label}</NavLink>
+                                </NavItem>
+                            ))}
+                        </NavList>
+                    </Navbar>
+                </HeaderNav>
+            </Header>
         );
 
         const headerNav = document.querySelector('.c-header__nav');
@@ -87,23 +68,19 @@ describe('headerNav', () => {
 
     test('locks the body when headerNav is open', () => {
         const { rerender } = render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Header>
-                        <HeaderNav isOpen={true}>
-                            <Navbar>
-                                <NavList>
-                                    {simpleNav.map((item, index) => (
-                                        <NavItem key={index}>
-                                            <NavLink href={item.href}>{item.label}</NavLink>
-                                        </NavItem>
-                                    ))}
-                                </NavList>
-                            </Navbar>
-                        </HeaderNav>
-                    </Header>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Header>
+                <HeaderNav isOpen={true}>
+                    <Navbar>
+                        <NavList>
+                            {simpleNav.map((item, index) => (
+                                <NavItem key={index}>
+                                    <NavLink href={item.href}>{item.label}</NavLink>
+                                </NavItem>
+                            ))}
+                        </NavList>
+                    </Navbar>
+                </HeaderNav>
+            </Header>
         );
 
         const headerNav = document.querySelector('.c-header__nav');
@@ -112,23 +89,19 @@ describe('headerNav', () => {
         expect(document.body).toHaveStyle('overflow-y: hidden;');
 
         rerender(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Header>
-                        <HeaderNav isOpen={false}>
-                            <Navbar>
-                                <NavList>
-                                    {simpleNav.map((item, index) => (
-                                        <NavItem key={index}>
-                                            <NavLink href={item.href}>{item.label}</NavLink>
-                                        </NavItem>
-                                    ))}
-                                </NavList>
-                            </Navbar>
-                        </HeaderNav>
-                    </Header>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Header>
+                <HeaderNav isOpen={false}>
+                    <Navbar>
+                        <NavList>
+                            {simpleNav.map((item, index) => (
+                                <NavItem key={index}>
+                                    <NavLink href={item.href}>{item.label}</NavLink>
+                                </NavItem>
+                            ))}
+                        </NavList>
+                    </Navbar>
+                </HeaderNav>
+            </Header>
         );
 
         expect(headerNav).not.toHaveStyle('overflow-y: auto;');
@@ -139,15 +112,11 @@ describe('headerNav', () => {
 describe('headerActionBar', () => {
     test('renders the headerAction Bar', () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Header>
-                        <HeaderActionBar>
-                            <a href="/">Test link</a>
-                        </HeaderActionBar>
-                    </Header>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Header>
+                <HeaderActionBar>
+                    <a href="/">Test link</a>
+                </HeaderActionBar>
+            </Header>
         );
 
         expect(document.querySelector('.c-header__action-bar')).toBeInTheDocument();

--- a/packages/osc-ui/src/components/Navbar/Navbar.spec.tsx
+++ b/packages/osc-ui/src/components/Navbar/Navbar.spec.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render } from 'test-utils';
+
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { SpritesheetProvider } from '../Icon/Icon';
 import { Navbar, NavContent, NavItem, NavLink, NavList, NavSubMenu, NavTrigger } from './Navbar';
 import { nestedSubMenuNav, simpleNav, subMenuNav, testNestedSubMenuNav } from './navContent';
 
@@ -18,19 +18,15 @@ beforeEach(() => {
 
 test('renders a single level Nav', () => {
     render(
-        <MemoryRouter>
-            <SpritesheetProvider>
-                <Navbar>
-                    <NavList>
-                        {simpleNav.map((item, index) => (
-                            <NavItem key={index}>
-                                <NavLink href={item.href}>{item.label}</NavLink>
-                            </NavItem>
-                        ))}
-                    </NavList>
-                </Navbar>
-            </SpritesheetProvider>
-        </MemoryRouter>
+        <Navbar>
+            <NavList>
+                {simpleNav.map((item, index) => (
+                    <NavItem key={index}>
+                        <NavLink href={item.href}>{item.label}</NavLink>
+                    </NavItem>
+                ))}
+            </NavList>
+        </Navbar>
     );
 
     const nav = screen.getByRole('navigation');
@@ -44,38 +40,34 @@ test('renders a single level Nav', () => {
 
 test('renders a nav with a submenu', async () => {
     render(
-        <MemoryRouter>
-            <SpritesheetProvider>
-                <Navbar>
-                    <NavList>
-                        {subMenuNav.map((item, index) => (
-                            <NavItem key={index}>
-                                {item.subMenu ? (
-                                    <NavSubMenu level={0} label={item.label}>
-                                        <NavTrigger>{item.label}</NavTrigger>
-                                        <NavContent level={0}>
-                                            <NavList>
-                                                {item.subMenu.map((subItem, subIndex) => (
-                                                    <NavItem key={subIndex}>
-                                                        <NavLink href={subItem.href}>
-                                                            {subItem.label}
-                                                        </NavLink>
-                                                    </NavItem>
-                                                ))}
-                                            </NavList>
-                                        </NavContent>
-                                    </NavSubMenu>
-                                ) : (
-                                    <NavLink href={item?.href} isExternal={item?.isExternal}>
-                                        {item.label}
-                                    </NavLink>
-                                )}
-                            </NavItem>
-                        ))}
-                    </NavList>
-                </Navbar>
-            </SpritesheetProvider>
-        </MemoryRouter>
+        <Navbar>
+            <NavList>
+                {subMenuNav.map((item, index) => (
+                    <NavItem key={index}>
+                        {item.subMenu ? (
+                            <NavSubMenu level={0} label={item.label}>
+                                <NavTrigger>{item.label}</NavTrigger>
+                                <NavContent level={0}>
+                                    <NavList>
+                                        {item.subMenu.map((subItem, subIndex) => (
+                                            <NavItem key={subIndex}>
+                                                <NavLink href={subItem.href}>
+                                                    {subItem.label}
+                                                </NavLink>
+                                            </NavItem>
+                                        ))}
+                                    </NavList>
+                                </NavContent>
+                            </NavSubMenu>
+                        ) : (
+                            <NavLink href={item?.href} isExternal={item?.isExternal}>
+                                {item.label}
+                            </NavLink>
+                        )}
+                    </NavItem>
+                ))}
+            </NavList>
+        </Navbar>
     );
 
     // Setup our user
@@ -175,22 +167,18 @@ describe('Nested sub menus', () => {
 
     test('renders a nav with a nested submenu', async () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Navbar>
-                        <NavList>
-                            {testNestedSubMenuNav.map((item, index) => (
-                                <RecursiveNavItemWrapper
-                                    key={index}
-                                    item={item}
-                                    level={0}
-                                    value={item.label}
-                                />
-                            ))}
-                        </NavList>
-                    </Navbar>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Navbar>
+                <NavList>
+                    {testNestedSubMenuNav.map((item, index) => (
+                        <RecursiveNavItemWrapper
+                            key={index}
+                            item={item}
+                            level={0}
+                            value={item.label}
+                        />
+                    ))}
+                </NavList>
+            </Navbar>
         );
 
         // Setup our user
@@ -220,22 +208,18 @@ describe('Nested sub menus', () => {
 
     test("Sets the correct level to the subnav and it's children", async () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Navbar>
-                        <NavList>
-                            {nestedSubMenuNav.map((item, index) => (
-                                <RecursiveNavItemWrapper
-                                    key={index}
-                                    item={item}
-                                    level={0}
-                                    value={item.label}
-                                />
-                            ))}
-                        </NavList>
-                    </Navbar>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Navbar>
+                <NavList>
+                    {nestedSubMenuNav.map((item, index) => (
+                        <RecursiveNavItemWrapper
+                            key={index}
+                            item={item}
+                            level={0}
+                            value={item.label}
+                        />
+                    ))}
+                </NavList>
+            </Navbar>
         );
 
         const subMenu = document.querySelector('.c-nav__submenu');
@@ -246,22 +230,18 @@ describe('Nested sub menus', () => {
 
     test('clicking outside the nav closes the submenus', async () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Navbar>
-                        <NavList>
-                            {nestedSubMenuNav.map((item, index) => (
-                                <RecursiveNavItemWrapper
-                                    key={index}
-                                    item={item}
-                                    level={0}
-                                    value={item.label}
-                                />
-                            ))}
-                        </NavList>
-                    </Navbar>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Navbar>
+                <NavList>
+                    {nestedSubMenuNav.map((item, index) => (
+                        <RecursiveNavItemWrapper
+                            key={index}
+                            item={item}
+                            level={0}
+                            value={item.label}
+                        />
+                    ))}
+                </NavList>
+            </Navbar>
         );
 
         // Setup our user
@@ -284,22 +264,18 @@ describe('Nested sub menus', () => {
 
     test('clicking escape with the keyboard closes the submenus', async () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Navbar>
-                        <NavList>
-                            {nestedSubMenuNav.map((item, index) => (
-                                <RecursiveNavItemWrapper
-                                    key={index}
-                                    item={item}
-                                    level={0}
-                                    value={item.label}
-                                />
-                            ))}
-                        </NavList>
-                    </Navbar>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Navbar>
+                <NavList>
+                    {nestedSubMenuNav.map((item, index) => (
+                        <RecursiveNavItemWrapper
+                            key={index}
+                            item={item}
+                            level={0}
+                            value={item.label}
+                        />
+                    ))}
+                </NavList>
+            </Navbar>
         );
 
         // Setup our user
@@ -323,22 +299,18 @@ describe('Nested sub menus', () => {
 
     test('opening a submenu sets the correct tabindex', async () => {
         render(
-            <MemoryRouter>
-                <SpritesheetProvider>
-                    <Navbar>
-                        <NavList>
-                            {testNestedSubMenuNav.map((item, index) => (
-                                <RecursiveNavItemWrapper
-                                    key={index}
-                                    item={item}
-                                    level={0}
-                                    value={item.label}
-                                />
-                            ))}
-                        </NavList>
-                    </Navbar>
-                </SpritesheetProvider>
-            </MemoryRouter>
+            <Navbar>
+                <NavList>
+                    {testNestedSubMenuNav.map((item, index) => (
+                        <RecursiveNavItemWrapper
+                            key={index}
+                            item={item}
+                            level={0}
+                            value={item.label}
+                        />
+                    ))}
+                </NavList>
+            </Navbar>
         );
 
         const navTrigger = screen.getByRole('button', { name: 'Courses' });

--- a/packages/osc-ui/src/components/Select/Select.spec.tsx
+++ b/packages/osc-ui/src/components/Select/Select.spec.tsx
@@ -1,26 +1,22 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
-import { SpritesheetProvider } from '../Icon/Icon';
+import { render } from 'test-utils';
 import { Select, SelectItem } from './Select';
 
 test('should render a select component', () => {
     render(
-        <SpritesheetProvider>
-            <Select name="courses-1">
-                <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
-            </Select>
-        </SpritesheetProvider>
+        <Select name="courses-1">
+            <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
+        </Select>
     );
 
     expect(screen.getByRole('combobox')).toBeInTheDocument();
 });
 test('should render a disabled select component', () => {
     const { container } = render(
-        <SpritesheetProvider>
-            <Select disabled={true} name="courses-1">
-                <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
-            </Select>
-        </SpritesheetProvider>
+        <Select disabled={true} name="courses-1">
+            <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
+        </Select>
     );
 
     expect(container.querySelector(`button[data-disabled]`)).toBeInTheDocument();
@@ -28,11 +24,9 @@ test('should render a disabled select component', () => {
 });
 test('should render a placeholder in the select component', () => {
     const { container } = render(
-        <SpritesheetProvider>
-            <Select placeholder="Please Select" name="courses-1">
-                <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
-            </Select>
-        </SpritesheetProvider>
+        <Select placeholder="Please Select" name="courses-1">
+            <SelectItem value="a-level-psychology"> A Level Psychology </SelectItem>
+        </Select>
     );
 
     expect(screen.getByText('Please Select')).toHaveTextContent('Please Select');

--- a/packages/osc-ui/src/components/TextArea/TextArea.spec.tsx
+++ b/packages/osc-ui/src/components/TextArea/TextArea.spec.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
-import { Icon, SpritesheetProvider } from '../Icon/Icon';
+import { render } from 'test-utils';
+import { Icon } from '../Icon/Icon';
 import { TextArea } from './TextArea';
 
 test('should render a textarea component with a label', () => {
@@ -18,19 +19,17 @@ test('should render an asterisk when input field is required', () => {
 
 test('should render an icon when passed as a prop', () => {
     render(
-        <SpritesheetProvider>
-            <TextArea
-                icon={{
-                    content: <Icon id="exclamation-mark" />,
-                    label: 'Exclamation Triangle Icon',
-                    type: 'error',
-                }}
-                id="enquiry"
-                name="Enquiry"
-                required={true}
-                wasSubmitted={true}
-            />
-        </SpritesheetProvider>
+        <TextArea
+            icon={{
+                content: <Icon id="exclamation-mark" />,
+                label: 'Exclamation Triangle Icon',
+                type: 'error',
+            }}
+            id="enquiry"
+            name="Enquiry"
+            required={true}
+            wasSubmitted={true}
+        />
     );
 
     expect(document.querySelector('use')).toBeInTheDocument();
@@ -41,19 +40,11 @@ test('should render an icon when passed as a prop', () => {
 });
 
 test('should disable the input when disabled prop is true', () => {
-    render(
-        <SpritesheetProvider>
-            <TextArea id="enquiry" name="Enquiry" disabled={true} />
-        </SpritesheetProvider>
-    );
+    render(<TextArea id="enquiry" name="Enquiry" disabled={true} />);
     expect(screen.getByRole('textbox')).toBeDisabled();
 });
 
 test('should render an error message if "wasSubmitted" is true, the field is required, and no value is present', () => {
-    render(
-        <SpritesheetProvider>
-            <TextArea id="enquiry" name="Enquiry" required={true} wasSubmitted={true} />
-        </SpritesheetProvider>
-    );
+    render(<TextArea id="enquiry" name="Enquiry" required={true} wasSubmitted={true} />);
     expect(screen.getByRole('alert')).toBeInTheDocument();
 });

--- a/packages/osc-ui/src/components/VideoPlayer/VideoPlayer.spec.tsx
+++ b/packages/osc-ui/src/components/VideoPlayer/VideoPlayer.spec.tsx
@@ -1,7 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { SpritesheetProvider } from '../Icon/Icon';
+import { render } from 'test-utils';
 import { Image } from '../Image/Image';
 import { VideoPlayer } from './VideoPlayer';
 
@@ -16,11 +16,7 @@ beforeEach(() => {
 });
 
 test('renders the default video player preview', async () => {
-    render(
-        <SpritesheetProvider>
-            <VideoPlayer url="https://youtu.be/w36Yhxxuk_c" />
-        </SpritesheetProvider>
-    );
+    render(<VideoPlayer url="https://youtu.be/w36Yhxxuk_c" />);
 
     await waitFor(() => {
         expect(document.querySelector('.react-player__preview')).toBeInTheDocument();
@@ -32,19 +28,17 @@ test('renders the default video player preview', async () => {
 
 test('renders the custom video player preview', async () => {
     render(
-        <SpritesheetProvider>
-            <VideoPlayer
-                url="https://youtu.be/w36Yhxxuk_c"
-                previewImage={
-                    <Image
-                        src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1675425684/maxresdefault_si26jj.jpg"
-                        width={968}
-                        height={544}
-                        alt="A cartoon man sitting on an armchair with his laptop on his knees. He's looking at his laptop and there are some shelves and lights in the background."
-                    />
-                }
-            />
-        </SpritesheetProvider>
+        <VideoPlayer
+            url="https://youtu.be/w36Yhxxuk_c"
+            previewImage={
+                <Image
+                    src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1675425684/maxresdefault_si26jj.jpg"
+                    width={968}
+                    height={544}
+                    alt="A cartoon man sitting on an armchair with his laptop on his knees. He's looking at his laptop and there are some shelves and lights in the background."
+                />
+            }
+        />
     );
 
     await waitFor(() => {
@@ -57,11 +51,7 @@ test('renders the custom video player preview', async () => {
 });
 
 test("doesn't render the video player preview if autoplay is true", async () => {
-    render(
-        <SpritesheetProvider>
-            <VideoPlayer autoplay={true} url="https://youtu.be/w36Yhxxuk_c" />
-        </SpritesheetProvider>
-    );
+    render(<VideoPlayer autoplay={true} url="https://youtu.be/w36Yhxxuk_c" />);
 
     await waitFor(() => {
         expect(document.querySelector('.react-player__preview')).not.toBeInTheDocument();
@@ -71,15 +61,13 @@ test("doesn't render the video player preview if autoplay is true", async () => 
 test('clears the icon, content and overlay when the video is played', async () => {
     const user = userEvent.setup();
     render(
-        <SpritesheetProvider>
-            <VideoPlayer url="https://youtu.be/w36Yhxxuk_c">
-                <p>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Quidem sit dicta
-                    voluptatum aspernatur neque possimus animi, nihil ex deleniti, sapiente illo ab,
-                    velit in hic! Nam quasi ea velit error?
-                </p>
-            </VideoPlayer>
-        </SpritesheetProvider>
+        <VideoPlayer url="https://youtu.be/w36Yhxxuk_c">
+            <p>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Quidem sit dicta voluptatum
+                aspernatur neque possimus animi, nihil ex deleniti, sapiente illo ab, velit in hic!
+                Nam quasi ea velit error?
+            </p>
+        </VideoPlayer>
     );
 
     const preview = document.querySelector('.react-player__preview');
@@ -108,15 +96,13 @@ test('clears the icon, content and overlay when the video is played', async () =
 test("doesn't clear the content or overlay if preserveContent is true", async () => {
     const user = userEvent.setup();
     render(
-        <SpritesheetProvider>
-            <VideoPlayer url="https://youtu.be/w36Yhxxuk_c" preserveContent={true}>
-                <p>
-                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Quidem sit dicta
-                    voluptatum aspernatur neque possimus animi, nihil ex deleniti, sapiente illo ab,
-                    velit in hic! Nam quasi ea velit error?
-                </p>
-            </VideoPlayer>
-        </SpritesheetProvider>
+        <VideoPlayer url="https://youtu.be/w36Yhxxuk_c" preserveContent={true}>
+            <p>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Quidem sit dicta voluptatum
+                aspernatur neque possimus animi, nihil ex deleniti, sapiente illo ab, velit in hic!
+                Nam quasi ea velit error?
+            </p>
+        </VideoPlayer>
     );
 
     const preview = document.querySelector('.react-player__preview');

--- a/packages/osc-ui/tsconfig.spec.json
+++ b/packages/osc-ui/tsconfig.spec.json
@@ -4,7 +4,10 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "module": "commonjs",
-    "types": ["vitest/globals", "node"]
+    "types": ["vitest/globals", "node"],
+    "paths": {
+      "test-utils": ["./__test__/test-utils"]
+    }
   },
   "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js", "**/*.spec.jsx", "**/*.d.ts"],
   "exclude": ["node_modules"]

--- a/packages/osc-ui/vite.config.ts
+++ b/packages/osc-ui/vite.config.ts
@@ -1,12 +1,12 @@
 /// <reference types="vitest" />
 /// <reference types="vite/client" />
 
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import fs from 'fs';
 import { resolve } from 'path';
-import type { ResolvedConfig, PluginOption } from 'vite';
+import type { PluginOption, ResolvedConfig } from 'vite';
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 const fileRegex = /\.(css)$/;
 
@@ -31,7 +31,7 @@ function libInjectCss(): PluginOption {
             if (fileRegex.test(id)) {
                 css.push(code);
                 return {
-                    code: ''
+                    code: '',
                 };
             }
             if (
@@ -40,7 +40,7 @@ function libInjectCss(): PluginOption {
             ) {
                 return {
                     code: `${code}
-          ${template}`
+          ${template}`,
                 };
             }
             return null;
@@ -55,7 +55,7 @@ function libInjectCss(): PluginOption {
 
                 try {
                     let data: string = fs.readFileSync(filePath, {
-                        encoding: 'utf8'
+                        encoding: 'utf8',
                     });
 
                     if (data.includes(template)) {
@@ -67,7 +67,7 @@ function libInjectCss(): PluginOption {
                     console.error(e);
                 }
             }
-        }
+        },
     };
 }
 export default defineConfig({
@@ -78,6 +78,11 @@ export default defineConfig({
         globals: true,
         environment: 'jsdom',
         setupFiles: ['./__test__/setup-test-env.ts'],
-        include: ['./src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx,css}']
-    }
+        include: ['./src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx,css}'],
+    },
+    resolve: {
+        alias: {
+            'test-utils': resolve(__dirname, './__test__/test-utils'),
+        },
+    },
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I discovered recently that you can create a wrapper around rtl's render function which allows you to add providers and other components around the component you want to render. https://testing-library.com/docs/react-testing-library/setup/#custom-render

I thought it would be a good idea for us to adopt this as we are starting to need a bit of boilerplate around our tests with things like the `<MemoryRouter>` for testing components that contain Remix's `<Link>` and the `<SpriteSheetProvider>` provider for when we have icons.

## ⛳️ Current behavior (updates)

Currently when writing a test you will import the render function from react testing library and wrap your test with `<MemoryRouter>` and `<SpritesheetProider>` which may look something like this:

```tsx
// ... other imports
import { render, screen, waitFor } from '@testing-library/react';
import { SpritesheetProvider } from '../Icon/Icon';
import { MemoryRouter } from 'react-router-dom';

test('', () => {
    render (
        <MemoryRouter>
            <SpritesheetProvider>
                 <MyComponent />
            </SpritesheetProvider>
        </MemoryRouter>
    )
})
```

## 🚀 New behavior

Now rather than bringing in all of that boilerplate you can do this:

```tsx
// ... other imports
import { render } from 'test-utils';

test('', () => {
    render ( <MyComponent />)
})
```

## 💣 Is this a breaking change (Yes/No): Yes

Rather than importing the render function from `@testing-library/react` now you will import it from `test-utils` like this
```tsx
import { render } from 'test-utils';
```

## 📝 Additional Information

I've updated the tsconfig and the vite config so the path to the utility file is just `test-utils`

I haven't updated the tests for the Icon as I would want to test the `SpritesheetProvider` explicitly there.