### PR TITLE
Feature/o-page

### DIFF
--- a/packages/osc-ecommerce/app/root.tsx
+++ b/packages/osc-ecommerce/app/root.tsx
@@ -228,11 +228,13 @@ export default function App() {
 
             <SkipLink anchor="main-content">Skip to main content</SkipLink>
 
-            <SiteHeader navSettings={navSettings} actionNav={siteSettings?.actionNav} />
+            <div className="o-page">
+                <SiteHeader navSettings={navSettings} actionNav={siteSettings?.actionNav} />
 
-            <main id="main-content" tabIndex={-1}>
-                <Outlet />
-            </main>
+                <main id="main-content" tabIndex={-1}>
+                    <Outlet />
+                </main>
+            </div>
         </Document>
     );
 }

--- a/packages/osc-ui/src/styles/main.scss
+++ b/packages/osc-ui/src/styles/main.scss
@@ -80,6 +80,7 @@
     @include meta.load-css("objects/list");
     @include meta.load-css("objects/main");
     @include meta.load-css("objects/icon");
+    @include meta.load-css("objects/page");
 }
 
 /* ============================

--- a/packages/osc-ui/src/styles/objects/_page.scss
+++ b/packages/osc-ui/src/styles/objects/_page.scss
@@ -1,0 +1,6 @@
+.o-page {
+    display: grid;
+    min-height: 100vh; // fallback if dvh is not supported
+    min-height: 100dvh;
+    grid-template-rows: auto 1fr auto;
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In preparation to adding the footer to the ecommerce site I've added an `o-page` object class to set the layout of the pages and force shorter pages to keep the footer at the bottom of the page.

## ⛳️ Current behavior (updates)

Page content is all pulled together

<img width="1357" alt="image" src="https://user-images.githubusercontent.com/23461173/222138531-45e41b5e-e320-44e9-9c91-f7401fbc8c1e.png">


## 🚀 New behavior

Wraps the content inside root.tsx in a `div` with the class of `o-page` which forces the footer (last child) to the end of the page
<img width="1355" alt="image" src="https://user-images.githubusercontent.com/23461173/222138696-d7b92cd7-2ecd-4acd-80b7-400d34eb567c.png">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
