### PR TITLE
Bugfix/Dots and arrows missing from carousel

### DIFF
--- a/packages/osc-ui/src/components/Carousel/carousel.scss
+++ b/packages/osc-ui/src/components/Carousel/carousel.scss
@@ -1,9 +1,10 @@
 @import "../../styles/settings";
+@import "../../styles/tools";
 
 @layer components {
     $carousel-control-color: var(--color-neutral-400);
-    $carousel-dot-dimensions: ($base-fs * 0.75);
-    $carousel-arrow-dimensions: ($base-fs * 1.875);
+    $carousel-dot-dimensions: ($base-fs * rem(0.75));
+    $carousel-arrow-dimensions: ($base-fs * rem(1.875));
 
     /* stylelint-disable selector-class-pattern */
     .c-carousel {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Noticed that the dots and arrows had stopped working correctly, looks like at some point the units had gotten missed off 😅 

## ⛳️ Current behavior (updates)

Dots and arrows on the carousel aren't rendering at the correct size or at all
![image](https://user-images.githubusercontent.com/23461173/222726155-032e9384-1db9-4ad5-ba73-43932f4af675.png)


## 🚀 New behavior

Dots and arrows will render as expected
![image](https://user-images.githubusercontent.com/23461173/222726032-50717b73-17b5-4939-9672-7769d916d743.png)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
