### PR TITLE
Bugfix/loading dynamic stylesheets

### DIFF
--- a/packages/osc-academic-hub/app/root.tsx
+++ b/packages/osc-academic-hub/app/root.tsx
@@ -83,8 +83,8 @@ const Document = ({ children }: DocumentProps) => {
     return (
         <html lang="en">
             <head>
-                {typeof document === 'undefined' && <Meta />}
-                {typeof document === 'undefined' && <Links />}
+                <Meta />
+                <Links />
             </head>
             <body>
                 {children}

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -9,7 +9,6 @@ import islandGrid from 'osc-ui/dist/src-components-IslandGrid-island-grid.css';
 import popoverStyles from 'osc-ui/dist/src-components-Popover-popover.css';
 import textGridStyles from 'osc-ui/dist/src-components-TextGrid-text-grid.css';
 import videoStyles from 'osc-ui/dist/src-components-VideoPlayer-video-player.css';
-import { getTypes } from '~/models/sanity.server';
 import type {
     accordionModule,
     cardModule,
@@ -28,6 +27,37 @@ import { Cards } from './Cards/Cards';
 import { Hero } from './Hero/Hero';
 import { TextGridModule } from './TextGrid/TextGrid';
 import { VideoPlayerModule } from './VideoPlayer/VideoPlayer';
+
+/**
+ * Recursively search for all types in a Sanity schema and filter them by type
+ *
+ * @param sanityData - The Sanity data to extract modules from
+ * @return An non unique array of all modules in the Sanity data
+ */
+const getTypes = (sanityData: SanityPage) => {
+    const types: string[] = [];
+
+    const recurse = (obj: SanityPage) => {
+        for (const key in obj) {
+            // Check whether the key exists in our object
+            if (obj.hasOwnProperty(key)) {
+                // IF the key is equal to `_type` push it into the types array
+                // ELSE if the key is an object, recurse into it
+                if (key === '_type') {
+                    types.push(obj[key]);
+                } else if (typeof obj[key as keyof SanityPage] === 'object') {
+                    // @ts-ignore -- we can safely ignore this error because we're already checking the type of the key
+                    recurse(obj[key as keyof SanityPage]);
+                }
+            }
+        }
+    };
+    recurse(sanityData);
+
+    const filteredTypes = types.filter((type) => type.includes('module.'));
+
+    return filteredTypes;
+};
 
 // So we can dynamically add the styles of each component into remix we need to create an array of stylesheet objects.
 // We will then call this function in each of the `route` files where we have a dynamicLinks.

--- a/packages/osc-ecommerce/app/models/sanity.server.ts
+++ b/packages/osc-ecommerce/app/models/sanity.server.ts
@@ -113,34 +113,3 @@ export async function shouldRedirect(request: Request) {
         console.error(err);
     }
 }
-
-/**
- * Recursively search for all types in a Sanity schema and filter them by type
- *
- * @param sanityData - The Sanity data to extract modules from
- * @return An non unique array of all modules in the Sanity data
- */
-export const getTypes = (sanityData: SanityPage) => {
-    const types: string[] = [];
-
-    const recurse = (obj: SanityPage) => {
-        for (const key in obj) {
-            // Check whether the key exists in our object
-            if (obj.hasOwnProperty(key)) {
-                // IF the key is equal to `_type` push it into the types array
-                // ELSE if the key is an object, recurse into it
-                if (key === '_type') {
-                    types.push(obj[key]);
-                } else if (typeof obj[key as keyof SanityPage] === 'object') {
-                    // @ts-ignore -- we can safely ignore this error because we're already checking the type of the key
-                    recurse(obj[key as keyof SanityPage]);
-                }
-            }
-        }
-    };
-    recurse(sanityData);
-
-    const filteredTypes = types.filter((type) => type.includes('module.'));
-
-    return filteredTypes;
-};

--- a/packages/osc-ecommerce/app/root.tsx
+++ b/packages/osc-ecommerce/app/root.tsx
@@ -186,12 +186,10 @@ const Document = ({ children }: DocumentProps) => {
     return (
         <html lang="en">
             <head>
-                {typeof document === 'undefined' && <Meta />}
-                {typeof document === 'undefined' && canonical && (
-                    <link rel="canonical" href={canonical} />
-                )}
-                {typeof document === 'undefined' && <Links />}
-                {typeof document === 'undefined' && <DynamicLinks />}
+                <Meta />
+                {canonical && <link rel="canonical" href={canonical} />}
+                <Links />
+                <DynamicLinks />
             </head>
             <body>
                 {children}

--- a/packages/osc-ecommerce/app/routes/blog/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/blog/$slug.tsx
@@ -23,7 +23,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const data = await getPageData({
         request,
         params,
-        query: POST_QUERY
+        query: POST_QUERY,
     });
 
     if (!data?.page) {
@@ -39,20 +39,20 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const { page: post, isPreview }: PageData = data;
     const canonicalUrl = buildCanonicalUrl({
         canonical: post?.seo?.canonicalUrl,
-        request
+        request,
     });
 
     return json({
         post,
         isPreview,
         canonicalUrl,
-        query: isPreview ? POST_QUERY : null
+        query: isPreview ? POST_QUERY : null,
     });
 };
 
 // https://github.com/sergiodxa/remix-utils#dynamiclinks
 const dynamicLinks: DynamicLinksFunction = ({ data }) => {
-    return getComponentStyles(data.page);
+    return getComponentStyles(data.post);
 };
 
 export const handle = { dynamicLinks };
@@ -63,7 +63,7 @@ export const meta: MetaFunction = ({ data, parentsData }) => {
     const meta = buildHtmlMetaTags({
         pageData: data.post,
         globalData: globalSeoSettings,
-        canonicalUrl: data.canonicalUrl
+        canonicalUrl: data.canonicalUrl,
     });
 
     return meta;

--- a/packages/osc-ecommerce/app/routes/blog/index.tsx
+++ b/packages/osc-ecommerce/app/routes/blog/index.tsx
@@ -20,7 +20,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     // Query the page data
     const data = await getPageData({
         request,
-        query: BLOG_QUERY
+        query: BLOG_QUERY,
     });
 
     if (!data?.page) {
@@ -36,20 +36,20 @@ export const loader: LoaderFunction = async ({ request }) => {
     const { page: blog, isPreview }: PageData = data;
     const canonicalUrl = buildCanonicalUrl({
         canonical: blog?.seo?.canonicalUrl,
-        request
+        request,
     });
 
     return json({
         blog,
         isPreview,
         canonicalUrl,
-        query: isPreview ? BLOG_QUERY : null
+        query: isPreview ? BLOG_QUERY : null,
     });
 };
 
 // https://github.com/sergiodxa/remix-utils#dynamiclinks
 const dynamicLinks: DynamicLinksFunction = ({ data }) => {
-    return getComponentStyles(data.page);
+    return getComponentStyles(data.blog);
 };
 
 export const handle = { dynamicLinks };
@@ -60,7 +60,7 @@ export const meta: MetaFunction = ({ data, parentsData }) => {
     const meta = buildHtmlMetaTags({
         pageData: data.blog,
         globalData: globalSeoSettings,
-        canonicalUrl: data.canonicalUrl
+        canonicalUrl: data.canonicalUrl,
     });
 
     return meta;

--- a/packages/osc-ecommerce/app/routes/collections/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/collections/$slug.tsx
@@ -23,7 +23,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const data = await getPageData({
         request,
         params,
-        query: COLLECTION_QUERY
+        query: COLLECTION_QUERY,
     });
 
     if (!data?.page) {
@@ -39,20 +39,20 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const { page: collection, isPreview }: PageData = data;
     const canonicalUrl = buildCanonicalUrl({
         canonical: collection?.seo?.canonicalUrl,
-        request
+        request,
     });
 
     return json({
         collection,
         isPreview,
         canonicalUrl,
-        query: isPreview ? COLLECTION_QUERY : null
+        query: isPreview ? COLLECTION_QUERY : null,
     });
 };
 
 // https://github.com/sergiodxa/remix-utils#dynamiclinks
 const dynamicLinks: DynamicLinksFunction = ({ data }) => {
-    return getComponentStyles(data.page);
+    return getComponentStyles(data.collection);
 };
 
 export const handle = { dynamicLinks };
@@ -63,7 +63,7 @@ export const meta: MetaFunction = ({ data, parentsData }) => {
     const meta = buildHtmlMetaTags({
         pageData: data.collection,
         globalData: globalSeoSettings,
-        canonicalUrl: data.canonicalUrl
+        canonicalUrl: data.canonicalUrl,
     });
 
     return meta;

--- a/packages/osc-ecommerce/app/routes/index.tsx
+++ b/packages/osc-ecommerce/app/routes/index.tsx
@@ -25,7 +25,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     // Query the page data
     const data = await getPageData({
         request,
-        query: HOME_QUERY
+        query: HOME_QUERY,
     });
 
     if (!data?.page) {
@@ -35,7 +35,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     const { page: home, isPreview }: PageData = data;
     const canonicalUrl = buildCanonicalUrl({
         canonical: home?.seo?.canonicalUrl,
-        request
+        request,
     });
 
     return json({
@@ -43,13 +43,13 @@ export const loader: LoaderFunction = async ({ request }) => {
         home,
         canonicalUrl,
         isPreview,
-        query: isPreview ? HOME_QUERY : null
+        query: isPreview ? HOME_QUERY : null,
     });
 };
 
 // https://github.com/sergiodxa/remix-utils#dynamiclinks
 const dynamicLinks: DynamicLinksFunction = ({ data }) => {
-    return getComponentStyles(data.page);
+    return getComponentStyles(data.home);
 };
 
 export const handle = { dynamicLinks };
@@ -60,7 +60,7 @@ export const meta: MetaFunction = ({ data, parentsData }) => {
     const meta = buildHtmlMetaTags({
         pageData: data.home,
         globalData: globalSeoSettings,
-        canonicalUrl: data.canonicalUrl
+        canonicalUrl: data.canonicalUrl,
     });
 
     return meta;
@@ -102,7 +102,7 @@ export default function Index() {
                             formData.set('pathname', location.pathname);
                             submit(formData, {
                                 method: 'post',
-                                action: '/actions/changeTheme'
+                                action: '/actions/changeTheme',
                             });
                         }}
                     />

--- a/packages/osc-ecommerce/app/routes/products/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/products/$slug.tsx
@@ -23,7 +23,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const data = await getPageData({
         request,
         params,
-        query: PRODUCT_QUERY
+        query: PRODUCT_QUERY,
     });
 
     if (!data?.page) {
@@ -39,20 +39,20 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const { page: product, isPreview }: PageData = data;
     const canonicalUrl = buildCanonicalUrl({
         canonical: product?.seo?.canonicalUrl,
-        request
+        request,
     });
 
     return json({
         product,
         isPreview,
         canonicalUrl,
-        query: isPreview ? PRODUCT_QUERY : null
+        query: isPreview ? PRODUCT_QUERY : null,
     });
 };
 
 // https://github.com/sergiodxa/remix-utils#dynamiclinks
 const dynamicLinks: DynamicLinksFunction = ({ data }) => {
-    return getComponentStyles(data.page);
+    return getComponentStyles(data.product);
 };
 
 export const handle = { dynamicLinks };
@@ -63,7 +63,7 @@ export const meta: MetaFunction = ({ data, parentsData }) => {
     const meta = buildHtmlMetaTags({
         pageData: data.product,
         globalData: globalSeoSettings,
-        canonicalUrl: data.canonicalUrl
+        canonicalUrl: data.canonicalUrl,
     });
 
     return meta;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #662 

## 📝 Description

I discovered a bug where if you navigate our site using the Remix `<Link>` or `<NavLink>` component the dynamic styles would not apply to the page unless you manually refreshed it.

I setup a minimal test on codesandbox and noticed that the dynamic styles would apply there as you'd expect. After a bit more poking around; I noticed that in a few examples and in the Indie Stack itself they weren't type guarding the `<Meta>` or `<Links>` components in the `root.tsx` file whereas we were. 

Removing the type guard seems to have solved it. This makes sense as the `<Link>` component adds [client-side routing](https://remix.run/docs/en/1.14.0/components/link), so by saying "render the `<DynamicLink>` if the document is undefined" we're forcing it to only add the `<DynamicLink>` if the server is doing the routing.

An alternative solution would be to only use `<a>` tags however we would then lose out on the benefits of CSR and being able to include things like [prefetch to the links](https://remix.run/docs/en/1.14.0/components/link#prefetch). But open to discussion on this.

## ⛳️ Current behavior (updates)

- The `<Meta>`, `canonical`, `<Link>` & `<DynamicLink>` are type guarded with `typeof document === 'undefined'`
- `getTypes` function is strictly a server only function and lives in `sanity.server.ts`

## 🚀 New behavior

- Removes type guard from `<Meta>`, `canonical`, `<Link>` & `<DynamicLink>`
- Moves `getTypes` into `Module.tsx` so it's accessible in the client bundle

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
