### PR TITLE
Refactor/island grid items positioning

### DIFF
--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -223,6 +223,7 @@ $card-fs-3xl: $fs-3xl;
             }
 
             #{$self}__footer {
+                align-items: center;
                 border-top: var(--card-border);
                 margin-block-start: $card-space-l;
                 padding-block: $card-space-l;

--- a/packages/osc-ui/src/components/IslandGrid/IslandGrid.stories.tsx
+++ b/packages/osc-ui/src/components/IslandGrid/IslandGrid.stories.tsx
@@ -1,5 +1,20 @@
+import { VisuallyHidden } from '@react-aria/visually-hidden';
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
+import { truncate } from '../../utils/truncate';
+import { Button } from '../Button/Button';
+import {
+    BlogCard,
+    CardBody,
+    CardFooter,
+    CardHeader,
+    CardImage,
+    CardInner,
+    CardTitle,
+    CollectionCard,
+} from '../Card/Card';
+import { collectionCardData, collectionCardDataHzntl, postCardData } from '../Card/cardData';
+import { Image } from '../Image/Image';
 import type { IslandGridProps } from './IslandGrid';
 import { IslandGrid } from './IslandGrid';
 
@@ -19,24 +34,66 @@ export default {
 const Template: Story<IslandGridProps> = ({ ...args }) => (
     <div className="o-container">
         <IslandGrid {...args}>
-            <div
-                style={{
-                    height: '638px',
-                    backgroundImage: 'var(--color-gradient-quaternary-90)',
-                }}
-            />
-            <div
-                style={{
-                    height: '310px',
-                    backgroundImage: 'var(--color-gradient-quaternary-90)',
-                }}
-            />
-            <div
-                style={{
-                    height: '310px',
-                    backgroundImage: 'var(--color-gradient-quaternary-90)',
-                }}
-            />
+            <CollectionCard size="lg">
+                <CardImage>
+                    <Image
+                        src={collectionCardData.image.secure_url}
+                        alt={collectionCardData.image.alt}
+                        width={collectionCardData.image.width}
+                        height={collectionCardData.image.height}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{collectionCardData.title}</CardTitle>
+                    </CardHeader>
+
+                    <CardBody>
+                        <p>{truncate(collectionCardData.body)}</p>
+                        <Button isFull>23 Courses</Button>
+                    </CardBody>
+                </CardInner>
+            </CollectionCard>
+            <CollectionCard size="md">
+                <CardImage>
+                    <Image
+                        src={collectionCardDataHzntl.image.secure_url}
+                        alt={collectionCardDataHzntl.image.alt}
+                        width={collectionCardDataHzntl.image.width}
+                        height={collectionCardDataHzntl.image.height}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{collectionCardDataHzntl.title}</CardTitle>
+                    </CardHeader>
+
+                    <CardBody>
+                        <p>{truncate(collectionCardDataHzntl.body)}</p>
+                        <Button isFull>23 Courses</Button>
+                    </CardBody>
+                </CardInner>
+            </CollectionCard>
+            <CollectionCard size="md">
+                <CardImage>
+                    <Image
+                        src={collectionCardDataHzntl.image.secure_url}
+                        alt={collectionCardDataHzntl.image.alt}
+                        width={collectionCardDataHzntl.image.width}
+                        height={collectionCardDataHzntl.image.height}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{collectionCardDataHzntl.title}</CardTitle>
+                    </CardHeader>
+
+                    <CardBody>
+                        <p>{truncate(collectionCardDataHzntl.body)}</p>
+                        <Button isFull>23 Courses</Button>
+                    </CardBody>
+                </CardInner>
+            </CollectionCard>
         </IslandGrid>
     </div>
 );
@@ -44,30 +101,110 @@ const Template: Story<IslandGridProps> = ({ ...args }) => (
 const TemplateWithFour: Story<IslandGridProps> = ({ ...args }) => (
     <div className="o-container">
         <IslandGrid {...args}>
-            <div
-                style={{
-                    height: '665px',
-                    backgroundImage: 'var(--color-gradient-quaternary-90)',
-                }}
-            />
-            <div
-                style={{
-                    height: '200px',
-                    backgroundImage: 'var(--color-gradient-quaternary-90)',
-                }}
-            />
-            <div
-                style={{
-                    height: '200px',
-                    backgroundImage: 'var(--color-gradient-quaternary-90)',
-                }}
-            />
-            <div
-                style={{
-                    height: '200px',
-                    backgroundImage: 'var(--color-gradient-quaternary-90)',
-                }}
-            />
+            <BlogCard>
+                <CardImage>
+                    <Image
+                        src={postCardData.image.secure_url}
+                        alt={postCardData.image.alt}
+                        width={postCardData.image.width}
+                        height={postCardData.image.height}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{postCardData.title}</CardTitle>
+                        <CardTitle as="h3" subtitle>
+                            {postCardData.subtitle}
+                        </CardTitle>
+                    </CardHeader>
+
+                    <CardBody>
+                        <p>{truncate(postCardData.body)}</p>
+                    </CardBody>
+
+                    <CardFooter>
+                        <time dateTime="2022-10-08" className="u-text-reg">
+                            Wednesday 8th October
+                        </time>
+                        <Button variant="secondary">
+                            Read more
+                            <VisuallyHidden>about {postCardData.title}</VisuallyHidden>
+                        </Button>
+                    </CardFooter>
+                </CardInner>
+            </BlogCard>
+            <BlogCard variant="media-object">
+                <CardImage isRounded>
+                    <Image
+                        src={postCardData.image.secure_url}
+                        alt={postCardData.image.alt}
+                        width={postCardData.image.width}
+                        height={postCardData.image.height}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{postCardData.title}</CardTitle>
+                        <CardTitle as="h3" subtitle>
+                            {postCardData.subtitle}
+                        </CardTitle>
+                    </CardHeader>
+
+                    <CardFooter>
+                        <Button variant="secondary">
+                            Read more <VisuallyHidden>about {postCardData.title}</VisuallyHidden>
+                        </Button>
+                    </CardFooter>
+                </CardInner>
+            </BlogCard>
+            <BlogCard variant="media-object">
+                <CardImage isRounded>
+                    <Image
+                        src={postCardData.image.secure_url}
+                        alt={postCardData.image.alt}
+                        width={postCardData.image.width}
+                        height={postCardData.image.height}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{postCardData.title}</CardTitle>
+                        <CardTitle as="h3" subtitle>
+                            {postCardData.subtitle}
+                        </CardTitle>
+                    </CardHeader>
+
+                    <CardFooter>
+                        <Button variant="secondary">
+                            Read more <VisuallyHidden>about {postCardData.title}</VisuallyHidden>
+                        </Button>
+                    </CardFooter>
+                </CardInner>
+            </BlogCard>
+            <BlogCard variant="media-object">
+                <CardImage isRounded>
+                    <Image
+                        src={postCardData.image.secure_url}
+                        alt={postCardData.image.alt}
+                        width={postCardData.image.width}
+                        height={postCardData.image.height}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{postCardData.title}</CardTitle>
+                        <CardTitle as="h3" subtitle>
+                            {postCardData.subtitle}
+                        </CardTitle>
+                    </CardHeader>
+
+                    <CardFooter>
+                        <Button variant="secondary">
+                            Read more <VisuallyHidden>about {postCardData.title}</VisuallyHidden>
+                        </Button>
+                    </CardFooter>
+                </CardInner>
+            </BlogCard>
         </IslandGrid>
     </div>
 );

--- a/packages/osc-ui/src/components/IslandGrid/IslandGrid.tsx
+++ b/packages/osc-ui/src/components/IslandGrid/IslandGrid.tsx
@@ -19,7 +19,12 @@ export interface IslandGridProps {
 export const IslandGrid = (props: IslandGridProps) => {
     const { children, className } = props;
 
-    const classes = classNames('c-island-grid', 'o-grid', className);
+    const classes = classNames(
+        'c-island-grid',
+        'o-grid',
+        `has-${children.length}-islands`,
+        className
+    );
 
     return (
         <div className={classes}>

--- a/packages/osc-ui/src/components/IslandGrid/island-grid.scss
+++ b/packages/osc-ui/src/components/IslandGrid/island-grid.scss
@@ -1,26 +1,36 @@
+/* stylelint-disable plugin/selector-bem-pattern */
 @use "sass:list";
 @import "../../styles/settings";
 @import "../../styles/tools";
 
 @layer components {
-    $island-cols: 2;
-    $max-islands: 4;
-
     .c-island-grid {
+        $self: &;
+        $island-cols: 2;
+        $max-islands: 4;
+
         @include mq($mq-tab) {
             grid-template-rows: repeat($island-cols, minmax(0, 1fr));
         }
 
-        &__island {
-            @include mq($mq-tab) {
-                &:nth-child(1) {
-                    grid-row: list.slash(1, $max-islands);
-                }
+        @for $i from 3 through $max-islands {
+            &.has-#{$i}-islands {
+                @include mq($mq-tab) {
+                    #{$self}__island {
+                        &:nth-child(1) {
+                            grid-row: list.slash(1, $i);
+                        }
 
-                @for $i from 2 through $max-islands {
-                    &:nth-child(#{$i}) {
-                        // Position the island in the row minus 1 place from it's index
-                        grid-row: #{$i - 1};
+                        @for $j from 2 through $i {
+                            &:nth-child(#{$j}) {
+                                // Position the island in the row minus 1 place from it's index
+                                grid-row: #{$j - 1};
+                            }
+                        }
+
+                        > * {
+                            height: 100%;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #765 

## 📝 Description

Tweaks the island grid css slightly so the height of the first item will match with the height of the items on the right. 
Currently setting of the max end of the rows as 4 causes the large item to expand past the end of the last item on the right if there are only two.

## ⛳️ Current behavior (updates)

- Height of the "large" island is handled by `grid-row: 1 / 4`

## 🚀 New behavior

- Adds a `has-{n}-islands` class
- adds a loop to loop through the max islands and sets the value to each `has-{n}-islands` class
- positioning is then handled by these classes

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
