### PR TITLE
Refactor/cards height

### DIFF
--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -117,6 +117,11 @@ $card-fs-3xl: $fs-3xl;
             margin-block-start: auto;
             display: flex;
             flex-direction: column;
+            height: 100%;
+
+            &-inner {
+                margin-block-end: auto;
+            }
         }
 
         &__footer {

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -82,6 +82,7 @@ $card-fs-3xl: $fs-3xl;
         &__inner {
             z-index: 1;
             padding: $card-space-m $card-space-xl $card-space-xl;
+            grid-template-rows: auto 1fr;
         }
 
         &__header {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #764 

## 📝 Description
Adds a few extra properties to the `.c-card` class to help align the content better when used in layouts like `o-grid` or our `<Carousel>` component.

Before:
<img width="384" alt="image" src="https://user-images.githubusercontent.com/23461173/223463816-5774d05b-238e-442c-a610-f1b94ca76ec7.png">

After:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/23461173/223462474-542ffa9f-9062-48fc-8bb4-f2ff3f6015bf.png">


## ⛳️ Current behavior (updates)

- Height is controlled by the content and the implicit grid of `c-card__inner`

## 🚀 New behavior

- `c-card__inner` now has an explicit grid, this prevents the `<CardHeader>` setting it's own height based on the height if the card and instead sets it to the height of it's contents.
- `c-card` and `c-card__body` have a height of 100%, this makes the card fill the height of any grid or flex container
- `c-card__body-inner` has a bottom margin of auto to push following items such as buttons to the end

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
