### PR TITLE
Bugfix/duplicate stylesheets

### DIFF
--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -4,6 +4,7 @@ import oscUiAccordionStyles from 'osc-ui/dist/src-components-Accordion-accordion
 import alertStyles from 'osc-ui/dist/src-components-Alert-alert.css';
 import buttonStyles from 'osc-ui/dist/src-components-Button-button.css';
 import cardStyles from 'osc-ui/dist/src-components-Card-card.css';
+import carouselStyles from 'osc-ui/dist/src-components-Carousel-carousel.css';
 import contentStyles from 'osc-ui/dist/src-components-Content-content.css';
 import contentMediaStyles from 'osc-ui/dist/src-components-ContentMedia-content-media.css';
 import heroStyles from 'osc-ui/dist/src-components-Hero-hero.css';
@@ -79,10 +80,15 @@ export const getComponentStyles = (data: SanityPage) => {
     // with the same type. Causing multiples of the same stylesheet to be loaded.
     const moduleTypes = [...new Set(getTypes(data))];
 
+    // We then need to add all of the stylesheet dependencies for each module type.
+    // We will dedupe these after they are all pushed into the styles array.
     for (const module of moduleTypes) {
         switch (module) {
             case 'module.accordion':
-                styles.push({ rel: 'stylesheet', href: oscUiAccordionStyles });
+                styles.push(
+                    { rel: 'stylesheet', href: oscUiAccordionStyles },
+                    { rel: 'stylesheet', href: contentStyles }
+                );
                 break;
 
             case 'module.button':
@@ -90,13 +96,21 @@ export const getComponentStyles = (data: SanityPage) => {
                 break;
 
             case 'module.cards':
-                styles.push({ rel: 'stylesheet', href: cardStyles });
-                styles.push({ rel: 'stylesheet', href: popoverStyles });
-                styles.push({ rel: 'stylesheet', href: islandGrid });
+                styles.push(
+                    { rel: 'stylesheet', href: cardStyles },
+                    { rel: 'stylesheet', href: carouselStyles },
+                    { rel: 'stylesheet', href: popoverStyles },
+                    { rel: 'stylesheet', href: islandGrid },
+                    { rel: 'stylesheet', href: contentStyles },
+                    { rel: 'stylesheet', href: buttonStyles }
+                );
                 break;
 
             case 'module.content':
-                styles.push({ rel: 'stylesheet', href: contentStyles });
+                styles.push(
+                    { rel: 'stylesheet', href: contentStyles },
+                    { rel: 'stylesheet', href: buttonStyles }
+                );
                 break;
 
             case 'module.forms':
@@ -104,7 +118,12 @@ export const getComponentStyles = (data: SanityPage) => {
                 styles.push({ rel: 'stylesheet', href: textInputStyles });
                 break;
             case 'module.hero':
-                styles.push({ rel: 'stylesheet', href: heroStyles });
+                styles.push(
+                    { rel: 'stylesheet', href: heroStyles },
+                    { rel: 'stylesheet', href: carouselStyles },
+                    { rel: 'stylesheet', href: contentStyles },
+                    { rel: 'stylesheet', href: buttonStyles }
+                );
                 break;
 
             case 'module.textGrid':
@@ -116,7 +135,10 @@ export const getComponentStyles = (data: SanityPage) => {
                 break;
 
             case 'module.video':
-                styles.push({ rel: 'stylesheet', href: videoStyles });
+                styles.push(
+                    { rel: 'stylesheet', href: videoStyles },
+                    { rel: 'stylesheet', href: contentStyles }
+                );
                 break;
         }
     }

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -28,6 +28,7 @@ import type {
     trustpilotModule,
     videoModule,
 } from '~/types/sanity';
+import { getUniqueObjects } from '~/utils/getUniqueObjects';
 import { AccordionModule } from './Accordion/Accordion';
 import { Cards } from './Cards/Cards';
 import { ContentMediaModule } from './ContentMedia/ContentMedia';
@@ -143,7 +144,8 @@ export const getComponentStyles = (data: SanityPage) => {
         }
     }
 
-    return styles;
+    // Dedupe the array of stylesheets based on the href property.
+    return getUniqueObjects(styles, 'href');
 };
 
 interface Props {

--- a/packages/osc-ecommerce/app/root.tsx
+++ b/packages/osc-ecommerce/app/root.tsx
@@ -15,7 +15,6 @@ import { SkipLink } from 'osc-ui';
 import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import oscUiAccordionStyles from 'osc-ui/dist/src-components-Accordion-accordion.css';
 import oscUiBurgerStyles from 'osc-ui/dist/src-components-Burger-burger.css';
-import oscUiCarouselStyles from 'osc-ui/dist/src-components-Carousel-carousel.css';
 import oscFooterStyles from 'osc-ui/dist/src-components-Footer-footer.css';
 import oscHeaderStyles from 'osc-ui/dist/src-components-Header-header.css';
 import oscLogoStyles from 'osc-ui/dist/src-components-Logo-logo.css';
@@ -44,7 +43,6 @@ export const links: LinksFunction = () => {
             as: 'image',
         },
         { rel: 'stylesheet', href: styles },
-        { rel: 'stylesheet', href: oscUiCarouselStyles },
         { rel: 'stylesheet', href: oscUiSwitchStyles },
         { rel: 'stylesheet', href: oscUiSkipLinkStyle },
         { rel: 'stylesheet', href: oscHeaderStyles },

--- a/packages/osc-ecommerce/app/utils/getUniqueObjects.spec.ts
+++ b/packages/osc-ecommerce/app/utils/getUniqueObjects.spec.ts
@@ -1,0 +1,26 @@
+import { getUniqueObjects } from './getUniqueObjects';
+
+test('removes duplicate objects from the array', () => {
+    const stylesheets = [
+        { rel: 'stylesheet', href: 'accordionStyles' },
+        { rel: 'stylesheet', href: 'contentStyles' },
+        { rel: 'stylesheet', href: 'cardStyles' },
+        { rel: 'stylesheet', href: 'carouselStyles' },
+        { rel: 'stylesheet', href: 'popoverStyles' },
+        { rel: 'stylesheet', href: 'islandGrid' },
+        { rel: 'stylesheet', href: 'contentStyles' },
+        { rel: 'stylesheet', href: 'buttonStyles' },
+        { rel: 'stylesheet', href: 'heroStyles' },
+        { rel: 'stylesheet', href: 'carouselStyles' },
+        { rel: 'stylesheet', href: 'contentStyles' },
+        { rel: 'stylesheet', href: 'buttonStyles' },
+    ];
+
+    const uniqueStyleSheets = getUniqueObjects(stylesheets, 'href');
+
+    expect(uniqueStyleSheets).toHaveLength(8);
+
+    expect(uniqueStyleSheets).toEqual(
+        expect.arrayContaining([expect.objectContaining({ href: expect.any(String) })])
+    );
+});

--- a/packages/osc-ecommerce/app/utils/getUniqueObjects.ts
+++ b/packages/osc-ecommerce/app/utils/getUniqueObjects.ts
@@ -1,0 +1,30 @@
+/**
+ * Get a unique array of objects
+ *
+ * @param array array of objects
+ * @param identifier string to identify the object property you want to use as a unique identifier
+ * @returns Array of unique objects
+ */
+
+type ObjWithWildcards<T> = T & { [key: string]: unknown };
+type Identifier = string | number;
+
+export const getUniqueObjects = (array: object[], identifier: Identifier) => {
+    const arrayOfObjects = array as ObjWithWildcards<{ [identifier: Identifier]: Identifier }>[];
+    // Create a place to store the unique values
+    const flag: { [identifier: Identifier]: Identifier | boolean } = {};
+    const unique: typeof array = [];
+
+    // If the item isn't in the flag object add it and push into the array
+    // Otherwise skip over it
+    arrayOfObjects.forEach((item) => {
+        const id = identifier as keyof typeof item;
+
+        if (!flag[item[id]]) {
+            flag[item[id]] = true;
+            unique.push(item);
+        }
+    });
+
+    return unique;
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #772 

## 📝 Description

When loading the stylesheets for the modules coming out of Sanity we will need to include both the stylesheet for the component and it's dependencies. For example the Hero is made up of `<Hero>`, `<Content>`, `<Carousel>` and `<Button>`. Currently when we add these stylesheets we are only adding them like this
```ts
case 'module.hero':
  styles.push(
    { rel: 'stylesheet', href: heroStyles }
  );
  break;
```
Which means the dependent styles will either be missing or loaded because we are using another module on the page.
To get around this we will do this
```ts
case 'module.hero':
  styles.push(
    { rel: 'stylesheet', href: heroStyles },
    { rel: 'stylesheet', href: carouselStyles },
    { rel: 'stylesheet', href: contentStyles },
    { rel: 'stylesheet', href: buttonStyles }
  );
  break;
```
However this will lead to loading duplicate stylesheets onto the page.

## ⛳️ Current behavior (updates)

Either missing style dependencies or duplicate stylesheets.

## 🚀 New behavior

Adds a `getUniqueObjects` function which we can use to dedupe the styles array in `getComponentStyles`

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
