### PR TITLE
Refactor/carousel on ecommerce

### DIFF
--- a/packages/osc-ecommerce/app/components/Carousel/Carousel.tsx
+++ b/packages/osc-ecommerce/app/components/Carousel/Carousel.tsx
@@ -1,0 +1,61 @@
+import { Carousel, Image, rem } from 'osc-ui';
+import type { carouselModule } from '~/types/sanity';
+
+// ! TEMPORARY fix for tokens path not matching dev and prod environments
+// ! Once solution in place we can update this to use design token files instead
+const mq = {
+    tab: 768,
+    'desk-lrg': 1440,
+};
+
+export const CarouselModule = (props: { module: carouselModule }) => {
+    const { carouselName, slides, settings } = props?.module;
+
+    const perView = (perView: number | undefined) => (perView ? perView : 1);
+
+    return slides && slides.length > 0 ? (
+        <Carousel
+            carouselName={carouselName ? carouselName : ''}
+            arrows={settings?.arrows}
+            dotNav={settings?.dotNav}
+            loop={settings?.loop}
+            autoplay={settings?.autoplay}
+            slidesPerView={perView(settings?.slidesPerView?.mobile)}
+            startIndex={settings?.startIndex ? settings?.startIndex - 1 : 0} // minus 1 so cms users can start at 1
+            breakpoints={{
+                [`(min-width: ${rem(mq['tab'])}rem)`]: {
+                    slides: {
+                        origin: 'auto',
+                        perView: perView(settings?.slidesPerView?.tablet),
+                        spacing: 16,
+                    },
+                },
+                [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
+                    slides: {
+                        origin: 'auto',
+                        perView: perView(settings?.slidesPerView?.desktop),
+                        spacing: 16,
+                    },
+                },
+            }}
+        >
+            {slides.map((slide) =>
+                slide?.image?.src ? (
+                    <Image
+                        key={slide?.image?._key}
+                        src={slide?.image?.src}
+                        width={slide?.image?.width}
+                        height={slide?.image?.height}
+                        alt={slide?.image?.alt}
+                        artDirectedImages={
+                            slide?.image?.responsiveImages
+                                ? slide?.image?.responsiveImages
+                                : undefined
+                        }
+                        className="o-img--contain"
+                    />
+                ) : null
+            )}
+        </Carousel>
+    ) : null;
+};

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -1,5 +1,5 @@
 import type { LinkDescriptor } from '@remix-run/node';
-import { Carousel, Content, Image, Trustpilot } from 'osc-ui';
+import { Content, Image, Trustpilot } from 'osc-ui';
 import oscUiAccordionStyles from 'osc-ui/dist/src-components-Accordion-accordion.css';
 import alertStyles from 'osc-ui/dist/src-components-Alert-alert.css';
 import buttonStyles from 'osc-ui/dist/src-components-Button-button.css';
@@ -14,6 +14,7 @@ import textGridStyles from 'osc-ui/dist/src-components-TextGrid-text-grid.css';
 import textInputStyles from 'osc-ui/dist/src-components-TextInput-text-input.css';
 import videoStyles from 'osc-ui/dist/src-components-VideoPlayer-video-player.css';
 import type {
+    SanityPage,
     accordionModule,
     cardModule,
     carouselModule,
@@ -23,7 +24,6 @@ import type {
     heroModule,
     imageModule,
     module,
-    SanityPage,
     textGridModule,
     trustpilotModule,
     videoModule,
@@ -31,11 +31,12 @@ import type {
 import { getUniqueObjects } from '~/utils/getUniqueObjects';
 import { AccordionModule } from './Accordion/Accordion';
 import { Cards } from './Cards/Cards';
+import { CarouselModule } from './Carousel/Carousel';
 import { ContentMediaModule } from './ContentMedia/ContentMedia';
+import { Forms } from './Forms/Forms';
 import { Hero } from './Hero/Hero';
 import { TextGridModule } from './TextGrid/TextGrid';
 import { VideoPlayerModule } from './VideoPlayer/VideoPlayer';
-import { Forms } from './Forms/Forms';
 
 /**
  * Recursively search for all types in a Sanity schema and filter them by type
@@ -179,19 +180,7 @@ export default function Module(props: Props) {
         case 'module.carousel':
             const moduleCarousel = module as carouselModule;
 
-            return (
-                <Carousel
-                    mediaArray={moduleCarousel.mediaArray}
-                    active={moduleCarousel.active} // fine
-                    delay={moduleCarousel.delay} // fine
-                    slidesPerPage={moduleCarousel.slidesPerPage} // fine
-                    slideGap={moduleCarousel.slideGap} // fine
-                    axis={moduleCarousel.axis} // fine
-                    height={moduleCarousel.height} // fine
-                    loop={moduleCarousel.loop} // fine
-                    startIndex={moduleCarousel.startIndex} // fine
-                ></Carousel>
-            );
+            return <CarouselModule module={moduleCarousel} />;
 
         case 'module.content':
             const moduleContent = module as contentModule;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/carousel.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/carousel.ts
@@ -1,19 +1,14 @@
 import groq from 'groq';
 import { MODULE_IMAGES } from './images';
 
-// pick the info you want
-// TODO: ak add fields from props
 export const MODULE_CAROUSEL = groq`
     _key,
-    height,
-    active,
-    startIndex,
-    mediaArray[] {
-      ${MODULE_IMAGES}
+    _type,
+    carouselName,
+    slides[] {
+        "image": {
+            ${MODULE_IMAGES}
+        }
     },
-    delay,
-    slidesPerPage,
-    slideGap,
-    axis,
-    loop,
+    settings
 `;

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -225,15 +225,11 @@ export interface trustpilotModule extends module {
 }
 
 export interface carouselModule extends module {
-    mediaArray: SanityImage<HTMLImageElement>[];
-    active: boolean;
-    delay: string;
-    slidesPerPage: number;
-    slideGap: number;
-    axis: 'x' | 'y';
-    height: string;
-    loop: boolean;
-    startIndex: number;
+    carouselName?: string;
+    slides?: {
+        image?: imageModule<HTMLImageElement>;
+    }[];
+    settings?: carouselModuleSettings;
 }
 
 export interface carouselModuleSettings extends module {

--- a/packages/osc-studio/schemas/objects/module/carousel.ts
+++ b/packages/osc-studio/schemas/objects/module/carousel.ts
@@ -1,10 +1,10 @@
 import { StarIcon } from '@sanity/icons';
+import pluralize from 'pluralize';
 import { defineField, defineType } from 'sanity';
-import { capitalizeFirstLetter } from '../../../utils/capitalizeFirstLetter';
 
 export default defineType({
     name: 'module.carousel',
-    title: 'Carousel',
+    title: 'Image Carousel',
     type: 'object',
     icon: StarIcon,
     groups: [
@@ -21,11 +21,19 @@ export default defineType({
     fields: [
         defineField({
             title: 'Images',
-            name: 'mediaArray',
+            name: 'slides',
             type: 'array',
             of: [{ type: 'module.images' }],
             description: 'The images and text within the Carousel',
             group: 'slide',
+        }),
+        defineField({
+            name: 'carouselName',
+            title: 'Carousel Name',
+            type: 'string',
+            description: 'The accessible name of the carousel.',
+            group: 'settings',
+            validation: (Rule) => Rule.required(),
         }),
         defineField({
             name: 'settings',
@@ -36,12 +44,16 @@ export default defineType({
     ],
     preview: {
         select: {
-            subtitle: 'type',
+            title: 'carouselName',
+            slides: 'slides',
         },
         prepare(selection) {
+            const { title } = selection;
+            const numberOfSlides = selection.slides.length;
+
             return {
-                title: 'Carousel',
-                subtitle: capitalizeFirstLetter(selection.subtitle),
+                title,
+                subtitle: `Carousel: (${numberOfSlides} ${pluralize('slide', numberOfSlides)})`,
             };
         },
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #771 

## 📝 Description

Trying to use the carousel module in studio would cause an error to throw on the front end of ecommerce. I've taken this opportunity to update the controls in studio to make them a bit more consistent with the others and to abstract the carousel into it's own component on ecommerce.

## ⛳️ Current behavior (updates)

- Using carousel module in Studio causes error in ecommerce
- Carousel is being used directly within the Module.tsx

## 🚀 New behavior

- Updates carousel module in studio for more consistency
- Moves Carousel into it's own component in ecommerce
- Fixes thrown error when used 

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
