### PR TITLE
Feature/add icon picker to button

### DIFF
--- a/packages/osc-ecommerce/app/components/Button/Button.tsx
+++ b/packages/osc-ecommerce/app/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { Button as OSCButton, CopyButton } from 'osc-ui';
+import { Button as OSCButton, CopyButton, Icon } from 'osc-ui';
 import type { buttonModule } from '~/types/sanity';
 
 type Props = {
@@ -21,6 +21,7 @@ export const Button = (props: Props) => {
         textToCopy,
         isInversed,
         variant,
+        icon,
     } = button;
 
     switch (type) {
@@ -36,6 +37,7 @@ export const Button = (props: Props) => {
                     {...rest}
                 >
                     {label}
+                    {icon && <Icon id={icon} />}
                 </OSCButton>
             ) : null;
 
@@ -50,6 +52,7 @@ export const Button = (props: Props) => {
                     {...rest}
                 >
                     {label}
+                    {icon && <Icon id={icon} />}
                 </OSCButton>
             ) : null;
 
@@ -64,6 +67,7 @@ export const Button = (props: Props) => {
                     {...rest}
                 >
                     {label}
+                    {icon && <Icon id={icon} />}
                 </OSCButton>
             ) : null;
 
@@ -79,6 +83,7 @@ export const Button = (props: Props) => {
                     {...rest}
                 >
                     {label}
+                    {icon && <Icon id={icon} />}
                 </OSCButton>
             ) : null;
 
@@ -93,6 +98,7 @@ export const Button = (props: Props) => {
                     {...rest}
                 >
                     {label}
+                    {icon && <Icon id={icon} />}
                 </OSCButton>
             ) : null;
 
@@ -106,6 +112,7 @@ export const Button = (props: Props) => {
                     {...rest}
                 >
                     {label}
+                    {icon && <Icon id={icon} />}
                 </CopyButton>
             ) : null;
 
@@ -113,6 +120,7 @@ export const Button = (props: Props) => {
             return (
                 <OSCButton key={_key} isInversed={isInversed} variant={variant} {...rest}>
                     {label}
+                    {icon && <Icon id={icon} />}
                 </OSCButton>
             );
     }

--- a/packages/osc-ecommerce/app/components/Button/Button.tsx
+++ b/packages/osc-ecommerce/app/components/Button/Button.tsx
@@ -9,26 +9,60 @@ type Props = {
 export const Button = (props: Props) => {
     const { button, isFull, ...rest } = props;
 
-    const { _key, email, externalLink, file, label, slug, telephone, type, textToCopy } = button;
+    const {
+        _key,
+        email,
+        externalLink,
+        file,
+        label,
+        slug,
+        telephone,
+        type,
+        textToCopy,
+        isInversed,
+        variant,
+    } = button;
 
     switch (type) {
         case 'file':
             return file ? (
-                <OSCButton key={_key} as="a" href={file} download {...rest}>
+                <OSCButton
+                    key={_key}
+                    as="a"
+                    href={file}
+                    download
+                    isInversed={isInversed}
+                    variant={variant}
+                    {...rest}
+                >
                     {label}
                 </OSCButton>
             ) : null;
 
         case 'email':
             return email ? (
-                <OSCButton key={_key} as="a" href={`mailto:${email}`} {...rest}>
+                <OSCButton
+                    key={_key}
+                    as="a"
+                    href={`mailto:${email}`}
+                    isInversed={isInversed}
+                    variant={variant}
+                    {...rest}
+                >
                     {label}
                 </OSCButton>
             ) : null;
 
         case 'telephone':
             return telephone ? (
-                <OSCButton key={_key} as="a" href={`tel:${telephone}`} {...rest}>
+                <OSCButton
+                    key={_key}
+                    as="a"
+                    href={`tel:${telephone}`}
+                    isInversed={isInversed}
+                    variant={variant}
+                    {...rest}
+                >
                     {label}
                 </OSCButton>
             ) : null;
@@ -40,6 +74,8 @@ export const Button = (props: Props) => {
                     as="a"
                     href={externalLink?.url}
                     target={externalLink?.newWindow ? '_blank' : '_self'}
+                    isInversed={isInversed}
+                    variant={variant}
                     {...rest}
                 >
                     {label}
@@ -48,21 +84,34 @@ export const Button = (props: Props) => {
 
         case 'internal':
             return slug ? (
-                <OSCButton key={_key} as="link" to={slug} {...rest}>
+                <OSCButton
+                    key={_key}
+                    as="link"
+                    to={slug}
+                    isInversed={isInversed}
+                    variant={variant}
+                    {...rest}
+                >
                     {label}
                 </OSCButton>
             ) : null;
 
         case 'copy to clipboard':
             return textToCopy ? (
-                <CopyButton key={_key} textToCopy={textToCopy} {...rest}>
+                <CopyButton
+                    key={_key}
+                    textToCopy={textToCopy}
+                    isInversed={isInversed}
+                    variant={variant}
+                    {...rest}
+                >
                     {label}
                 </CopyButton>
             ) : null;
 
         default:
             return (
-                <OSCButton key={_key} {...rest}>
+                <OSCButton key={_key} isInversed={isInversed} variant={variant} {...rest}>
                     {label}
                 </OSCButton>
             );

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -61,6 +61,7 @@ export interface buttonModule extends module {
     slug?: string;
     telephone?: string;
     textToCopy?: string;
+    isInversed?: boolean;
 }
 
 export interface contentModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -62,6 +62,7 @@ export interface buttonModule extends module {
     telephone?: string;
     textToCopy?: string;
     isInversed?: boolean;
+    icon?: string;
 }
 
 export interface contentModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -56,7 +56,14 @@ export interface buttonModule extends module {
     label: string;
     reference?: object;
     type: string;
-    variant?: string;
+    variant?:
+        | 'primary'
+        | 'secondary'
+        | 'tertiary'
+        | 'quaternary'
+        | 'quinary'
+        | 'primary-gradient'
+        | 'secondary-gradient';
     email?: string;
     slug?: string;
     telephone?: string;

--- a/packages/osc-studio/schemas/objects/module/button.ts
+++ b/packages/osc-studio/schemas/objects/module/button.ts
@@ -56,6 +56,8 @@ export default {
                 layout: 'radio',
                 direction: 'horizontal',
             },
+            initialValue: 'internal',
+            validation: (Rule) => Rule.required(),
         },
         {
             name: 'file',

--- a/packages/osc-studio/schemas/objects/module/button.ts
+++ b/packages/osc-studio/schemas/objects/module/button.ts
@@ -1,4 +1,5 @@
 import { ButtonIcon } from '@radix-ui/react-icons';
+import { IconPicker } from '../../../components/inputs/IconPicker';
 import { PAGE_REFERENCES } from '../../../constants';
 
 export default {
@@ -12,6 +13,13 @@ export default {
             title: 'Label',
             type: 'string',
             validation: (Rule) => Rule.required(),
+        },
+        {
+            name: 'icon',
+            title: 'Icon',
+            type: 'string',
+            inputComponent: IconPicker,
+            placeholder: 'Select an icon...',
         },
         {
             name: 'variant',

--- a/packages/osc-ui/src/components/Content/Content.tsx
+++ b/packages/osc-ui/src/components/Content/Content.tsx
@@ -8,6 +8,7 @@ import { useSpacing } from '../../hooks/useSpacing';
 import type { Maybe, Spacing } from '../../types';
 import { classNames } from '../../utils/classNames';
 import { Button, ButtonGroup, CopyButton } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
 import { Image } from '../Image/Image';
 import { List, ListItem } from '../List/List';
 
@@ -37,6 +38,7 @@ export interface ButtonProps {
         | 'primary-gradient'
         | 'secondary-gradient'; // TODO: This and the button component should share this
     isInversed?: boolean;
+    icon?: string;
 }
 
 export interface Props {
@@ -187,6 +189,7 @@ export const Content = (props: Props) => {
                                 textToCopy,
                                 isInversed,
                                 variant,
+                                icon,
                             } = button;
 
                             switch (type) {
@@ -201,6 +204,7 @@ export const Content = (props: Props) => {
                                             variant={variant}
                                         >
                                             {label}
+                                            {icon && <Icon id={icon} />}
                                         </Button>
                                     );
 
@@ -214,6 +218,7 @@ export const Content = (props: Props) => {
                                             variant={variant}
                                         >
                                             {label}
+                                            {icon && <Icon id={icon} />}
                                         </Button>
                                     );
 
@@ -227,6 +232,7 @@ export const Content = (props: Props) => {
                                             variant={variant}
                                         >
                                             {label}
+                                            {icon && <Icon id={icon} />}
                                         </Button>
                                     );
 
@@ -241,6 +247,7 @@ export const Content = (props: Props) => {
                                             variant={variant}
                                         >
                                             {label}
+                                            {icon && <Icon id={icon} />}
                                         </Button>
                                     );
 
@@ -254,6 +261,7 @@ export const Content = (props: Props) => {
                                             variant={variant}
                                         >
                                             {label}
+                                            {icon && <Icon id={icon} />}
                                         </Button>
                                     );
 
@@ -266,6 +274,7 @@ export const Content = (props: Props) => {
                                             variant={variant}
                                         >
                                             {label}
+                                            {icon && <Icon id={icon} />}
                                         </CopyButton>
                                     );
 
@@ -277,6 +286,7 @@ export const Content = (props: Props) => {
                                             variant={variant}
                                         >
                                             {label}
+                                            {icon && <Icon id={icon} />}
                                         </Button>
                                     );
                             }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

While putting the demo page together I noticed that cms users can't add icons to the buttons so this PR aims to allow that.
This should help with setting up the Cards on the homepage which have icons on the quaternary button

## ⛳️ Current behavior (updates)

- Buttons can't have icons

## 🚀 New behavior

- Add icon picker to button module in studio
- Update ecommerce `<Button>` and `<Content>` components to take an icon prop and display the icon

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
