### PR TITLE
Bugfix/carousel height

### DIFF
--- a/packages/osc-ui/src/components/Carousel/carousel.scss
+++ b/packages/osc-ui/src/components/Carousel/carousel.scss
@@ -11,7 +11,6 @@
         display: grid;
         grid-template-columns: 1fr;
         grid-template-rows: 1fr;
-        height: 100%;
 
         &__inner {
             grid-column: 1 / -1;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Removes the `height: 100%` set on the `c-carousel` introduced in #715

## ⛳️ Current behavior (updates)

Currently all carousels will take this value and will cause some of them to take up much more height than necessary and causing some strange visual bugs e.g. the hero on the kitchen sink test page:

https://user-images.githubusercontent.com/23461173/224772116-0c401548-723e-4cc4-9d8c-2bd8852f9fcf.mov

## 🚀 New behavior

- Removes `height: 100%` from the carousel so it won't take up the height of it's flex/grid parent.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
