### PR TITLE
Feature/design tokens vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58866,7 +58866,447 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "json-to-scss": "^1.6.2"
+        "@rollup/plugin-commonjs": "^24.0.1",
+        "json-to-scss": "^1.6.2",
+        "vite": "^4.2.1"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/android-arm": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.12.tgz",
+      "integrity": "sha512-E/sgkvwoIfj4aMAPL2e35VnUJspzVYl7+M1B2cqeubdBhADV4uPon0KCc8p2G+LqSJ6i8ocYPCqY3A4GGq0zkQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.12.tgz",
+      "integrity": "sha512-WQ9p5oiXXYJ33F2EkE3r0FRDFVpEdcDiwNX3u7Xaibxfx6vQE0Sb8ytrfQsA5WO6kDn6mDfKLh6KrPBjvkk7xA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/android-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.12.tgz",
+      "integrity": "sha512-m4OsaCr5gT+se25rFPHKQXARMyAehHTQAz4XX1Vk3d27VtqiX0ALMBPoXZsGaB6JYryCLfgGwUslMqTfqeLU0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.12.tgz",
+      "integrity": "sha512-O3GCZghRIx+RAN0NDPhyyhRgwa19MoKlzGonIb5hgTj78krqp9XZbYCvFr9N1eUxg0ZQEpiiZ4QvsOQwBpP+lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.12.tgz",
+      "integrity": "sha512-5D48jM3tW27h1qjaD9UNRuN+4v0zvksqZSPZqeSWggfMlsVdAhH3pwSfQIFJwcs9QJ9BRibPS4ViZgs3d2wsCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.12.tgz",
+      "integrity": "sha512-OWvHzmLNTdF1erSvrfoEBGlN94IE6vCEaGEkEH29uo/VoONqPnoDFfShi41Ew+yKimx4vrmmAJEGNoyyP+OgOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.12.tgz",
+      "integrity": "sha512-A0Xg5CZv8MU9xh4a+7NUpi5VHBKh1RaGJKqjxe4KG87X+mTjDE6ZvlJqpWoeJxgfXHT7IMP9tDFu7IZ03OtJAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.12.tgz",
+      "integrity": "sha512-WsHyJ7b7vzHdJ1fv67Yf++2dz3D726oO3QCu8iNYik4fb5YuuReOI9OtA+n7Mk0xyQivNTPbl181s+5oZ38gyA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.12.tgz",
+      "integrity": "sha512-cK3AjkEc+8v8YG02hYLQIQlOznW+v9N+OI9BAFuyqkfQFR+DnDLhEM5N8QRxAUz99cJTo1rLNXqRrvY15gbQUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.12.tgz",
+      "integrity": "sha512-jdOBXJqcgHlah/nYHnj3Hrnl9l63RjtQ4vn9+bohjQPI2QafASB5MtHAoEv0JQHVb/xYQTFOeuHnNYE1zF7tYw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.12.tgz",
+      "integrity": "sha512-GTOEtj8h9qPKXCyiBBnHconSCV9LwFyx/gv3Phw0pa25qPYjVuuGZ4Dk14bGCfGX3qKF0+ceeQvwmtI+aYBbVA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.12.tgz",
+      "integrity": "sha512-o8CIhfBwKcxmEENOH9RwmUejs5jFiNoDw7YgS0EJTF6kgPgcqLFjgoc5kDey5cMHRVCIWc6kK2ShUePOcc7RbA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.12.tgz",
+      "integrity": "sha512-biMLH6NR/GR4z+ap0oJYb877LdBpGac8KfZoEnDiBKd7MD/xt8eaw1SFfYRUeMVx519kVkAOL2GExdFmYnZx3A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.12.tgz",
+      "integrity": "sha512-jkphYUiO38wZGeWlfIBMB72auOllNA2sLfiZPGDtOBb1ELN8lmqBrlMiucgL8awBw1zBXN69PmZM6g4yTX84TA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.12.tgz",
+      "integrity": "sha512-j3ucLdeY9HBcvODhCY4b+Ds3hWGO8t+SAidtmWu/ukfLLG/oYDMaA+dnugTVAg5fnUOGNbIYL9TOjhWgQB8W5g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.12.tgz",
+      "integrity": "sha512-uo5JL3cgaEGotaqSaJdRfFNSCUJOIliKLnDGWaVCgIKkHxwhYMm95pfMbWZ9l7GeW9kDg0tSxcy9NYdEtjwwmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.12.tgz",
+      "integrity": "sha512-DNdoRg8JX+gGsbqt2gPgkgb00mqOgOO27KnrWZtdABl6yWTST30aibGJ6geBq3WM2TIeW6COs5AScnC7GwtGPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.12.tgz",
+      "integrity": "sha512-aVsENlr7B64w8I1lhHShND5o8cW6sB9n9MUtLumFlPhG3elhNWtE7M1TFpj3m7lT3sKQUMkGFjTQBrvDDO1YWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.12.tgz",
+      "integrity": "sha512-qbHGVQdKSwi0JQJuZznS4SyY27tYXYF0mrgthbxXrZI3AHKuRvU+Eqbg/F0rmLDpW/jkIZBlCO1XfHUBMNJ1pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.12.tgz",
+      "integrity": "sha512-zsCp8Ql+96xXTVTmm6ffvoTSZSV2B/LzzkUXAY33F/76EajNw1m+jZ9zPfNJlJ3Rh4EzOszNDHsmG/fZOhtqDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.12.tgz",
+      "integrity": "sha512-FfrFjR4id7wcFYOdqbDfDET3tjxCozUgbqdkOABsSFzoZGFC92UK7mg4JKRc/B3NNEf1s2WHxJ7VfTdVDPN3ng==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.12.tgz",
+      "integrity": "sha512-JOOxw49BVZx2/5tW3FqkdjSD/5gXYeVGPDcB0lvap0gLQshkh1Nyel1QazC+wNxus3xPlsYAgqU1BUmrmCvWtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/esbuild": {
+      "version": "0.17.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.12.tgz",
+      "integrity": "sha512-bX/zHl7Gn2CpQwcMtRogTTBf9l1nl+H6R8nUbjk+RuKqAE3+8FDulLA+pHvX7aA7Xe07Iwa+CWvy9I8Y2qqPKQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.12",
+        "@esbuild/android-arm64": "0.17.12",
+        "@esbuild/android-x64": "0.17.12",
+        "@esbuild/darwin-arm64": "0.17.12",
+        "@esbuild/darwin-x64": "0.17.12",
+        "@esbuild/freebsd-arm64": "0.17.12",
+        "@esbuild/freebsd-x64": "0.17.12",
+        "@esbuild/linux-arm": "0.17.12",
+        "@esbuild/linux-arm64": "0.17.12",
+        "@esbuild/linux-ia32": "0.17.12",
+        "@esbuild/linux-loong64": "0.17.12",
+        "@esbuild/linux-mips64el": "0.17.12",
+        "@esbuild/linux-ppc64": "0.17.12",
+        "@esbuild/linux-riscv64": "0.17.12",
+        "@esbuild/linux-s390x": "0.17.12",
+        "@esbuild/linux-x64": "0.17.12",
+        "@esbuild/netbsd-x64": "0.17.12",
+        "@esbuild/openbsd-x64": "0.17.12",
+        "@esbuild/sunos-x64": "0.17.12",
+        "@esbuild/win32-arm64": "0.17.12",
+        "@esbuild/win32-ia32": "0.17.12",
+        "@esbuild/win32-x64": "0.17.12"
+      }
+    },
+    "packages/osc-design-tokens/node_modules/vite": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.2.1.tgz",
+      "integrity": "sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.17.5",
+        "postcss": "^8.4.21",
+        "resolve": "^1.22.1",
+        "rollup": "^3.18.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
       }
     },
     "packages/osc-ecommerce": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59468,7 +59468,6 @@
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "^5.0.0",
         "@portabletext/types": "^2.0.2",
-        "@rollup/plugin-commonjs": "^24.0.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:osc-studio": "npx nx run osc-studio:build",
     "build:osc-ecommerce": "npx nx run osc-ecommerce:build",
     "build:osc-academic-hub": "npx nx run osc-academic-hub:build",
+    "build:osc-design-tokens": "npx nx run osc-design-tokens:build",
     "test": "npx nx run-many --target=test --all",
     "test:osc-ui": "npx nx run osc-ui:test",
     "test:osc-ecommerce": "npx nx run osc-ecommerce:test",

--- a/packages/osc-design-tokens/index.js
+++ b/packages/osc-design-tokens/index.js
@@ -4,10 +4,8 @@ const fluidScale = require('./tokens/fluid-scale');
 const mediaQueries = require('./tokens/media-queries');
 const typography = require('./tokens/typography');
 
-module.exports = {
-    colors,
-    containers,
-    fluidScale,
-    mediaQueries,
-    typography,
-};
+exports.colors = colors;
+exports.containers = containers;
+exports.fluidScale = fluidScale;
+exports.mediaQueries = mediaQueries;
+exports.typography = typography;

--- a/packages/osc-design-tokens/package.json
+++ b/packages/osc-design-tokens/package.json
@@ -2,14 +2,27 @@
   "name": "osc-design-tokens",
   "version": "1.0.0",
   "description": "Most of our configurable styles are handled in here by our tokens. Tokens are a way to define a set of variables that can be used across multiple platforms. We use tokens to define our colors, spacing, typography, and more.",
-  "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "generate": "json-to-scss ./tokens/**/*.* ../osc-ui/src/styles/settings/_tokens.scss --tn 2"
+    "build": "vite build",
+    "generate": "vite build && json-to-scss ./tokens/**/*.* ../osc-ui/src/styles/settings/_tokens.scss --tn 2"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "json-to-scss": "^1.6.2"
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "json-to-scss": "^1.6.2",
+    "vite": "^4.2.1"
   }
 }

--- a/packages/osc-design-tokens/vite.config.js
+++ b/packages/osc-design-tokens/vite.config.js
@@ -1,0 +1,16 @@
+import commonjs from '@rollup/plugin-commonjs';
+import path from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    plugins: [commonjs()],
+    build: {
+        minify: true,
+        reportCompressedSize: true,
+        lib: {
+            entry: path.resolve(__dirname, 'index.js'),
+            fileName: 'index',
+            formats: ['es', 'cjs'],
+        },
+    },
+});

--- a/packages/osc-studio/components/inputs/ColorPicker.tsx
+++ b/packages/osc-studio/components/inputs/ColorPicker.tsx
@@ -4,9 +4,11 @@ import PatchEvent, { set, unset } from '@sanity/form-builder/PatchEvent';
 import { SearchIcon } from '@sanity/icons';
 import { Autocomplete, Box, Card, Flex, Text } from '@sanity/ui';
 import { uuid } from '@sanity/uuid';
-import { colors } from 'osc-design-tokens';
 import React from 'react';
 import { capitalizeFirstLetter } from '../../utils/capitalizeFirstLetter';
+
+// ! Temporary fix: can update this to an import in Sanity V3
+const { colors } = require('osc-design-tokens/dist/index.js');
 
 interface Props {
     /**

--- a/packages/osc-studio/schemas/blocks/body.tsx
+++ b/packages/osc-studio/schemas/blocks/body.tsx
@@ -1,5 +1,8 @@
-import { colors, fluidScale as sizes } from 'osc-design-tokens';
 import React from 'react';
+
+// ! Temporary fix: can update this to an import in Sanity V3
+const { colors, fluidScale } = require('osc-design-tokens/dist/index.js');
+const sizes = fluidScale;
 
 const excludeColors = (key) =>
     !key.includes('shadow') &&

--- a/packages/osc-ui/package.json
+++ b/packages/osc-ui/package.json
@@ -62,7 +62,6 @@
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^5.0.0",
     "@portabletext/types": "^2.0.2",
-    "@rollup/plugin-commonjs": "^24.0.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/packages/osc-ui/rollup.config.js
+++ b/packages/osc-ui/rollup.config.js
@@ -1,4 +1,3 @@
-import commonjs from '@rollup/plugin-commonjs';
 import dotenv from 'dotenv';
 import copy from 'rollup-plugin-copy';
 import dts from 'rollup-plugin-dts';
@@ -22,7 +21,6 @@ export default [
             },
         ],
         plugins: [
-            commonjs(),
             typescript({ check: false }),
             // Copy the fonts into our dist folder
             copy({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Part one of the Sanity V3 updates.

With V3 now using Vite as the compiler it has started throwing an error when we try to import our design tokens
```
Uncaught error: require is not defined
http://localhost:3333/schemas/blocks/body.tsx?t=1679325463566:5:5
ReferenceError: require is not defined
    at http://localhost:3333/schemas/blocks/body.tsx?t=1679325463566:5:5
```
This is because Sanity is an SPA and `require` is not available so we need to provide the tokens as a module.

However because we need to make use of the `json-to-scss` package we need our input files to continue to use the `require` syntax. Therefore I have added Vite to bundle the package into both `es` and `cjs` syntaxes, stored in the `dist` directory.

I believe Vite is treeshakable by default as well so we might gain some perf improvements, albeit pretty minor in this case.

## ⛳️ Current behavior (updates)

- Design tokens package simply exports the objects using `module.exports`

## 🚀 New behavior

- Adds Vite to bundle the package into `es` and `cjs` files
- Changes default exports to named exports
- Adds `build:osc-design-tokens` script

## 💣 Is this a breaking change (Yes/No): Yes

Should only be temporary but for the time being; if you wish to use tokens inside of Sanity you will need to directly target the `cjs` file like this
```ts
const { colors } = require('osc-design-tokens/dist/index.js');
```
But once V3 is implemented this should no longer be needed

## 📝 Additional Information
