### PR TITLE
Refactor/modal

### DIFF
--- a/packages/osc-ui/package.json
+++ b/packages/osc-ui/package.json
@@ -30,6 +30,7 @@
     "@portabletext/react": "^2.0.2",
     "@radix-ui/react-accessible-icon": "^1.0.1",
     "@radix-ui/react-accordion": "^1.1.0",
+    "@radix-ui/react-alert-dialog": "^1.0.3",
     "@radix-ui/react-avatar": "^1.0.1",
     "@radix-ui/react-checkbox": "^1.0.2",
     "@radix-ui/react-dialog": "^1.0.2",

--- a/packages/osc-ui/src/components/Modal/AlertModal.stories.tsx
+++ b/packages/osc-ui/src/components/Modal/AlertModal.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+import { Button, ButtonGroup } from '../Button/Button';
+import type { AlertModalProps } from './AlertModal';
+import {
+    AlertModal,
+    AlertModalAction,
+    AlertModalCancel,
+    AlertModalContent,
+    AlertModalDescription,
+    AlertModalTitle,
+    AlertModalTrigger,
+} from './AlertModal';
+
+export default {
+    title: 'osc-ui/Dialogs/AlertModal',
+    component: AlertModal,
+    subcomponents: {
+        AlertModalContent,
+        AlertModalDescription,
+        AlertModalTitle,
+        AlertModalTrigger,
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'A modal dialog that interrupts the user with important content and expects a response.<br>Takes the same props as the default `Modal` component. However can only be closed by interacting with the `AlertModalAction` or `AlertModalCancel` components.',
+            },
+        },
+    },
+} as Meta;
+
+const Template: Story<AlertModalProps> = (args) => (
+    <AlertModal {...args}>
+        <AlertModalTrigger asChild>
+            <Button>Open modal</Button>
+        </AlertModalTrigger>
+        <AlertModalContent>
+            <AlertModalTitle>Are you absolutely sure?</AlertModalTitle>
+            <AlertModalDescription>
+                This action cannot be undone. This will permanently delete your account and remove
+                your data from our servers.
+            </AlertModalDescription>
+
+            <ButtonGroup>
+                <AlertModalAction asChild>
+                    <Button variant="secondary" size="sm">
+                        Confirm
+                    </Button>
+                </AlertModalAction>
+
+                <AlertModalCancel asChild>
+                    <Button variant="tertiary" size="sm">
+                        Cancel
+                    </Button>
+                </AlertModalCancel>
+            </ButtonGroup>
+        </AlertModalContent>
+    </AlertModal>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {};

--- a/packages/osc-ui/src/components/Modal/AlertModal.tsx
+++ b/packages/osc-ui/src/components/Modal/AlertModal.tsx
@@ -1,0 +1,184 @@
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import React, { forwardRef } from 'react';
+
+import type { ComponentPropsWithoutRef, ElementRef } from 'react';
+import { useModifier } from '../../hooks/useModifier';
+import type { Maybe } from '../../types';
+import { classNames } from '../../utils/classNames';
+
+export interface SharedAlertModalProps {
+    /**
+     * Custom class
+     */
+    className?: string;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Alert Modal
+ * -----------------------------------------------------------------------------------------------*/
+export interface AlertModalProps
+    extends ComponentPropsWithoutRef<typeof AlertDialog.Root>,
+        SharedAlertModalProps {}
+
+export const AlertModal = (props: AlertModalProps) => {
+    const { children } = props;
+
+    return (
+        <AlertDialog.Root className="c-modal" {...props}>
+            {children}
+        </AlertDialog.Root>
+    );
+};
+AlertModal.displayName = 'AlertModal';
+
+/* -------------------------------------------------------------------------------------------------
+ * Alert Modal Trigger
+ * -----------------------------------------------------------------------------------------------*/
+export interface AlertModalTriggerProps
+    extends ComponentPropsWithoutRef<typeof AlertDialog.Trigger>,
+        SharedAlertModalProps {}
+
+export const AlertModalTrigger = forwardRef<
+    ElementRef<typeof AlertDialog.Trigger>,
+    AlertModalTriggerProps
+>((props, forwardedRef) => {
+    const { children, className, ...rest } = props;
+    const classes = classNames('c-modal__trigger', className);
+
+    return (
+        <AlertDialog.Trigger className={classes} {...rest} ref={forwardedRef}>
+            {children}
+        </AlertDialog.Trigger>
+    );
+});
+AlertModalTrigger.displayName = 'AlertModalTrigger';
+
+/* -------------------------------------------------------------------------------------------------
+ * Alert Modal Content
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalContentProps
+    extends ComponentPropsWithoutRef<typeof AlertDialog.Content>,
+        SharedAlertModalProps {
+    /**
+     * Customise the element that your alert dialog portals into.
+     * @see: https://www.radix-ui.com/docs/primitives/components/alert-dialog#custom-portal-container
+     * @default undefined
+     */
+    container?: Maybe<HTMLElement>;
+    /**
+     * Whether to display the overlay or not
+     * @default true
+     */
+    showOverlay?: boolean;
+    /**
+     * 'Sets the size of the button'
+     * @default md
+     */
+    size?: 'sm' | 'md' | 'lg' | 'full';
+}
+
+export const AlertModalContent = forwardRef<
+    ElementRef<typeof AlertDialog.Content>,
+    ModalContentProps
+>((props, forwardedRef) => {
+    const { children, className, container, showOverlay = true, size = 'md', ...rest } = props;
+    const sizeModifier = useModifier('c-modal__content', size);
+    const classes = classNames('c-modal__content', sizeModifier, className);
+
+    return (
+        <AlertDialog.Portal container={container}>
+            {showOverlay ? <AlertDialog.Overlay className="c-modal__overlay" /> : null}
+
+            <AlertDialog.Content className={classes} {...rest} ref={forwardedRef}>
+                {children}
+            </AlertDialog.Content>
+        </AlertDialog.Portal>
+    );
+});
+AlertModalContent.displayName = 'AlertModalContent';
+
+/* -------------------------------------------------------------------------------------------------
+ * Alert Modal Title
+ * -----------------------------------------------------------------------------------------------*/
+export interface AlertModalTitleProps
+    extends ComponentPropsWithoutRef<typeof AlertDialog.Title>,
+        SharedAlertModalProps {}
+
+export const AlertModalTitle = forwardRef<
+    ElementRef<typeof AlertDialog.Title>,
+    AlertModalTitleProps
+>((props, forwardedRef) => {
+    const { children, className, ...rest } = props;
+    const classes = classNames('c-modal__ttl t-font-m u-text-bold', className);
+
+    return (
+        <AlertDialog.Title className={classes} {...rest} ref={forwardedRef}>
+            {children}
+        </AlertDialog.Title>
+    );
+});
+AlertModalTitle.displayName = 'AlertModalTitle';
+
+/* -------------------------------------------------------------------------------------------------
+ * Alert Modal Description
+ * -----------------------------------------------------------------------------------------------*/
+export interface AlertModalDescriptionProps
+    extends ComponentPropsWithoutRef<typeof AlertDialog.Description>,
+        SharedAlertModalProps {}
+
+export const AlertModalDescription = forwardRef<
+    ElementRef<typeof AlertDialog.Description>,
+    AlertModalDescriptionProps
+>((props, forwardedRef) => {
+    const { children, className, ...rest } = props;
+    const classes = classNames('c-modal__desc', className);
+
+    return (
+        <AlertDialog.Description className={classes} {...rest} ref={forwardedRef}>
+            {children}
+        </AlertDialog.Description>
+    );
+});
+AlertModalDescription.displayName = 'AlertModalTitle';
+
+/* -------------------------------------------------------------------------------------------------
+ * Alert Modal Action
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalActionProps
+    extends ComponentPropsWithoutRef<typeof AlertDialog.Action>,
+        SharedAlertModalProps {}
+
+export const AlertModalAction = forwardRef<ElementRef<typeof AlertDialog.Action>, ModalActionProps>(
+    (props, forwardedRef) => {
+        const { children, className, ...rest } = props;
+        const classes = classNames('c-modal__action', className);
+
+        return (
+            <AlertDialog.Action className={classes} {...rest} ref={forwardedRef}>
+                {children}
+            </AlertDialog.Action>
+        );
+    }
+);
+AlertModalAction.displayName = 'AlertModalAction';
+
+/* -------------------------------------------------------------------------------------------------
+ * Alert Modal Cancel
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalCancelProps
+    extends ComponentPropsWithoutRef<typeof AlertDialog.Action>,
+        SharedAlertModalProps {}
+
+export const AlertModalCancel = forwardRef<ElementRef<typeof AlertDialog.Action>, ModalCancelProps>(
+    (props, forwardedRef) => {
+        const { children, className, ...rest } = props;
+        const classes = classNames('c-modal__action', className);
+
+        return (
+            <AlertDialog.Action className={classes} {...rest} ref={forwardedRef}>
+                {children}
+            </AlertDialog.Action>
+        );
+    }
+);
+AlertModalCancel.displayName = 'AlertModalCancel';

--- a/packages/osc-ui/src/components/Modal/Modal.spec.tsx
+++ b/packages/osc-ui/src/components/Modal/Modal.spec.tsx
@@ -1,106 +1,115 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import type { Props } from './Modal';
-import { Modal } from './Modal';
+import { render } from 'test-utils';
+import { Button } from '../Button/Button';
+import { Modal, ModalAction, ModalCancel, ModalContent, ModalTrigger } from './Modal';
 
-describe('Modal component', () => {
-    const setup = ({
-        open,
-        onOpenChange,
-        ModalButtonText,
-        title,
-        modalDescription,
-        hideFooterCloseButton,
-        hideHeaderCloseButton,
-        overlayColour,
-        primaryActionButton,
-        primaryActionButtonText,
-        onClick
-    }: Props) => {
-        render(
-            <Modal
-                open={open}
-                onOpenChange={onOpenChange}
-                ModalButtonText={ModalButtonText}
-                hideFooterCloseButton={hideFooterCloseButton}
-                hideHeaderCloseButton={hideHeaderCloseButton}
-                overlayColour={overlayColour}
-                disableOutsideClick={false}
-                modalDescription={modalDescription}
-                primaryActionButton={primaryActionButton}
-                primaryActionButtonText={primaryActionButtonText}
-                onClick={onClick}
-                title={title}
-                size={'lg'}
-            />
-        );
-    };
+const content = {
+    open: 'Open modal',
+    title: 'An accessible title to be announced when the dialog is opened.',
+    description: 'An optional accessible description to be announced when the dialog is opened.',
+};
 
-    test('renders modal with no close button', async () => {
-        const user = userEvent.setup();
+test('renders the modal component', async () => {
+    const user = userEvent.setup();
 
-        setup({
-            ModalButtonText: 'click to open modal',
-            title: 'testing modal',
-            modalDescription: 'An accessible description to be announced when the dialog is opened',
-            size: 'xl',
-            hideHeaderCloseButton: false,
-            hideFooterCloseButton: true,
-            overlayColour: 'green',
-            primaryActionButton: true,
-            primaryActionButtonText: 'click me',
-            onClick: () => {}
-        });
+    render(
+        <Modal>
+            <ModalTrigger asChild>
+                <Button>{content.open}</Button>
+            </ModalTrigger>
+            <ModalContent title={content.title} description={content.description}>
+                <p>Modal content</p>
+            </ModalContent>
+        </Modal>
+    );
 
-        await user.click(screen.getByRole('button', { name: 'click to open modal' }));
+    await user.click(screen.getByRole('button', { name: content.open }));
 
-        const closeButton = document.querySelector('.c-modal__footer button[aria-label="Close"]');
-        expect(closeButton).not.toBeInTheDocument();
-    });
+    expect(document.querySelector('.c-modal__overlay')).toBeVisible();
+    expect(screen.getByRole('dialog')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeVisible();
+    expect(
+        screen.getByRole('heading', {
+            name: content.title,
+        })
+    ).toBeVisible();
+    expect(screen.getByText(content.description)).toBeVisible();
+    expect(screen.getByText('Modal content')).toBeVisible();
+});
 
-    test('renders modal with no X button', async () => {
-        const user = userEvent.setup();
+test('renders the modal component without a description', async () => {
+    const user = userEvent.setup();
 
-        setup({
-            ModalButtonText: 'click to open modal',
-            title: 'testing modal',
-            modalDescription: 'An accessible description to be announced when the dialog is opened',
-            size: 'xl',
-            hideHeaderCloseButton: true,
-            hideFooterCloseButton: false,
-            overlayColour: 'green',
-            primaryActionButton: true,
-            primaryActionButtonText: 'click me',
-            onClick: () => {}
-        });
+    render(
+        <Modal>
+            <ModalTrigger asChild>
+                <Button>{content.open}</Button>
+            </ModalTrigger>
+            <ModalContent title={content.title} aria-describedby={undefined}>
+                <p>Modal content</p>
+            </ModalContent>
+        </Modal>
+    );
 
-        await user.click(screen.getByRole('button', { name: 'click to open modal' }));
+    await user.click(screen.getByRole('button', { name: content.open }));
 
-        const closeButton = document.querySelector('.c-modal__header button');
-        expect(closeButton).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText(content.description)).not.toBeInTheDocument();
+});
 
-    test('renders the primary action button', async () => {
-        const user = userEvent.setup();
+test('renders the modal without an overlay', async () => {
+    const user = userEvent.setup();
 
-        setup({
-            ModalButtonText: 'click to open modal',
-            title: 'testing modal',
-            modalDescription: 'An accessible description to be announced when the dialog is opened',
-            size: 'xl',
-            hideHeaderCloseButton: true,
-            hideFooterCloseButton: true,
-            overlayColour: 'green',
-            primaryActionButton: true,
-            primaryActionButtonText: 'primary action button',
-            onClick: () => {}
-        });
+    render(
+        <Modal>
+            <ModalTrigger asChild>
+                <Button>{content.open}</Button>
+            </ModalTrigger>
+            <ModalContent
+                title={content.title}
+                description={content.description}
+                showOverlay={false}
+            >
+                <p>Modal content</p>
+            </ModalContent>
+        </Modal>
+    );
 
-        await user.click(screen.getByRole('button', { name: 'click to open modal' }));
+    await user.click(screen.getByRole('button', { name: content.open }));
 
-        expect(screen.getByText('primary action button')).toHaveTextContent(
-            'primary action button'
-        );
-    });
+    expect(document.querySelector('.c-modal__overlay')).not.toBeInTheDocument();
+});
+
+test('renders the modal as an alert dialog', async () => {
+    const user = userEvent.setup();
+
+    render(
+        <Modal isAlert>
+            <ModalTrigger asChild>
+                <Button>{content.open}</Button>
+            </ModalTrigger>
+            <ModalContent
+                title={content.title}
+                description={content.description}
+                showOverlay={false}
+            >
+                <ModalAction>Confirm</ModalAction>
+
+                <ModalCancel>Cancel</ModalCancel>
+            </ModalContent>
+        </Modal>
+    );
+
+    await user.click(screen.getByRole('button', { name: content.open }));
+
+    expect(screen.getByRole('alertdialog')).toBeVisible();
+    expect(
+        screen.getByRole('heading', {
+            name: content.title,
+        })
+    ).toBeVisible();
+    expect(screen.getByText(content.description)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
 });

--- a/packages/osc-ui/src/components/Modal/Modal.spec.tsx
+++ b/packages/osc-ui/src/components/Modal/Modal.spec.tsx
@@ -1,9 +1,27 @@
+import { Icon } from '@radix-ui/react-select';
+import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render } from 'test-utils';
 import { Button } from '../Button/Button';
-import { Modal, ModalAction, ModalCancel, ModalContent, ModalTrigger } from './Modal';
+import {
+    AlertModal,
+    AlertModalAction,
+    AlertModalCancel,
+    AlertModalContent,
+    AlertModalDescription,
+    AlertModalTitle,
+    AlertModalTrigger,
+} from './AlertModal';
+import {
+    Modal,
+    ModalCloseButton,
+    ModalContent,
+    ModalDescription,
+    ModalTitle,
+    ModalTrigger,
+} from './Modal';
 
 const content = {
     open: 'Open modal',
@@ -11,105 +29,122 @@ const content = {
     description: 'An optional accessible description to be announced when the dialog is opened.',
 };
 
-test('renders the modal component', async () => {
-    const user = userEvent.setup();
+describe('Modal', () => {
+    test('renders the modal component', async () => {
+        const user = userEvent.setup();
 
-    render(
-        <Modal>
-            <ModalTrigger asChild>
-                <Button>{content.open}</Button>
-            </ModalTrigger>
-            <ModalContent title={content.title} description={content.description}>
-                <p>Modal content</p>
-            </ModalContent>
-        </Modal>
-    );
+        render(
+            <Modal>
+                <ModalTrigger asChild>
+                    <Button>{content.open}</Button>
+                </ModalTrigger>
+                <ModalContent>
+                    <ModalCloseButton>
+                        <Icon id="close" />
+                        <VisuallyHidden>Close</VisuallyHidden>
+                    </ModalCloseButton>
 
-    await user.click(screen.getByRole('button', { name: content.open }));
+                    <ModalTitle>{content.title}</ModalTitle>
+                    <ModalDescription>{content.description}</ModalDescription>
+                    <p>Modal content</p>
+                </ModalContent>
+            </Modal>
+        );
 
-    expect(document.querySelector('.c-modal__overlay')).toBeVisible();
-    expect(screen.getByRole('dialog')).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Close' })).toBeVisible();
-    expect(
-        screen.getByRole('heading', {
-            name: content.title,
-        })
-    ).toBeVisible();
-    expect(screen.getByText(content.description)).toBeVisible();
-    expect(screen.getByText('Modal content')).toBeVisible();
+        await user.click(screen.getByRole('button', { name: content.open }));
+
+        expect(document.querySelector('.c-modal__overlay')).toBeVisible();
+        expect(screen.getByRole('dialog')).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Close' })).toBeVisible();
+        expect(
+            screen.getByRole('heading', {
+                name: content.title,
+            })
+        ).toBeVisible();
+        expect(screen.getByText(content.description)).toBeVisible();
+        expect(screen.getByText('Modal content')).toBeVisible();
+    });
+
+    test('renders the modal component without a description', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <Modal>
+                <ModalTrigger asChild>
+                    <Button>{content.open}</Button>
+                </ModalTrigger>
+                <ModalContent aria-describedby={undefined}>
+                    <ModalCloseButton>
+                        <Icon id="close" />
+                        <VisuallyHidden>Close</VisuallyHidden>
+                    </ModalCloseButton>
+
+                    <ModalTitle>{content.title}</ModalTitle>
+                    <p>Modal content</p>
+                </ModalContent>
+            </Modal>
+        );
+
+        await user.click(screen.getByRole('button', { name: content.open }));
+
+        expect(screen.queryByText(content.description)).not.toBeInTheDocument();
+    });
+
+    test('renders the modal without an overlay', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <Modal>
+                <ModalTrigger asChild>
+                    <Button>{content.open}</Button>
+                </ModalTrigger>
+                <ModalContent showOverlay={false}>
+                    <ModalCloseButton>
+                        <Icon id="close" />
+                        <VisuallyHidden>Close</VisuallyHidden>
+                    </ModalCloseButton>
+
+                    <ModalTitle>{content.title}</ModalTitle>
+                    <ModalDescription>{content.description}</ModalDescription>
+                    <p>Modal content</p>
+                </ModalContent>
+            </Modal>
+        );
+
+        await user.click(screen.getByRole('button', { name: content.open }));
+
+        expect(document.querySelector('.c-modal__overlay')).not.toBeInTheDocument();
+    });
 });
 
-test('renders the modal component without a description', async () => {
-    const user = userEvent.setup();
+describe('AlertModal', () => {
+    test('renders the modal as an alert dialog', async () => {
+        const user = userEvent.setup();
 
-    render(
-        <Modal>
-            <ModalTrigger asChild>
-                <Button>{content.open}</Button>
-            </ModalTrigger>
-            <ModalContent title={content.title} aria-describedby={undefined}>
-                <p>Modal content</p>
-            </ModalContent>
-        </Modal>
-    );
+        render(
+            <AlertModal>
+                <AlertModalTrigger asChild>
+                    <Button>{content.open}</Button>
+                </AlertModalTrigger>
+                <AlertModalContent showOverlay={false}>
+                    <AlertModalTitle>{content.title}</AlertModalTitle>
+                    <AlertModalDescription>{content.description}</AlertModalDescription>
+                    <AlertModalAction>Confirm</AlertModalAction>
+                    <AlertModalCancel>Cancel</AlertModalCancel>
+                </AlertModalContent>
+            </AlertModal>
+        );
 
-    await user.click(screen.getByRole('button', { name: content.open }));
+        await user.click(screen.getByRole('button', { name: content.open }));
 
-    expect(screen.queryByText(content.description)).not.toBeInTheDocument();
-});
-
-test('renders the modal without an overlay', async () => {
-    const user = userEvent.setup();
-
-    render(
-        <Modal>
-            <ModalTrigger asChild>
-                <Button>{content.open}</Button>
-            </ModalTrigger>
-            <ModalContent
-                title={content.title}
-                description={content.description}
-                showOverlay={false}
-            >
-                <p>Modal content</p>
-            </ModalContent>
-        </Modal>
-    );
-
-    await user.click(screen.getByRole('button', { name: content.open }));
-
-    expect(document.querySelector('.c-modal__overlay')).not.toBeInTheDocument();
-});
-
-test('renders the modal as an alert dialog', async () => {
-    const user = userEvent.setup();
-
-    render(
-        <Modal isAlert>
-            <ModalTrigger asChild>
-                <Button>{content.open}</Button>
-            </ModalTrigger>
-            <ModalContent
-                title={content.title}
-                description={content.description}
-                showOverlay={false}
-            >
-                <ModalAction>Confirm</ModalAction>
-
-                <ModalCancel>Cancel</ModalCancel>
-            </ModalContent>
-        </Modal>
-    );
-
-    await user.click(screen.getByRole('button', { name: content.open }));
-
-    expect(screen.getByRole('alertdialog')).toBeVisible();
-    expect(
-        screen.getByRole('heading', {
-            name: content.title,
-        })
-    ).toBeVisible();
-    expect(screen.getByText(content.description)).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Confirm' })).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
+        expect(screen.getByRole('alertdialog')).toBeVisible();
+        expect(
+            screen.getByRole('heading', {
+                name: content.title,
+            })
+        ).toBeVisible();
+        expect(screen.getByText(content.description)).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    });
 });

--- a/packages/osc-ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/osc-ui/src/components/Modal/Modal.stories.tsx
@@ -129,6 +129,7 @@ const ControlledTemplate: Story<ModalProps> = (args) => {
                     }}
                 >
                     <TextInput
+                        id="fullName"
                         name="Full Name"
                         defaultValue="Sarah"
                         required

--- a/packages/osc-ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/osc-ui/src/components/Modal/Modal.stories.tsx
@@ -1,183 +1,183 @@
 import type { Meta, Story } from '@storybook/react';
-import React from 'react';
-import type { Props } from './Modal';
-import { Modal } from './Modal';
+import React, { useState } from 'react';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+import { TextInput } from '../TextInput/TextInput';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
+import type { ModalProps } from './Modal';
+import {
+    Modal,
+    ModalCloseButton,
+    ModalContent,
+    ModalDescription,
+    ModalTitle,
+    ModalTrigger,
+} from './Modal';
 
 export default {
-    title: 'osc-ui/Modal',
+    title: 'osc-ui/Dialogs/Modal',
     component: Modal,
+    subcomponents: {
+        ModalCloseButton,
+        ModalContent,
+        ModalDescription,
+        ModalTitle,
+        ModalTrigger,
+    },
     parameters: {
         docs: {
             description: {
                 component:
-                    'A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.'
-            }
-        }
+                    'A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.',
+            },
+        },
     },
-    argTypes: {
-        children: {
-            table: {
-                disable: true
-            }
-        },
-        disableOutsideClick: {
-            description: 'Sets whether the user can click outside of the modal to close it',
-            table: {
-                type: {
-                    summary: 'boolean'
-                }
-            }
-        },
-        hideFooterCloseButton: {
-            description:
-                'Sets whether or not to prevent rendering of the close button in the footer',
-            type: { name: 'boolean', required: true },
-            table: {
-                type: {
-                    summary: 'boolean'
-                }
-            }
-        },
-        hideHeaderCloseButton: {
-            description:
-                'Sets whether or not to prevent rendering of the close button in the header',
-            type: { name: 'boolean', required: true },
-            table: {
-                type: {
-                    summary: 'boolean'
-                }
-            }
-        },
-        ModalButtonText: {
-            description: 'Sets the text of the button that opens the modal',
-            type: { name: 'string', required: true },
-            table: {
-                type: {
-                    summary: 'boolean'
-                }
-            }
-        },
-        modalDescription: {
-            description: 'An accessible description to be announced when the dialog is opened',
-            type: { name: 'string', required: true },
-            table: {
-                type: {
-                    summary: 'string'
-                }
-            }
-        },
-        onOpenChange: {
-            description: 'Event handler called when the open state of the dialog changes.',
-            table: {
-                type: {
-                    summary: '(open: boolean) => void'
-                }
-            }
-        },
-        onClick: {
-            description: 'The function that is passed to the primary action button',
-            type: { name: 'function', required: true },
-            table: {
-                type: {
-                    summary: '() => void'
-                }
-            }
-        },
-        overlayColour: {
-            description: 'Colour of the overlay background',
-            type: { name: 'string', required: true },
-            table: {
-                type: {
-                    summary: 'string'
-                }
-            }
-        },
-        primaryActionButton: {
-            description: 'Sets whether the primary action button is visible',
-            type: { name: 'boolean', required: true },
-            table: {
-                type: {
-                    summary: 'boolean'
-                }
-            }
-        },
-        primaryActionButtonText: {
-            description: 'Sets the text of the primary action button',
-            type: { name: 'string', required: true },
-            table: {
-                type: {
-                    summary: 'string'
-                }
-            }
-        },
-        size: {
-            description: 'Sets the size of the modal',
-            control: { type: 'select', options: ['xs', 'sm', 'md', 'lg', 'xl', 'full'] },
-            type: { name: 'string', required: true },
-            table: {
-                type: {
-                    summary: 'string'
-                }
-            }
-        },
-        title: {
-            description: 'Modal heading',
-            type: { name: 'string', required: true },
-            table: {
-                type: {
-                    summary: 'string'
-                }
-            }
-        }
-    }
 } as Meta;
 
-const Template: Story<Props> = (args) => <Modal {...args} />;
+const Template: Story<ModalProps> = (args) => (
+    <Modal {...args}>
+        <ModalTrigger asChild>
+            <Button>Open modal</Button>
+        </ModalTrigger>
+        <ModalContent>
+            <ModalCloseButton>
+                <Icon id="close" />
+                <VisuallyHidden>Close</VisuallyHidden>
+            </ModalCloseButton>
+
+            <ModalTitle>An accessible title to be announced when the dialog is opened.</ModalTitle>
+
+            <ModalDescription>
+                An optional accessible description to be announced when the dialog is opened.
+            </ModalDescription>
+
+            <p>Modal content</p>
+        </ModalContent>
+    </Modal>
+);
+
+const HasNoDescriptionTemplate: Story<ModalProps> = (args) => (
+    <Modal {...args}>
+        <ModalTrigger asChild>
+            <Button>Open modal</Button>
+        </ModalTrigger>
+        <ModalContent aria-describedby={undefined}>
+            <ModalCloseButton>
+                <Icon id="close" />
+                <VisuallyHidden>Close</VisuallyHidden>
+            </ModalCloseButton>
+
+            <ModalTitle>An accessible title to be announced when the dialog is opened.</ModalTitle>
+
+            <p>Modal content</p>
+        </ModalContent>
+    </Modal>
+);
+
+const HasNoOverlayTemplate: Story<ModalProps> = (args) => (
+    <Modal {...args}>
+        <ModalTrigger asChild>
+            <Button>Open modal</Button>
+        </ModalTrigger>
+        <ModalContent aria-describedby={undefined} showOverlay={false}>
+            <ModalCloseButton>
+                <Icon id="close" />
+                <VisuallyHidden>Close</VisuallyHidden>
+            </ModalCloseButton>
+
+            <ModalTitle>An accessible title to be announced when the dialog is opened.</ModalTitle>
+
+            <p>Modal content</p>
+        </ModalContent>
+    </Modal>
+);
+
+const ControlledTemplate: Story<ModalProps> = (args) => {
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const wait = () => new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return (
+        <Modal
+            open={isOpen}
+            onOpenChange={(b: boolean) => {
+                setIsOpen(b);
+                setIsLoading(!b);
+            }}
+            {...args}
+        >
+            <ModalTrigger asChild>
+                <Button>Open modal</Button>
+            </ModalTrigger>
+            <ModalContent>
+                <ModalCloseButton>
+                    <Icon id="close" />
+                    <VisuallyHidden>Close</VisuallyHidden>
+                </ModalCloseButton>
+
+                <ModalTitle>Edit profile</ModalTitle>
+
+                <ModalDescription>
+                    Make changes to your profile here. Click save when you're done.
+                </ModalDescription>
+
+                <form
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        setIsLoading(true);
+                        wait().then(() => setIsOpen(false));
+                    }}
+                >
+                    <TextInput
+                        name="Full Name"
+                        defaultValue="Sarah"
+                        required
+                        style={{ marginBlockEnd: '1rem' }}
+                    />
+                    <Button isLoading={isLoading} loadingText="Saving">
+                        Save
+                    </Button>
+                </form>
+            </ModalContent>
+        </Modal>
+    );
+};
 
 export const Primary = Template.bind({});
+Primary.args = {};
 
-Primary.args = {
-    children: <p>hello world</p>,
-    ModalButtonText: 'Click to open',
-    title: 'whats up',
-    modalDescription: 'An accessible description to be announced when the dialog is opened',
-    size: 'xs',
-    hideHeaderCloseButton: false,
-    hideFooterCloseButton: false,
-    disableOutsideClick: false,
-    overlayColour: 'grey',
-    primaryActionButton: false,
-    primaryActionButtonText: 'click me',
-    onClick: () => {
-        alert('modal cliked');
-    }
+export const HasNoDescription = HasNoDescriptionTemplate.bind({});
+HasNoDescription.args = {
+    ...Primary.args,
+};
+HasNoDescription.parameters = {
+    docs: {
+        description: {
+            story: 'If you choose to omit the description above, then make sure to pass `aria-describedby={undefined}` to the `ModalContent`',
+        },
+    },
 };
 
-export const Small = Template.bind({});
-Small.args = {
+export const HasNoOverlay = HasNoOverlayTemplate.bind({});
+HasNoOverlay.args = {
     ...Primary.args,
-    size: 'sm'
 };
-export const Medium = Template.bind({});
-Medium.args = {
-    ...Primary.args,
-    size: 'md'
-};
-
-export const Large = Template.bind({});
-Large.args = {
-    ...Primary.args,
-    size: 'lg'
+HasNoOverlay.parameters = {
+    docs: {
+        description: {
+            story: 'Remove the overlay by passing `showOverlay={false}` to the `ModalContent`',
+        },
+    },
 };
 
-export const ExtraLarge = Template.bind({});
-ExtraLarge.args = {
+export const ControlledModal = ControlledTemplate.bind({});
+ControlledModal.args = {
     ...Primary.args,
-    size: 'xl'
 };
-
-export const Full = Template.bind({});
-Full.args = {
-    ...Primary.args,
-    size: 'full'
+ControlledModal.parameters = {
+    docs: {
+        description: {
+            story: 'Can be opened and closed programmatically, i.e when a form submits.',
+        },
+    },
 };

--- a/packages/osc-ui/src/components/Modal/Modal.tsx
+++ b/packages/osc-ui/src/components/Modal/Modal.tsx
@@ -1,102 +1,161 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { Cross2Icon } from '@radix-ui/react-icons';
-import type { ButtonHTMLAttributes, ComponentPropsWithoutRef, ElementRef, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 import React, { forwardRef } from 'react';
 import { classNames } from '../../utils/classNames';
+
+import { useModifier } from '../../hooks/useModifier';
+import type { Maybe } from '../../types';
 import './modal.scss';
 
-interface CloseProps<T> extends ButtonHTMLAttributes<T> {
-    children: ReactNode;
+export interface SharedModalProps {
+    /**
+     * Custom class
+     */
+    className?: string;
 }
 
-const ModalCloseButton = forwardRef<
-    ElementRef<typeof Dialog.Close>,
-    ComponentPropsWithoutRef<typeof Dialog.Close>
->((props: CloseProps<HTMLButtonElement>, forwardedRef) => {
-    const { children, ...attr } = props;
+/* -------------------------------------------------------------------------------------------------
+ * Modal
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalProps
+    extends ComponentPropsWithoutRef<typeof Dialog.Root>,
+        SharedModalProps {}
+
+export const Modal = (props: ModalProps) => {
+    const { children } = props;
 
     return (
-        <Dialog.Close asChild>
-            <button aria-label="Close" {...attr} ref={forwardedRef}>
-                {children}
-            </button>
-        </Dialog.Close>
-    );
-});
-ModalCloseButton.displayName = 'ModalCloseButton';
-
-export interface Props {
-    open?: boolean;
-    onOpenChange?: () => void;
-    ModalButtonText: string;
-    title: string;
-    size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
-    hideHeaderCloseButton: boolean;
-    hideFooterCloseButton: boolean;
-    disableOutsideClick?: boolean;
-    overlayColour: string;
-    primaryActionButton: boolean;
-    primaryActionButtonText: string;
-    onClick: () => void;
-    modalDescription: string;
-    children: ReactNode;
-}
-
-export const Modal = (props: Props) => {
-    const {
-        open,
-        onOpenChange,
-        ModalButtonText,
-        title,
-        size,
-        children,
-        hideHeaderCloseButton,
-        hideFooterCloseButton,
-        disableOutsideClick,
-        primaryActionButton,
-        primaryActionButtonText,
-        onClick,
-        modalDescription,
-    } = props;
-    const width = `c-modal--${size}`;
-    const classes = classNames('c-modal', width);
-
-    return (
-        <Dialog.Root modal open={open} onOpenChange={onOpenChange}>
-            <Dialog.Trigger asChild>
-                <button>{ModalButtonText}</button>
-            </Dialog.Trigger>
-
-            <Dialog.Portal>
-                <Dialog.Overlay className="c-modal__overlay" />
-
-                <Dialog.Content
-                    onPointerDownOutside={disableOutsideClick ? (e) => e.preventDefault() : null}
-                    className={classes}
-                >
-                    <header className="c-modal__header">
-                        <Dialog.Title>{title}</Dialog.Title>
-                        {!hideHeaderCloseButton ? (
-                            <ModalCloseButton>
-                                <Cross2Icon />
-                            </ModalCloseButton>
-                        ) : null}
-                    </header>
-                    <Dialog.Description className="c-modal__description sr-only">
-                        {modalDescription}
-                    </Dialog.Description>
-
-                    <div>{children}</div>
-
-                    <footer className="c-modal__footer">
-                        {!hideFooterCloseButton ? <ModalCloseButton>Close</ModalCloseButton> : null}
-
-                        {primaryActionButton ? (
-                            <button onClick={onClick}>{primaryActionButtonText}</button>
-                        ) : null}
-                    </footer>
-                </Dialog.Content>
-            </Dialog.Portal>
+        <Dialog.Root className="c-modal" {...props}>
+            {children}
         </Dialog.Root>
     );
 };
+Modal.displayName = 'Modal';
+
+/* -------------------------------------------------------------------------------------------------
+ * Modal Trigger
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalTriggerProps
+    extends ComponentPropsWithoutRef<typeof Dialog.Trigger>,
+        SharedModalProps {}
+
+export const ModalTrigger = forwardRef<ElementRef<typeof Dialog.Trigger>, ModalTriggerProps>(
+    (props, forwardedRef) => {
+        const { children, className, ...rest } = props;
+        const classes = classNames('c-modal__trigger', className);
+
+        return (
+            <Dialog.Trigger className={classes} {...rest} ref={forwardedRef}>
+                {children}
+            </Dialog.Trigger>
+        );
+    }
+);
+ModalTrigger.displayName = 'ModalTrigger';
+
+/* -------------------------------------------------------------------------------------------------
+ * Modal Content
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalContentProps
+    extends ComponentPropsWithoutRef<typeof Dialog.Content>,
+        SharedModalProps {
+    /**
+     * Customise the element that your alert dialog portals into.
+     * @see: https://www.radix-ui.com/docs/primitives/components/dialog#custom-portal-container
+     * @default undefined
+     */
+    container?: Maybe<HTMLElement>;
+    /**
+     * Whether to display the overlay or not
+     * @default true
+     */
+    showOverlay?: boolean;
+    /**
+     * 'Sets the size of the button'
+     * @default md
+     */
+    size?: 'sm' | 'md' | 'lg' | 'full';
+}
+
+export const ModalContent = forwardRef<ElementRef<typeof Dialog.Content>, ModalContentProps>(
+    (props, forwardedRef) => {
+        const { children, className, container, showOverlay = true, size = 'md', ...rest } = props;
+        const sizeModifier = useModifier('c-modal__content', size);
+        const classes = classNames('c-modal__content', sizeModifier, className);
+
+        return (
+            <Dialog.Portal container={container}>
+                {showOverlay ? <Dialog.Overlay className="c-modal__overlay" /> : null}
+
+                <Dialog.Content className={classes} {...rest} ref={forwardedRef}>
+                    {children}
+                </Dialog.Content>
+            </Dialog.Portal>
+        );
+    }
+);
+ModalContent.displayName = 'ModalContent';
+
+/* -------------------------------------------------------------------------------------------------
+ * Modal Title
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalTitleProps
+    extends ComponentPropsWithoutRef<typeof Dialog.Title>,
+        SharedModalProps {}
+
+export const ModalTitle = forwardRef<ElementRef<typeof Dialog.Title>, ModalTitleProps>(
+    (props, forwardedRef) => {
+        const { children, className, ...rest } = props;
+        const classes = classNames('c-modal__ttl t-font-m u-text-bold', className);
+
+        return (
+            <Dialog.Title className={classes} {...rest} ref={forwardedRef}>
+                {children}
+            </Dialog.Title>
+        );
+    }
+);
+ModalTitle.displayName = 'ModalTitle';
+
+/* -------------------------------------------------------------------------------------------------
+ * Modal Description
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalDescriptionProps
+    extends ComponentPropsWithoutRef<typeof Dialog.Description>,
+        SharedModalProps {}
+
+export const ModalDescription = forwardRef<
+    ElementRef<typeof Dialog.Description>,
+    ModalDescriptionProps
+>((props, forwardedRef) => {
+    const { children, className, ...rest } = props;
+    const classes = classNames('c-modal__desc', className);
+
+    return (
+        <Dialog.Description className={classes} {...rest} ref={forwardedRef}>
+            {children}
+        </Dialog.Description>
+    );
+});
+ModalDescription.displayName = 'ModalTitle';
+
+/* -------------------------------------------------------------------------------------------------
+ * Modal Close Button
+ * -----------------------------------------------------------------------------------------------*/
+export interface ModalCloseButtonProps
+    extends ComponentPropsWithoutRef<typeof Dialog.Close>,
+        SharedModalProps {}
+
+export const ModalCloseButton = forwardRef<ElementRef<typeof Dialog.Close>, ModalCloseButtonProps>(
+    (props, forwardedRef) => {
+        const { children, className, ...rest } = props;
+        const classes = classNames('c-modal__close', className);
+
+        return (
+            <Dialog.Close className={classes} {...rest} ref={forwardedRef}>
+                {children}
+            </Dialog.Close>
+        );
+    }
+);
+ModalCloseButton.displayName = 'ModalCloseButton';

--- a/packages/osc-ui/src/components/Modal/modal.scss
+++ b/packages/osc-ui/src/components/Modal/modal.scss
@@ -1,80 +1,82 @@
 @import "../../styles/tools";
 @import "../../styles/settings";
 
-// TODO: sb - we should probably set these as variables
-
 @layer components {
-    .c-modal {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        width: 100%;
-        padding: 25px;
-        background-color: var(--color-tertiary);
-        box-shadow: $shadow-l;
-        transform: translate(-50%, -50%);
-        animation: content-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+    $modal-max-height: 570px;
+    $modal-overlay-opacity: 0.3;
 
-        &:focus {
-            outline: none;
+    .c-modal {
+        &__content {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            max-height: $modal-max-height;
+            padding: $space-m;
+            background-color: var(--color-tertiary);
+            border-radius: $rad-xs;
+            box-shadow: $shadow-m;
+            overflow-y: auto;
+
+            @include z-index(modal);
+
+            &[data-state="open"] {
+                @include animate(modal-scale-in, $timing-s, $ease-out-sine);
+            }
+
+            &[data-state="closed"] {
+                @include animate(modal-scale-out, $timing-s, $ease-out-sine);
+            }
+
+            &--sm {
+                max-width: #{calc($container-3xs / 2)}px;
+            }
+
+            &--md {
+                max-width: 768px;
+            }
+
+            &--lg {
+                max-width: #{$container-2xs}px;
+            }
+
+            &--full {
+                max-width: 100%;
+            }
         }
 
-        &__header {
-            display: flex;
-            justify-content: space-between;
+        &__ttl {
+            margin-block-start: $space-2xs;
+        }
+
+        &__close {
+            align-self: end;
+            color: var(--color-neutral-500);
+            transition: color $timing-s $ease-in-out;
+            cursor: pointer;
+
+            &:hover,
+            &:active {
+                color: var(--color-neutral-600);
+            }
         }
 
         &__overlay {
             position: fixed;
-            background-color: var(--color-neutral-200);
-            animation: overlay-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+            background-color: var(--color-secondary);
             inset: 0;
-        }
 
-        &--xs {
-            max-width: 360px;
-        }
+            @include z-index(modal);
 
-        &--sm {
-            max-width: #{calc($container-3xs / 2)}px;
-        }
+            &[data-state="open"] {
+                @include animate(overlay-fade-in, $timing-s, $ease-out-sine);
+            }
 
-        &--md {
-            max-width: 768px;
-        }
-
-        &--lg {
-            max-width: #{$container-2xs}px;
-        }
-
-        &--xl {
-            max-width: #{$container-m}px;
-        }
-
-        &--full {
-            max-width: 100%;
-        }
-    }
-
-    @keyframes overlay-show {
-        from {
-            opacity: 0;
-        }
-
-        to {
-            opacity: 1;
-        }
-    }
-
-    @keyframes content-show {
-        from {
-            opacity: 0;
-            opacity: translate(-0.5, -0.48) scale(0.96);
-        }
-
-        to {
-            transform: translate(-50%, -50%) scale(1);
-            opacity: 1;
+            &[data-state="closed"] {
+                @include animate(overlay-fade-out, $timing-s, $ease-out-sine);
+            }
         }
     }
 }

--- a/packages/osc-ui/src/styles/settings/_animation.scss
+++ b/packages/osc-ui/src/styles/settings/_animation.scss
@@ -50,6 +50,22 @@ $animations: (
             opacity: 0
         )
     ),
+    "overlay-fade-in": (
+        0%: (
+            opacity: 0
+        ),
+        100%: (
+            opacity: 0.3
+        )
+    ),
+    "overlay-fade-out": (
+        0%: (
+            opacity: 0.3
+        ),
+        100%: (
+            opacity: 0
+        )
+    ),
     "fade-in-up": (
         0%: (
             transform: translate3d(0, 100px, 0),
@@ -131,6 +147,26 @@ $animations: (
         100%: (
             transform: scale(1),
             opacity: 1
+        )
+    ),
+    "modal-scale-in": (
+        0%: (
+            transform: translate(-50%, -50%) scale(0.9),
+            opacity: 0
+        ),
+        100%: (
+            transform: translate(-50%, -50%) scale(1),
+            opacity: 1
+        )
+    ),
+    "modal-scale-out": (
+        0%: (
+            transform: translate(-50%, -50%) scale(1),
+            opacity: 1
+        ),
+        100%: (
+            transform: translate(-50%, -50%) scale(0.9),
+            opacity: 0
         )
     ),
     "jingleBell": (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes https://github.com/Open-Study-College/osc/issues/734

## 📝 Description

Refactors the `Modal` component to make it more composable and set it up for the other drawer variations.

## ⛳️ Current behavior (updates)

- Modal it buildable via props, and restricted to those

## 🚀 New behavior

- Modal is composable and can take any kind of content
- Can be programatically controlled
- Adds styles / animations
- Can be swapped over to an `AlertDialog` which interrupts the user with important content and expects a response

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
