### PR TITLE
Feature/add flourishes to hero sanity

### DIFF
--- a/packages/osc-ecommerce/app/components/Hero/Hero.spec.tsx
+++ b/packages/osc-ecommerce/app/components/Hero/Hero.spec.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
 test('renders a single Hero', () => {
     render(
         <MemoryRouter>
-            <Hero data={heroSingle as heroModule} />
+            <Hero data={heroSingle as unknown as heroModule} />
         </MemoryRouter>
     );
 
@@ -51,7 +51,7 @@ test('renders a single Hero', () => {
 test("renders multiple Hero's in a carousel", () => {
     render(
         <MemoryRouter>
-            <Hero data={heroCarousel as heroModule} />
+            <Hero data={heroCarousel as unknown as heroModule} />
         </MemoryRouter>
     );
 
@@ -65,7 +65,7 @@ test("renders multiple Hero's in a carousel", () => {
 test('sets the title as a h1 on the initial slide', () => {
     render(
         <MemoryRouter>
-            <Hero data={heroCarousel as heroModule} />
+            <Hero data={heroCarousel as unknown as heroModule} />
         </MemoryRouter>
     );
 

--- a/packages/osc-ecommerce/app/components/Hero/Hero.spec.tsx
+++ b/packages/osc-ecommerce/app/components/Hero/Hero.spec.tsx
@@ -48,6 +48,29 @@ test('renders a single Hero', () => {
     expect(image).toBeInTheDocument();
 });
 
+test('renders the hero with the flourishes attached', () => {
+    const clonedData = JSON.parse(JSON.stringify(heroSingle)) as heroModule;
+
+    clonedData.slides[0].flourishes = {
+        pattern: 'flourishHeroPrimary',
+        color: 'tertiary',
+    };
+
+    render(
+        <MemoryRouter>
+            <Hero data={clonedData} />
+        </MemoryRouter>
+    );
+
+    const flourishes = document.querySelectorAll('.c-flourish');
+
+    expect(flourishes).toHaveLength(8);
+
+    flourishes.forEach((flourish) => {
+        expect(flourish).toHaveClass('c-flourish--hero-primary');
+    });
+});
+
 test("renders multiple Hero's in a carousel", () => {
     render(
         <MemoryRouter>

--- a/packages/osc-ecommerce/app/components/Hero/Hero.tsx
+++ b/packages/osc-ecommerce/app/components/Hero/Hero.tsx
@@ -11,6 +11,7 @@ import {
     rem,
 } from 'osc-ui';
 import type { heroModule, heroSlide } from '~/types/sanity';
+import { remapFlourishObject } from '~/utils/remapFlourishObject';
 
 // ! TEMPORARY fix for tokens path not matching dev and prod environments
 // ! Once solution in place we can update this to use design token files instead
@@ -83,7 +84,18 @@ interface SlideProps extends heroSlide {
 }
 
 const Slide = (props: SlideProps) => {
-    const { title, titleColor, backgroundColor, content, variant, image, initialSlide } = props;
+    const {
+        title,
+        titleColor,
+        backgroundColor,
+        content,
+        variant,
+        image,
+        initialSlide,
+        flourishes,
+    } = props;
+
+    const copyFlourishes = remapFlourishObject(flourishes);
 
     const Title = () => {
         return title ? (
@@ -101,7 +113,11 @@ const Slide = (props: SlideProps) => {
             backgroundColor={backgroundColor ? backgroundColor : 'tertiary'}
             variant={variant ? variant : 'primary'}
         >
-            <HeroInner>
+            <HeroInner
+                flourishColor={copyFlourishes?.color}
+                flourishPattern={copyFlourishes?.pattern}
+                flourishVariant={copyFlourishes?.variant}
+            >
                 {variant === 'tertiary' ? (
                     <HeroTitleGroup>
                         <Title />

--- a/packages/osc-ecommerce/app/components/Hero/Hero.tsx
+++ b/packages/osc-ecommerce/app/components/Hero/Hero.tsx
@@ -21,14 +21,14 @@ const mq = {
 };
 
 export const Hero = (props: { data: heroModule }) => {
-    const { carouselName, carouselSettings, slides } = props?.data;
+    const { carouselSettings, slides } = props?.data;
 
     const perView = (perView: number | undefined) => (perView ? perView : 1);
 
     if (slides.length > 1) {
         return (
             <Carousel
-                carouselName={carouselName}
+                carouselName={carouselSettings?.carouselName ?? ''}
                 arrows={carouselSettings?.arrows}
                 dotNav={carouselSettings?.dotNav}
                 loop={carouselSettings?.loop}

--- a/packages/osc-ecommerce/app/components/Hero/mockHeroData.tsx
+++ b/packages/osc-ecommerce/app/components/Hero/mockHeroData.tsx
@@ -70,6 +70,7 @@ export const heroCarousel = {
             title: 'Save on your study',
             titleColor: null,
             variant: 'primary',
+            flourishes: undefined,
         },
         {
             _key: '917bca21578d',
@@ -127,6 +128,7 @@ export const heroCarousel = {
             title: 'Black Friday',
             titleColor: 'tertiary',
             variant: 'secondary',
+            flourishes: undefined,
         },
     ],
 };
@@ -208,6 +210,7 @@ export const heroSingle = {
             title: 'Save on your study',
             titleColor: null,
             variant: 'primary',
+            flourishes: undefined,
         },
     ],
 };

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -12,6 +12,7 @@ import datePickerCalendarStyles from 'osc-ui/dist/src-components-DatePicker-cale
 import dateFieldStyles from 'osc-ui/dist/src-components-DatePicker-date-field.css';
 import datePickerStyles from 'osc-ui/dist/src-components-DatePicker-date-picker.css';
 import datePickerReactAriaStyles from 'osc-ui/dist/src-components-DatePicker-react-aria-components.css';
+import flourishStyles from 'osc-ui/dist/src-components-Flourishes-flourish.css';
 import heroStyles from 'osc-ui/dist/src-components-Hero-hero.css';
 import islandGrid from 'osc-ui/dist/src-components-IslandGrid-island-grid.css';
 import labelStyles from 'osc-ui/dist/src-components-Label-label.css';
@@ -141,12 +142,14 @@ export const getComponentStyles = (data: SanityPage) => {
                 styles.push({ rel: 'stylesheet', href: radioGroupStyles });
                 styles.push({ rel: 'stylesheet', href: labelStyles });
                 break;
+
             case 'module.hero':
                 styles.push(
                     { rel: 'stylesheet', href: heroStyles },
                     { rel: 'stylesheet', href: carouselStyles },
                     { rel: 'stylesheet', href: contentStyles },
-                    { rel: 'stylesheet', href: buttonStyles }
+                    { rel: 'stylesheet', href: buttonStyles },
+                    { rel: 'stylesheet', href: flourishStyles }
                 );
                 break;
 

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/hero.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/hero.ts
@@ -22,6 +22,7 @@ export const MODULE_HERO = groq`
         },
         title,
         titleColor,
-        variant
+        variant,
+        flourishes
     }
 `;

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -282,6 +282,7 @@ export interface heroSlide extends module {
     backgroundColor?: string;
     titleColor?: string;
     variant: 'primary' | 'secondary' | 'tertiary';
+    flourishes?: flourishSettings;
 }
 
 export interface heroModule extends module {
@@ -515,4 +516,9 @@ export interface PreviewProps {
     query: string;
     params: { [key: string]: string };
     token: string | null;
+}
+
+export interface flourishSettings extends module {
+    color: string | 'multicolor';
+    pattern: Maybe<'flourishHeroPrimary' | 'flourishHeroSecondary' | 'flourishHeroTertiary'>;
 }

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -286,7 +286,6 @@ export interface heroSlide extends module {
 }
 
 export interface heroModule extends module {
-    carouselName: string;
     carouselSettings: carouselModuleSettings;
     slides: heroSlide[];
 }

--- a/packages/osc-ecommerce/app/utils/remapFlourishObject.ts
+++ b/packages/osc-ecommerce/app/utils/remapFlourishObject.ts
@@ -1,0 +1,39 @@
+import { flourishHeroPrimary, flourishHeroSecondary, flourishHeroTertiary } from 'osc-ui';
+import type { Maybe } from 'osc-ui/src/types';
+import type { flourishSettings } from '~/types/sanity';
+
+/**
+ * Remaps the "flourishes" object pattern and variant values based on the input setting.
+ *
+ * @param {Maybe<flourishSettings>} flourishes - The object containing the pattern and variant values to be remapped.
+ * @returns {Maybe<flourishSettings>} The remapped "flourishes" object, or undefined if the input is null or undefined.
+ */
+export const remapFlourishObject = (flourishes: Maybe<flourishSettings>) => {
+    if (!flourishes) return;
+
+    let pattern;
+    let variant;
+    switch (flourishes.pattern) {
+        case 'flourishHeroPrimary':
+            pattern = flourishHeroPrimary;
+            variant = 'hero-primary';
+            break;
+        case 'flourishHeroSecondary':
+            pattern = flourishHeroSecondary;
+            variant = 'hero-secondary';
+            break;
+        case 'flourishHeroTertiary':
+            pattern = flourishHeroTertiary;
+            variant = 'hero-tertiary';
+            break;
+        default:
+            pattern = undefined;
+            variant = undefined;
+            break;
+    }
+
+    return Object.assign(flourishes, {
+        pattern,
+        variant,
+    });
+};

--- a/packages/osc-studio/components/inputs/ColorPickerRestricted.tsx
+++ b/packages/osc-studio/components/inputs/ColorPickerRestricted.tsx
@@ -36,16 +36,12 @@ const colorValues: { value: string; payload: { color: string } }[] = colorNames.
     })
 );
 
-console.log(colorValues);
-
 export const ColorPickerRestricted = (props: StringInputProps<StringSchemaType>) => {
     const { elementProps, onChange, value = '' } = props;
 
     const handleChange = (value: string) => {
         onChange(value ? set(value) : unset());
     };
-    console.log('colors', colors.default);
-    console.log('values', colorValues);
 
     return (
         <Autocomplete

--- a/packages/osc-studio/components/inputs/ColorPickerRestricted.tsx
+++ b/packages/osc-studio/components/inputs/ColorPickerRestricted.tsx
@@ -57,16 +57,14 @@ export const ColorPickerRestricted = (props: StringInputProps<StringSchemaType>)
                 value ? (
                     <div
                         style={{
-                            backgroundColor:
-                                colors.default[value] && !colors.default[value].includes('gradient')
-                                    ? colors.default[value]
-                                    : colors.default['primary'],
+                            backgroundColor: !colors?.default[value]?.includes('gradient')
+                                ? colors.default[value]
+                                : colors.default['primary'],
                             width: '1.25em',
                             height: '1.25em',
-                            backgroundImage:
-                                colors.default[value] && colors.default[value].includes('gradient')
-                                    ? colors.default[value]
-                                    : colors.default['gradient-primary'],
+                            backgroundImage: colors?.default[value]?.includes('gradient')
+                                ? colors.default[value]
+                                : '',
                         }}
                     ></div>
                 ) : (

--- a/packages/osc-studio/components/inputs/ColorPickerRestricted.tsx
+++ b/packages/osc-studio/components/inputs/ColorPickerRestricted.tsx
@@ -1,0 +1,109 @@
+import { SearchIcon } from '@sanity/icons';
+import { Autocomplete, Box, Card, Flex, Text } from '@sanity/ui';
+import { colors } from 'osc-design-tokens';
+import type { StringInputProps, StringSchemaType } from 'sanity';
+import { set, unset } from 'sanity';
+import { capitalizeFirstLetter } from '../../utils/capitalizeFirstLetter';
+
+const colorNames = Object.keys(colors.default).filter((color) => {
+    if (
+        color.includes('-90') ||
+        color.includes('-180') ||
+        color.includes('-270') ||
+        color.includes('error') ||
+        color.includes('success') ||
+        color.includes('notice') ||
+        color.includes('warning') ||
+        color.includes('neutral')
+    ) {
+        return false;
+    }
+
+    return true;
+});
+
+colorNames.push('multicolor');
+
+const colorValues: { value: string; payload: { color: string } }[] = colorNames.map(
+    (colorName) => ({
+        value: colorName,
+        payload: {
+            color:
+                colorName === 'multicolor'
+                    ? colors.default['gradient-primary']
+                    : colors.default[colorName],
+        },
+    })
+);
+
+console.log(colorValues);
+
+export const ColorPickerRestricted = (props: StringInputProps<StringSchemaType>) => {
+    const { elementProps, onChange, value = '' } = props;
+
+    const handleChange = (value: string) => {
+        onChange(value ? set(value) : unset());
+    };
+    console.log('colors', colors.default);
+    console.log('values', colorValues);
+
+    return (
+        <Autocomplete
+            fontSize={2}
+            padding={3}
+            {...elementProps}
+            onChange={handleChange}
+            // custom search filter
+            filterOption={(query, option) =>
+                option.value.toLowerCase().indexOf(query.toLowerCase()) > -1
+            }
+            icon={
+                value ? (
+                    <div
+                        style={{
+                            backgroundColor:
+                                colors.default[value] && !colors.default[value].includes('gradient')
+                                    ? colors.default[value]
+                                    : colors.default['primary'],
+                            width: '1.25em',
+                            height: '1.25em',
+                            backgroundImage:
+                                colors.default[value] && colors.default[value].includes('gradient')
+                                    ? colors.default[value]
+                                    : colors.default['gradient-primary'],
+                        }}
+                    ></div>
+                ) : (
+                    SearchIcon
+                )
+            }
+            openButton
+            options={colorValues}
+            // custom option render function
+            renderOption={(option) => (
+                <Card as="button">
+                    <Flex align="center">
+                        <Box paddingLeft={3} paddingY={2}>
+                            <div
+                                style={{
+                                    backgroundColor: !option.payload.color.includes('gradient')
+                                        ? option.payload.color
+                                        : '',
+                                    width: '1.25em',
+                                    height: '1.25em',
+                                    backgroundImage: option.payload.color.includes('gradient')
+                                        ? option.payload.color
+                                        : '',
+                                }}
+                            ></div>
+                        </Box>
+                        <Box flex={1} padding={3}>
+                            <Text size={2}>{capitalizeFirstLetter(option.value)}</Text>
+                        </Box>
+                    </Flex>
+                </Card>
+            )}
+            value={capitalizeFirstLetter(value)}
+        />
+    );
+};

--- a/packages/osc-studio/schemas/objects/flourishes.ts
+++ b/packages/osc-studio/schemas/objects/flourishes.ts
@@ -1,0 +1,42 @@
+import { defineField, defineType } from 'sanity';
+import { ColorPickerRestricted } from '../../components/inputs/ColorPickerRestricted';
+
+export default defineType({
+    name: 'flourishes',
+    title: 'Flourishes',
+    type: 'object',
+    fields: [
+        defineField({
+            name: 'color',
+            title: 'Colour',
+            type: 'string',
+            initialValue: 'tertiary',
+            components: {
+                input: ColorPickerRestricted,
+            },
+        }),
+        defineField({
+            name: 'pattern',
+            title: 'Pattern',
+            type: 'string',
+            initialValue: 'flourishHeroPrimary',
+            options: {
+                layout: 'dropdown',
+                list: [
+                    {
+                        title: 'Primary',
+                        value: 'flourishHeroPrimary',
+                    },
+                    {
+                        title: 'Secondary',
+                        value: 'flourishHeroSecondary',
+                    },
+                    {
+                        title: 'Tertiary',
+                        value: 'flourishHeroTertiary',
+                    },
+                ],
+            },
+        }),
+    ],
+});

--- a/packages/osc-studio/schemas/objects/heroSlide.ts
+++ b/packages/osc-studio/schemas/objects/heroSlide.ts
@@ -73,5 +73,19 @@ export default defineType({
             initialValue: 'primary',
             group: 'settings',
         }),
+        defineField({
+            name: 'showFlourishes',
+            title: 'Show Flourishes',
+            type: 'boolean',
+            initialValue: false,
+            group: 'settings',
+        }),
+        defineField({
+            name: 'flourishes',
+            title: 'Flourishes',
+            type: 'flourishes',
+            group: 'settings',
+            hidden: ({ parent }) => parent?.showFlourishes !== true,
+        }),
     ],
 });

--- a/packages/osc-studio/schemas/schema.ts
+++ b/packages/osc-studio/schemas/schema.ts
@@ -36,6 +36,7 @@ import carouselSettings from './objects/carouselSettings';
 import collectionRule from './objects/collectionRule';
 import contentMediaImage from './objects/contentMediaImage';
 import contentMediaSlide from './objects/contentMediaSlide';
+import flourishes from './objects/flourishes';
 import heroSlide from './objects/heroSlide';
 import linkExternal from './objects/linkExternal';
 import linkInternal from './objects/linkInternal';
@@ -119,6 +120,7 @@ export const schemaTypes: SchemaTypeDefinition[] = [
     partialCarouselSettings,
     heroSlide,
     collectionRule,
+    flourishes,
     textGridItem,
     linkExternal,
     linkInternal,

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -37,6 +37,14 @@ export { Content } from './components/Content/Content';
 export { ContentMedia, ContentMediaBlock } from './components/ContentMedia/ContentMedia';
 export { CountdownClock } from './components/CountdownClock/CountdownClock';
 export { DatePicker } from './components/DatePicker/DatePicker/DatePicker';
+export { Flourishes } from './components/Flourishes/Flourishes';
+export {
+    heroPrimary as flourishHeroPrimary,
+    heroSecondary as flourishHeroSecondary,
+    heroTertiary as flourishHeroTertiary,
+    primary as flourishPrimary,
+    secondary as flourishSecondary,
+} from './components/Flourishes/patterns';
 export {
     Drawer,
     DrawerCloseButton,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds the flourishes into the Hero component in `osc-ecommerce` controlled by Sanity.

I've added the `flourishes` schema into Sanity which will give us an object of settings that we can use to configure the flourishes. At the moment I have only linked it up to the `Hero` but planning on using this in other places as well.
I've had to create a copt of the `colorpicker` custom input which has a different array of colours to pick from. I would have preferred to do this as some props however Sanity doesn't let you pass props through to custom inputs :/ 

I've also fixed and updated the `Hero.spec.ts` tests.

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

- Adds `Flourishes` to `Hero` in ecommerce site
- Adds a `remapFlourishObject` function to map Sanity values to objects
- Adds `ColorPickerRestricted` to Sanity
- Adds `Flourishes` settings to `heroSlide` schema
- 

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information


You can test by going into the settings section of the Hero module in Sanity and adjusting the flourishes from in there
![image](https://user-images.githubusercontent.com/23461173/233569087-eb33ed76-d984-45a1-9b56-d267bc9143a9.png)
