### PR TITLE
Feature/add flourishes to product pages

### DIFF
--- a/packages/osc-ecommerce/app/components/Cards/mockCardData.ts
+++ b/packages/osc-ecommerce/app/components/Cards/mockCardData.ts
@@ -183,7 +183,6 @@ export const mockCardData = {
                 _rev: 'tV53p2YgFcEKyJnroJERpz',
                 _type: 'post',
                 _updatedAt: '2022-09-29T14:00:35Z',
-                showHero: false,
                 slug: {
                     _type: 'slug',
                     current: 'test-post',

--- a/packages/osc-ecommerce/app/models/sanity.server.ts
+++ b/packages/osc-ecommerce/app/models/sanity.server.ts
@@ -60,7 +60,8 @@ export default async function getPageData({ request, params, query }: Args) {
 
     // TODO: Secure the preview route, making it check if the slug currently exists in the dataset.
     try {
-        const param = params?.slug ? { slug: params.slug } : {};
+        const param = params?.slug ? params : {};
+
         const querySanityDataset = await getClient(isPreview).fetch(query, param);
 
         return { page: querySanityDataset[0], isPreview };

--- a/packages/osc-ecommerce/app/queries/sanity/collectionTheme.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/collectionTheme.ts
@@ -1,8 +1,0 @@
-import groq from 'groq';
-
-export const COLLECTION_THEME_QUERY = groq`
-    *[ _type == "collection" && store.slug.current == $slug ] {
-        _id,
-        theme
-    }
-`;

--- a/packages/osc-ecommerce/app/queries/sanity/collectionTheme.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/collectionTheme.ts
@@ -1,0 +1,8 @@
+import groq from 'groq';
+
+export const COLLECTION_THEME_QUERY = groq`
+    *[ _type == "collection" && store.slug.current == $slug ] {
+        _id,
+        theme
+    }
+`;

--- a/packages/osc-ecommerce/app/queries/sanity/product.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/product.ts
@@ -9,6 +9,10 @@ export const PRODUCT_QUERY = groq`
         _type,
         store,
         upperContent,
+        // Merge theme query into product
+        ...(*[_type == "collection" && store.slug.current == $collection][0] {
+            theme
+        }),
         ${MODULES},
         ${SEO}
     }

--- a/packages/osc-ecommerce/app/queries/shopify/product.ts
+++ b/packages/osc-ecommerce/app/queries/shopify/product.ts
@@ -77,6 +77,13 @@ export const PRODUCT_QUERY = `#graphql
                 ...ProductVariantFragment
             }
         }
+        collections(first: 1) {
+            edges {
+                node {
+                    handle
+                }
+            }
+        }
     }
   }
 `;

--- a/packages/osc-ecommerce/app/root.tsx
+++ b/packages/osc-ecommerce/app/root.tsx
@@ -292,9 +292,9 @@ export default function App() {
 
                 <main
                     id="main-content"
-                    className={
+                    className={`${
                         getPageType(location) === PATHS.PRODUCTS ? 'u-bg-color-neutral-100' : ''
-                    }
+                    } u-pos-rel`}
                     tabIndex={-1}
                 >
                     <Outlet />

--- a/packages/osc-ecommerce/app/routes/courses/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/courses/$slug.tsx
@@ -21,8 +21,7 @@ import productFormStyles from '~/components/Forms/ProductForm/product-form.css';
 import { getComponentStyles } from '~/components/Module';
 import { PageContent, PageContentUpper } from '~/components/PageContent';
 import { PreviewBanner } from '~/components/PreviewBanner';
-import getPageData, { getSettingsData, shouldRedirect } from '~/models/sanity.server';
-import { COLLECTION_THEME_QUERY } from '~/queries/sanity/collectionTheme';
+import getPageData, { shouldRedirect } from '~/models/sanity.server';
 import { PRODUCT_QUERY as SANITY_PRODUCT_QUERY } from '~/queries/sanity/product';
 import {
     RECOMMENDED_PRODUCTS_QUERY,
@@ -88,15 +87,11 @@ export const loader = async ({ request, params, context }: LoaderArgs) => {
     // Query the page data
     const data = await getPageData({
         request,
-        params,
-        query: SANITY_PRODUCT_QUERY,
-    });
-
-    const themeData = await getSettingsData({
-        query: COLLECTION_THEME_QUERY,
         params: {
-            slug: product.collections.edges[0].node.handle,
+            slug: params.slug,
+            collection: product.collections.edges[0].node.handle,
         },
+        query: SANITY_PRODUCT_QUERY,
     });
 
     if (!product || !data?.page) {
@@ -122,7 +117,6 @@ export const loader = async ({ request, params, context }: LoaderArgs) => {
         page,
         product,
         recommendedProducts,
-        themeData,
         isPreview,
         canonicalUrl,
         hubspotFormData: hubspotFormData ? hubspotFormData : null,
@@ -151,10 +145,10 @@ export const meta: MetaFunction = ({ data, parentsData }) => {
 };
 
 export default function Index() {
-    const { page, product, themeData, isPreview, query, params } = useLoaderData<typeof loader>();
+    const { page, product, isPreview, query, params } = useLoaderData<typeof loader>();
     const intersectionRef = useRef<HTMLDivElement>(null);
     const isPreviewMode = isPreview && query && params;
-    const pageThemeColor = themeData?.theme ? themeData.theme.color : 'gradient-primary';
+    const pageThemeColor = page?.theme ? page.theme.color : 'gradient-primary';
 
     const productFormIntersection = useIntersectionObserver(intersectionRef, {
         root: null,

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -531,5 +531,10 @@ export interface flourishSettings extends module {
         | 'flourishHeroPrimary'
         | 'flourishHeroSecondary'
         | 'flourishHeroTertiary'
+        | 'flourishCollectionPrimary'
+        | 'flourishCollectionSecondary'
+        | 'flourishCollectionTertiary'
+        | 'flourishCollectionQuaternary'
+        | 'flourishCollectionQuinary'
     >;
 }

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -521,3 +521,8 @@ export interface flourishSettings extends module {
     color: string | 'multicolor';
     pattern: Maybe<'flourishHeroPrimary' | 'flourishHeroSecondary' | 'flourishHeroTertiary'>;
 }
+
+export interface flourishSettings extends module {
+    color: string | 'multicolor';
+    pattern: Maybe<'flourishHeroPrimary' | 'flourishHeroSecondary' | 'flourishHeroTertiary'>;
+}

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -383,7 +383,7 @@ export interface SanityPage {
 }
 
 export interface SanityProduct extends SanityPage {
-    upperContent?: module[] | contentModule[];
+    upperContent: module[] | contentModule[];
     theme?: SanityPageTheme;
 }
 

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -367,7 +367,6 @@ export interface SanityPage {
           }
         | undefined;
     seo: SanitySEO;
-    showHero?: boolean;
     modules: module[] | contentModule[];
     store?: {
         title: string;

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -518,10 +518,11 @@ export interface PreviewProps {
 
 export interface flourishSettings extends module {
     color: string | 'multicolor';
-    pattern: Maybe<'flourishHeroPrimary' | 'flourishHeroSecondary' | 'flourishHeroTertiary'>;
-}
-
-export interface flourishSettings extends module {
-    color: string | 'multicolor';
-    pattern: Maybe<'flourishHeroPrimary' | 'flourishHeroSecondary' | 'flourishHeroTertiary'>;
+    pattern: Maybe<
+        | 'flourishPrimary'
+        | 'flourishSecondary'
+        | 'flourishHeroPrimary'
+        | 'flourishHeroSecondary'
+        | 'flourishHeroTertiary'
+    >;
 }

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -9,6 +9,12 @@ export interface SanityLinkItem {
     title: string;
 }
 
+export interface SanityPageTheme {
+    _type: string;
+    color: string;
+    pattern: string;
+}
+
 export interface InternalSanityLinkItem extends SanityLinkItem {
     documentType?: string;
     slug?: string;
@@ -377,7 +383,8 @@ export interface SanityPage {
 }
 
 export interface SanityProduct extends SanityPage {
-    upperContent: module[] | contentModule[];
+    upperContent?: module[] | contentModule[];
+    theme?: SanityPageTheme;
 }
 
 export interface shopifyProduct {

--- a/packages/osc-ecommerce/app/utils/remapFlourishObject.ts
+++ b/packages/osc-ecommerce/app/utils/remapFlourishObject.ts
@@ -1,4 +1,9 @@
 import {
+    flourishCollectionPrimary,
+    flourishCollectionQuaternary,
+    flourishCollectionQuinary,
+    flourishCollectionSecondary,
+    flourishCollectionTertiary,
     flourishHeroPrimary,
     flourishHeroSecondary,
     flourishHeroTertiary,
@@ -40,6 +45,27 @@ export const remapFlourishObject = (flourishes: Maybe<flourishSettings>) => {
             pattern = flourishHeroTertiary;
             variant = 'hero-tertiary';
             break;
+        case 'flourishCollectionPrimary':
+            pattern = flourishCollectionPrimary;
+            variant = 'collection-primary';
+            break;
+        case 'flourishCollectionSecondary':
+            pattern = flourishCollectionSecondary;
+            variant = 'collection-secondary';
+            break;
+        case 'flourishCollectionTertiary':
+            pattern = flourishCollectionTertiary;
+            variant = 'collection-tertiary';
+            break;
+        case 'flourishCollectionQuaternary':
+            pattern = flourishCollectionQuaternary;
+            variant = 'collection-quaternary';
+            break;
+        case 'flourishCollectionQuinary':
+            pattern = flourishCollectionQuinary;
+            variant = 'collection-quinary';
+            break;
+
         default:
             pattern = undefined;
             variant = undefined;

--- a/packages/osc-ecommerce/app/utils/remapFlourishObject.ts
+++ b/packages/osc-ecommerce/app/utils/remapFlourishObject.ts
@@ -1,4 +1,10 @@
-import { flourishHeroPrimary, flourishHeroSecondary, flourishHeroTertiary } from 'osc-ui';
+import {
+    flourishHeroPrimary,
+    flourishHeroSecondary,
+    flourishHeroTertiary,
+    flourishPrimary,
+    flourishSecondary,
+} from 'osc-ui';
 import type { Maybe } from 'osc-ui/src/types';
 import type { flourishSettings } from '~/types/sanity';
 
@@ -14,6 +20,14 @@ export const remapFlourishObject = (flourishes: Maybe<flourishSettings>) => {
     let pattern;
     let variant;
     switch (flourishes.pattern) {
+        case 'flourishPrimary':
+            pattern = flourishPrimary;
+            variant = 'primary';
+            break;
+        case 'flourishSecondary':
+            pattern = flourishSecondary;
+            variant = 'secondary';
+            break;
         case 'flourishHeroPrimary':
             pattern = flourishHeroPrimary;
             variant = 'hero-primary';

--- a/packages/osc-studio/schemas/documents/collection.tsx
+++ b/packages/osc-studio/schemas/documents/collection.tsx
@@ -88,7 +88,7 @@ export default defineType({
         defineField({
             name: 'theme',
             title: 'Theme',
-            type: 'theme',
+            type: 'flourishes',
             group: 'settings',
         }),
         defineField({

--- a/packages/osc-studio/schemas/documents/page.ts
+++ b/packages/osc-studio/schemas/documents/page.ts
@@ -34,15 +34,6 @@ export default defineType({
             options: { source: 'title' },
             validation: validateSlug,
         }),
-        // Show hero
-        defineField({
-            name: 'showHero',
-            title: 'Show hero',
-            type: 'boolean',
-            description: 'If disabled, page title will be displayed instead',
-            initialValue: false,
-            group: 'editorial',
-        }),
         // Modules
         defineField({
             name: 'modules',

--- a/packages/osc-studio/schemas/documents/post.ts
+++ b/packages/osc-studio/schemas/documents/post.ts
@@ -38,15 +38,6 @@ export default defineType({
             options: { source: 'title' },
             validation: validateSlug,
         }),
-        // Show hero
-        defineField({
-            name: 'showHero',
-            title: 'Show hero',
-            type: 'boolean',
-            description: 'If disabled, page title will be displayed instead',
-            initialValue: false,
-            group: 'editorial',
-        }),
         // Modules
         defineField({
             name: 'modules',

--- a/packages/osc-studio/schemas/objects/flourishes.ts
+++ b/packages/osc-studio/schemas/objects/flourishes.ts
@@ -19,20 +19,28 @@ export default defineType({
             name: 'pattern',
             title: 'Pattern',
             type: 'string',
-            initialValue: 'flourishHeroPrimary',
+            initialValue: '',
             options: {
                 layout: 'dropdown',
                 list: [
                     {
-                        title: 'Primary',
+                        title: 'Page - Primary',
+                        value: 'flourishPrimary',
+                    },
+                    {
+                        title: 'Page - Secondary',
+                        value: 'flourishSecondary',
+                    },
+                    {
+                        title: 'Hero - Primary',
                         value: 'flourishHeroPrimary',
                     },
                     {
-                        title: 'Secondary',
+                        title: 'Hero - Secondary',
                         value: 'flourishHeroSecondary',
                     },
                     {
-                        title: 'Tertiary',
+                        title: 'Hero - Tertiary',
                         value: 'flourishHeroTertiary',
                     },
                 ],

--- a/packages/osc-studio/schemas/objects/flourishes.ts
+++ b/packages/osc-studio/schemas/objects/flourishes.ts
@@ -43,6 +43,26 @@ export default defineType({
                         title: 'Hero - Tertiary',
                         value: 'flourishHeroTertiary',
                     },
+                    {
+                        title: 'Collection - Primary',
+                        value: 'flourishCollectionPrimary',
+                    },
+                    {
+                        title: 'Collection - Secondary',
+                        value: 'flourishCollectionSecondary',
+                    },
+                    {
+                        title: 'Collection - Tertiary',
+                        value: 'flourishCollectionTertiary',
+                    },
+                    {
+                        title: 'Collection - Quaternary',
+                        value: 'flourishCollectionQuaternary',
+                    },
+                    {
+                        title: 'Collection - Quinary',
+                        value: 'flourishCollectionQuinary',
+                    },
                 ],
             },
         }),

--- a/packages/osc-studio/schemas/singletons/blog.ts
+++ b/packages/osc-studio/schemas/singletons/blog.ts
@@ -37,15 +37,6 @@ export default defineType({
             options: { source: 'title' },
             validation: validateSlug,
         }),
-        // Show hero
-        defineField({
-            name: 'showHero',
-            title: 'Show hero',
-            type: 'boolean',
-            description: 'If disabled, page title will be displayed instead',
-            initialValue: false,
-            group: 'editorial',
-        }),
         // Modules
         defineField({
             name: 'modules',

--- a/packages/osc-studio/schemas/singletons/home.ts
+++ b/packages/osc-studio/schemas/singletons/home.ts
@@ -36,15 +36,6 @@ export default defineType({
             options: { source: 'title' },
             readOnly: true,
         }),
-        // Show hero
-        defineField({
-            name: 'showHero',
-            title: 'Show hero',
-            type: 'boolean',
-            description: 'If disabled, page title will be displayed instead',
-            initialValue: false,
-            group: 'editorial',
-        }),
         // Modules
         defineField({
             name: 'modules',

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -48,6 +48,11 @@ export {
 } from './components/Drawer/Drawer';
 export { Flourishes } from './components/Flourishes/Flourishes';
 export {
+    collectionPrimary as flourishCollectionPrimary,
+    collectionQuaternary as flourishCollectionQuaternary,
+    collectionQuinary as flourishCollectionQuinary,
+    collectionSecondary as flourishCollectionSecondary,
+    collectionTertiary as flourishCollectionTertiary,
     heroPrimary as flourishHeroPrimary,
     heroSecondary as flourishHeroSecondary,
     heroTertiary as flourishHeroTertiary,

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -37,14 +37,6 @@ export { Content } from './components/Content/Content';
 export { ContentMedia, ContentMediaBlock } from './components/ContentMedia/ContentMedia';
 export { CountdownClock } from './components/CountdownClock/CountdownClock';
 export { DatePicker } from './components/DatePicker/DatePicker/DatePicker';
-export { Flourishes } from './components/Flourishes/Flourishes';
-export {
-    heroPrimary as flourishHeroPrimary,
-    heroSecondary as flourishHeroSecondary,
-    heroTertiary as flourishHeroTertiary,
-    primary as flourishPrimary,
-    secondary as flourishSecondary,
-} from './components/Flourishes/patterns';
 export {
     Drawer,
     DrawerCloseButton,
@@ -54,6 +46,14 @@ export {
     DrawerTitle,
     DrawerTrigger,
 } from './components/Drawer/Drawer';
+export { Flourishes } from './components/Flourishes/Flourishes';
+export {
+    heroPrimary as flourishHeroPrimary,
+    heroSecondary as flourishHeroSecondary,
+    heroTertiary as flourishHeroTertiary,
+    primary as flourishPrimary,
+    secondary as flourishSecondary,
+} from './components/Flourishes/patterns';
 export {
     Footer,
     FooterBottom,

--- a/packages/osc-ui/src/styles/utilities/_util.scss
+++ b/packages/osc-ui/src/styles/utilities/_util.scss
@@ -177,6 +177,12 @@ $osc-config: (
             "full": 100%,
             "max": max-content
         )
+    ),
+    position: (
+        prefix: "pos",
+        values: (
+            "rel": relative
+        )
     )
 );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds an initial theme setting to the collections document in Sanity, which will pass the colour through to the product page. Note that on product pages the flourish pattern will always be `primary` although the control has an option for setting the pattern. This is intended for the pattern on the collections page. There will be further work to pass this colour through to other settings such as the product form which has been planned in for a later sprint.

To get the theme out of the collection and into the product there are a couple of steps, first one is to get the parent collection for the product, we have to do this using the shopify query, we then pass this into the sanity query as a `collections` param. I have updated the groq query to then merge this value into products query, looks a bit funky but works nicely.

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

- Adds `Flourishes` to products page
- Refactors `getPageData` to allow more flexible parameters
- Adds theme settings to collections document
- Updates Shopify product query to return the parent collection
- Updates Sanity product query to merge collection theme

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information

Note that there is a bug in Sanity currently. To temporarily get around this add `import { faqs } from './faqs';` to the top of `osc-studio/desk/index.ts`