### PR TITLE
Feature/product form drawer

### DIFF
--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
@@ -3,7 +3,7 @@ import type {
     Product as ProductType,
     ProductVariant,
 } from '@shopify/hydrogen/storefront-api-types';
-import { Button, ButtonGroup, RadioGroup, RadioItem } from 'osc-ui';
+import { Button, ButtonGroup, RadioGroup, RadioItem, classNames, useModifier } from 'osc-ui';
 import type { ElementRef, FormEvent } from 'react';
 import { Fragment, forwardRef, useMemo } from 'react';
 import { Price } from '~/components/Price/Price';
@@ -13,141 +13,160 @@ interface Product {
     product: ProductType & { selectedVariant?: ProductVariant };
 }
 
-export const ProductForm = forwardRef<ElementRef<'div'>>((_, forwardedRef) => {
-    const { product } = useLoaderData<Product>();
+interface ProductFormProps {
+    direction?: 'right' | 'bottom';
+}
 
-    const [currentSearchParams] = useSearchParams();
-    const transition = useNavigation();
-    const submit = useSubmit();
+export const ProductForm = forwardRef<ElementRef<'div'>, ProductFormProps>(
+    (props, forwardedRef) => {
+        const { direction } = props;
+        const { product } = useLoaderData<Product>();
 
-    const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
+        const [currentSearchParams] = useSearchParams();
+        const transition = useNavigation();
+        const directionModifier = useModifier('c-product-form', direction);
+        const submit = useSubmit();
 
-        submit(e.currentTarget, {
-            // Replace history stack so users can go back without having to revisit every selected option
-            replace: true,
-            // As we're using a 'get' method we want to make sure the page doesn't move around when the form is submitted
-            preventScrollReset: true,
-        });
-    };
+        const transitionIsNotIdle =
+            transition.state !== 'idle' && transition.formAction ? true : false;
 
-    /**
-     * We update `searchParams` with in-flight request data from `transition` (if available)
-     * to create an optimistic UI, e.g. check the product option before the
-     * request has completed.
-     */
-    const searchParams = useMemo(() => {
-        return transition.location
-            ? new URLSearchParams(transition.location.search)
-            : currentSearchParams;
-    }, [currentSearchParams, transition]);
+        const classes = classNames(
+            'c-product-form',
+            transitionIsNotIdle ? 'is-loading' : '',
+            directionModifier
+        );
 
-    const firstVariant = product.variants.nodes[0];
+        const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
 
-    /**
-     * We're making an explicit choice here to display the product options
-     * UI with a default variant, rather than wait for the user to select
-     * options first.
-     * By default, the first variant's options are used.
-     */
-    const searchParamsWithDefaults = useMemo<URLSearchParams>(() => {
-        const clonedParams = new URLSearchParams(searchParams);
+            submit(e.currentTarget, {
+                // Replace history stack so users can go back without having to revisit every selected option
+                replace: true,
+                // As we're using a 'get' method we want to make sure the page doesn't move around when the form is submitted
+                preventScrollReset: true,
+            });
+        };
 
-        for (const { name, value } of firstVariant.selectedOptions) {
-            if (!searchParams.has(name)) {
-                clonedParams.set(name, value);
+        /**
+         * We update `searchParams` with in-flight request data from `transition` (if available)
+         * to create an optimistic UI, e.g. check the product option before the
+         * request has completed.
+         */
+        const searchParams = useMemo(() => {
+            return transition.location
+                ? new URLSearchParams(transition.location.search)
+                : currentSearchParams;
+        }, [currentSearchParams, transition]);
+
+        const firstVariant = product.variants.nodes[0];
+
+        /**
+         * We're making an explicit choice here to display the product options
+         * UI with a default variant, rather than wait for the user to select
+         * options first.
+         * By default, the first variant's options are used.
+         */
+        const searchParamsWithDefaults = useMemo<URLSearchParams>(() => {
+            const clonedParams = new URLSearchParams(searchParams);
+
+            for (const { name, value } of firstVariant.selectedOptions) {
+                if (!searchParams.has(name)) {
+                    clonedParams.set(name, value);
+                }
             }
-        }
 
-        return clonedParams;
-    }, [searchParams, firstVariant.selectedOptions]);
+            return clonedParams;
+        }, [searchParams, firstVariant.selectedOptions]);
 
-    /**
-     * Likewise, we're defaulting to the first variant for purposes
-     * of add to cart if there is none returned from the loader.
-     */
-    const selectedVariant = product.selectedVariant ?? firstVariant;
-    const isOutOfStock = !selectedVariant?.availableForSale;
+        /**
+         * Likewise, we're defaulting to the first variant for purposes
+         * of add to cart if there is none returned from the loader.
+         */
+        const selectedVariant = product.selectedVariant ?? firstVariant;
+        const isOutOfStock = !selectedVariant?.availableForSale;
 
-    const transitionIsNotIdle = transition.state !== 'idle' && transition.formAction ? true : false;
+        return (
+            <div className={classes} ref={forwardedRef}>
+                <Form onChange={handleSubmit} className="c-product-form__form">
+                    {product.options && product.options.length > 0
+                        ? product.options.map((option, index) => {
+                              return (
+                                  <Fragment key={`option-${index}-${option.name}`}>
+                                      <RadioGroup
+                                          // TODO: Could we update the data in Shopify so the name values reflect the name on the FE?
+                                          // TODO: Can we change the order in the CMS?
+                                          description={{
+                                              id: option.name,
+                                              value: `<h2 class="t-font-l u-text-bold u-color-secondary">${option.name}</h2>`,
+                                          }}
+                                          name={option.name}
+                                          defaultValue={searchParamsWithDefaults.get(option.name)!}
+                                          direction={option.name === 'Format' ? 'column' : 'row'}
+                                          className="c-product-form__radio-group c-radio-group--col-gap-l"
+                                      >
+                                          {option.values.map((value) => (
+                                              <RadioItem
+                                                  key={`${option.name}-${value}`}
+                                                  id={`${option.name}-${value}`}
+                                                  name={value}
+                                                  value={value}
+                                              />
+                                          ))}
+                                      </RadioGroup>
+                                  </Fragment>
+                              );
+                          })
+                        : null}
+                </Form>
 
-    return (
-        <div className={`c-product-form ${transitionIsNotIdle ? 'is-loading' : ''}`}>
-            <Form onChange={handleSubmit} className="c-product-form__form">
-                {product.options && product.options.length > 0
-                    ? product.options.map((option, index) => {
-                          return (
-                              <Fragment key={`option-${index}-${option.name}`}>
-                                  <RadioGroup
-                                      // TODO: Could we update the data in Shopify so the name values reflect the name on the FE?
-                                      // TODO: Can we change the order in the CMS?
-                                      description={{
-                                          id: option.name,
-                                          value: `<h2 class="t-font-l u-text-bold u-color-secondary">${option.name}</h2>`,
-                                      }}
-                                      name={option.name}
-                                      defaultValue={searchParamsWithDefaults.get(option.name)!}
-                                      direction={option.name === 'Format' ? 'column' : 'row'}
-                                      className="c-product-form__radio-group c-radio-group--col-gap-l"
-                                  >
-                                      {option.values.map((value) => (
-                                          <RadioItem
-                                              key={`${option.name}-${value}`}
-                                              id={`${option.name}-${value}`}
-                                              name={value}
-                                              value={value}
-                                          />
-                                      ))}
-                                  </RadioGroup>
-                              </Fragment>
-                          );
-                      })
-                    : null}
-            </Form>
-
-            {/*
+                {/*
                 // TODO: This needs to come from Shopify once we have the setup
                 // TODO: Add to above form when this is available in Shopify, currently causes form to fail to submit correctly as the options are not available
             */}
-            <RadioGroup
-                description={{
-                    id: 'payment-options',
-                    value: '<h2 class="t-font-l u-text-bold u-color-secondary">Payment Options</h2>',
-                }}
-                name="payment-options"
-                defaultValue="Pay upfront"
-                direction="row"
-                className="c-product-form__radio-group"
-            >
-                <RadioItem id="payment-option-pay-upfront" name="Pay upfront" value="Pay upfront" />
-            </RadioGroup>
-
-            <div className="o-flex o-flex--end o-flex--wrap o-flex--v-center">
-                {/* // TODO: add this back in once Wishlist is ready  */}
-                {/* <SaveForLaterButton /> */}
-
-                <Price selectedVariant={selectedVariant} />
-            </div>
-
-            <ButtonGroup direction="column">
-                {!isOutOfStock ? (
-                    <AddToCart
-                        lines={[
-                            {
-                                merchandiseId: selectedVariant.id,
-                                quantity: 1,
-                            },
-                        ]}
+                <RadioGroup
+                    description={{
+                        id: 'payment-options',
+                        value: '<h2 class="t-font-l u-text-bold u-color-secondary">Payment Options</h2>',
+                    }}
+                    name="payment-options"
+                    defaultValue="Pay upfront"
+                    direction="row"
+                    className="c-product-form__radio-group"
+                >
+                    <RadioItem
+                        id="payment-option-pay-upfront"
+                        name="Pay upfront"
+                        value="Pay upfront"
                     />
-                ) : (
-                    <></>
-                )}
+                </RadioGroup>
 
-                <Button variant="tertiary" isFull as="link" to="/contact">
-                    Request a callback
-                </Button>
-            </ButtonGroup>
-        </div>
-    );
-});
+                <div className="o-flex o-flex--end o-flex--wrap o-flex--v-center">
+                    {/* // TODO: add this back in once Wishlist is ready  */}
+                    {/* <SaveForLaterButton /> */}
+
+                    <Price selectedVariant={selectedVariant} />
+                </div>
+
+                <ButtonGroup direction="column">
+                    {!isOutOfStock ? (
+                        <AddToCart
+                            lines={[
+                                {
+                                    merchandiseId: selectedVariant.id,
+                                    quantity: 1,
+                                },
+                            ]}
+                        />
+                    ) : (
+                        <></>
+                    )}
+
+                    <Button variant="tertiary" isFull as="link" to="/contact">
+                        Request a callback
+                    </Button>
+                </ButtonGroup>
+            </div>
+        );
+    }
+);
 ProductForm.displayName = 'ProductForm';

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
@@ -1,11 +1,12 @@
 import { Form, useLoaderData, useNavigation, useSearchParams, useSubmit } from '@remix-run/react';
 import type {
+    ProductOption,
     Product as ProductType,
     ProductVariant,
 } from '@shopify/hydrogen/storefront-api-types';
 import { Button, ButtonGroup, RadioGroup, RadioItem, classNames, useModifier } from 'osc-ui';
 import type { ElementRef, FormEvent } from 'react';
-import { Fragment, forwardRef, useMemo } from 'react';
+import { forwardRef, useMemo } from 'react';
 import { Price } from '~/components/Price/Price';
 import { AddToCart } from '../AddToCart/AddToCart';
 
@@ -92,29 +93,16 @@ export const ProductForm = forwardRef<ElementRef<'div'>, ProductFormProps>(
                     {product.options && product.options.length > 0
                         ? product.options.map((option, index) => {
                               return (
-                                  <Fragment key={`${id}-${index}-${option.name}`}>
-                                      <RadioGroup
-                                          // TODO: Could we update the data in Shopify so the name values reflect the name on the FE?
-                                          // TODO: Can we change the order in the CMS?
-                                          description={{
-                                              id: option.name,
-                                              value: `<h2 class="t-font-l u-text-bold u-color-secondary">${option.name}</h2>`,
-                                          }}
-                                          name={option.name}
-                                          defaultValue={searchParamsWithDefaults.get(option.name)!}
-                                          direction={option.name === 'Format' ? 'column' : 'row'}
-                                          className="c-product-form__radio-group c-radio-group--col-gap-l"
-                                      >
-                                          {option.values.map((value) => (
-                                              <RadioItem
-                                                  key={`${id}-${option.name}-${value}`}
-                                                  id={`${id}-${option.name}-${value}`}
-                                                  name={value}
-                                                  value={value}
-                                              />
-                                          ))}
-                                      </RadioGroup>
-                                  </Fragment>
+                                  <Options
+                                      // Here we're passing the searchParamsWithDefaults as part of the key so the options remount when searchParams changes
+                                      // This is needed to keep the main form and the drawer forms in sync
+                                      key={`${id}-${index}-${
+                                          option.name
+                                      }-${searchParamsWithDefaults.get(option.name)}`}
+                                      id={id}
+                                      option={option}
+                                      searchParamsWithDefaults={searchParamsWithDefaults}
+                                  />
                               );
                           })
                         : null}
@@ -171,3 +159,39 @@ export const ProductForm = forwardRef<ElementRef<'div'>, ProductFormProps>(
     }
 );
 ProductForm.displayName = 'ProductForm';
+
+/* -------------------------------------------------------------------------------------------------
+ * Product Options
+ * -----------------------------------------------------------------------------------------------*/
+interface OptionsProps {
+    id: string;
+    option: ProductOption;
+    searchParamsWithDefaults: URLSearchParams;
+}
+
+const Options = (props: OptionsProps) => {
+    const { id, option, searchParamsWithDefaults } = props;
+
+    return (
+        <RadioGroup
+            // TODO: Waiting for Tom to update the import so we have the correct option names on the FE
+            description={{
+                id: option.name,
+                value: `<h2 class="t-font-l u-text-bold u-color-secondary">${option.name}</h2>`,
+            }}
+            name={option.name}
+            defaultValue={searchParamsWithDefaults.get(option.name)!}
+            direction={option.name === 'Format' ? 'column' : 'row'}
+            className="c-product-form__radio-group c-radio-group--col-gap-l"
+        >
+            {option.values.map((value) => (
+                <RadioItem
+                    key={`${id}-${option.name}-${value}`}
+                    id={`${id}-${option.name}-${value}`}
+                    name={value}
+                    value={value}
+                />
+            ))}
+        </RadioGroup>
+    );
+};

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
@@ -4,8 +4,8 @@ import type {
     ProductVariant,
 } from '@shopify/hydrogen/storefront-api-types';
 import { Button, ButtonGroup, RadioGroup, RadioItem } from 'osc-ui';
-import type { FormEvent } from 'react';
-import { Fragment, useMemo } from 'react';
+import type { ElementRef, FormEvent } from 'react';
+import { Fragment, forwardRef, useMemo } from 'react';
 import { Price } from '~/components/Price/Price';
 import { AddToCart } from '../AddToCart/AddToCart';
 
@@ -13,7 +13,7 @@ interface Product {
     product: ProductType & { selectedVariant?: ProductVariant };
 }
 
-export const ProductForm = () => {
+export const ProductForm = forwardRef<ElementRef<'div'>>((_, forwardedRef) => {
     const { product } = useLoaderData<Product>();
 
     const [currentSearchParams] = useSearchParams();
@@ -149,4 +149,5 @@ export const ProductForm = () => {
             </ButtonGroup>
         </div>
     );
-};
+});
+ProductForm.displayName = 'ProductForm';

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
@@ -1,4 +1,4 @@
-import { Form, useNavigation, useSearchParams, useSubmit } from '@remix-run/react';
+import { Form, useLoaderData, useNavigation, useSearchParams, useSubmit } from '@remix-run/react';
 import type {
     Product as ProductType,
     ProductVariant,
@@ -9,11 +9,13 @@ import { Fragment, useMemo } from 'react';
 import { Price } from '~/components/Price/Price';
 import { AddToCart } from '../AddToCart/AddToCart';
 
-interface ProductFormProps {
+interface Product {
     product: ProductType & { selectedVariant?: ProductVariant };
 }
-export const ProductForm = (props: ProductFormProps) => {
-    const { product } = props;
+
+export const ProductForm = () => {
+    const { product } = useLoaderData<Product>();
+
     const [currentSearchParams] = useSearchParams();
     const transition = useNavigation();
     const submit = useSubmit();

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
@@ -14,12 +14,13 @@ interface Product {
 }
 
 interface ProductFormProps {
+    id: string;
     direction?: 'right' | 'bottom';
 }
 
 export const ProductForm = forwardRef<ElementRef<'div'>, ProductFormProps>(
     (props, forwardedRef) => {
-        const { direction } = props;
+        const { id, direction } = props;
         const { product } = useLoaderData<Product>();
 
         const [currentSearchParams] = useSearchParams();
@@ -91,7 +92,7 @@ export const ProductForm = forwardRef<ElementRef<'div'>, ProductFormProps>(
                     {product.options && product.options.length > 0
                         ? product.options.map((option, index) => {
                               return (
-                                  <Fragment key={`option-${index}-${option.name}`}>
+                                  <Fragment key={`${id}-${index}-${option.name}`}>
                                       <RadioGroup
                                           // TODO: Could we update the data in Shopify so the name values reflect the name on the FE?
                                           // TODO: Can we change the order in the CMS?
@@ -106,8 +107,8 @@ export const ProductForm = forwardRef<ElementRef<'div'>, ProductFormProps>(
                                       >
                                           {option.values.map((value) => (
                                               <RadioItem
-                                                  key={`${option.name}-${value}`}
-                                                  id={`${option.name}-${value}`}
+                                                  key={`${id}-${option.name}-${value}`}
+                                                  id={`${id}-${option.name}-${value}`}
                                                   name={value}
                                                   value={value}
                                               />

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
@@ -59,7 +59,7 @@ export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
                     <DrawerTitle>{BUTTON_TEXT}</DrawerTitle>
                 </VisuallyHidden>
 
-                <ProductForm direction={showOnGreaterThanTab ? 'right' : 'bottom'} />
+                <ProductForm id="drawer" direction={showOnGreaterThanTab ? 'right' : 'bottom'} />
             </DrawerContent>
         </Drawer>
     );

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
@@ -1,3 +1,4 @@
+import { mediaQueries as mq } from 'osc-design-tokens';
 import {
     Button,
     Drawer,
@@ -6,26 +7,54 @@ import {
     DrawerTrigger,
     Icon,
     VisuallyHidden,
+    rem,
+    useMediaQuery,
 } from 'osc-ui';
+import { useEffect, useState } from 'react';
 import { ProductForm } from './ProductForm';
 
-export const ProductFormDrawer = () => {
+interface ProductFormDrawerProps {
+    hideTrigger?: boolean;
+}
+export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
+    const { hideTrigger } = props;
+
+    const isGreaterThanTab = useMediaQuery(`(min-width: ${rem(mq.tab)}rem)`);
+    const [showOnGreaterThanTab, setShowOnGreaterThanTab] = useState(false);
+
+    const BUTTON_TEXT = 'Enrol now';
+
+    // We need this useEffect to set the showOnTab state only when the window object exists
+    // Otherwise we will receive an SSR warning telling us the markup differs from the server
+    useEffect(() => {
+        setShowOnGreaterThanTab(isGreaterThanTab);
+    }, [isGreaterThanTab]);
+
     return (
-        <Drawer direction="right" isOffset={true}>
+        <Drawer direction={showOnGreaterThanTab ? 'right' : 'bottom'} isOffset={true}>
             <DrawerTrigger asChild isPinned>
-                <Button variant="senary" className="c-btn--flush-r">
-                    Enrol now <Icon id="chevron-left" />
+                <Button
+                    variant="senary"
+                    className={`${showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'} ${
+                        hideTrigger ? 'is-hidden' : 'is-active'
+                    } u-w-max`}
+                >
+                    {BUTTON_TEXT} <Icon id={showOnGreaterThanTab ? 'chevron-left' : 'chevron-up'} />
                 </Button>
             </DrawerTrigger>
             <DrawerContent innerClassName="u-pt-0 u-pr-0 u-pb-0 u-pl-0">
                 <DrawerTrigger asChild isPinned isCloseButton>
-                    <Button variant="senary" className="c-btn--flush-r">
-                        Enrol now <Icon id="chevron-right" />
+                    <Button
+                        variant="senary"
+                        className={`${showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'}`}
+                    >
+                        {BUTTON_TEXT}{' '}
+                        <Icon id={showOnGreaterThanTab ? 'chevron-right' : 'chevron-down'} />
                     </Button>
                 </DrawerTrigger>
 
                 <VisuallyHidden>
-                    <DrawerTitle>Enrol now</DrawerTitle>
+                    <DrawerTitle>{BUTTON_TEXT}</DrawerTitle>
                 </VisuallyHidden>
 
                 <ProductForm />

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
@@ -20,7 +20,7 @@ export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
     const { hideTrigger } = props;
 
     const isGreaterThanTab = useMediaQuery(`(min-width: ${rem(mq.tab)}rem)`);
-    const [showOnGreaterThanTab, setShowOnGreaterThanTab] = useState(false);
+    const [showOnGreaterThanTab, setShowOnGreaterThanTab] = useState<boolean>(false);
 
     const BUTTON_TEXT = 'Enrol now';
 
@@ -32,11 +32,11 @@ export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
 
     return (
         <Drawer direction={showOnGreaterThanTab ? 'right' : 'bottom'} isOffset={true}>
-            <DrawerTrigger asChild isPinned>
+            <DrawerTrigger asChild isPinned className={`${hideTrigger ? 'is-hidden' : ''}`}>
                 <Button
                     variant="senary"
-                    className={`${showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'} ${
-                        hideTrigger ? 'is-hidden' : 'is-active'
+                    className={`${
+                        showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'
                     } u-w-max`}
                 >
                     {BUTTON_TEXT} <Icon id={showOnGreaterThanTab ? 'chevron-left' : 'chevron-up'} />
@@ -46,7 +46,9 @@ export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
                 <DrawerTrigger asChild isPinned isCloseButton>
                     <Button
                         variant="senary"
-                        className={`${showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'}`}
+                        className={`${
+                            showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'
+                        } c-btn--b-img-none`}
                     >
                         {BUTTON_TEXT}{' '}
                         <Icon id={showOnGreaterThanTab ? 'chevron-right' : 'chevron-down'} />
@@ -57,7 +59,7 @@ export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
                     <DrawerTitle>{BUTTON_TEXT}</DrawerTitle>
                 </VisuallyHidden>
 
-                <ProductForm />
+                <ProductForm direction={showOnGreaterThanTab ? 'right' : 'bottom'} />
             </DrawerContent>
         </Drawer>
     );

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
@@ -1,0 +1,35 @@
+import {
+    Button,
+    Drawer,
+    DrawerContent,
+    DrawerTitle,
+    DrawerTrigger,
+    Icon,
+    VisuallyHidden,
+} from 'osc-ui';
+import { ProductForm } from './ProductForm';
+
+export const ProductFormDrawer = () => {
+    return (
+        <Drawer direction="right" isOffset={true}>
+            <DrawerTrigger asChild isPinned>
+                <Button variant="senary" className="c-btn--flush-r">
+                    Enrol now <Icon id="chevron-left" />
+                </Button>
+            </DrawerTrigger>
+            <DrawerContent innerClassName="u-pt-0 u-pr-0 u-pb-0 u-pl-0">
+                <DrawerTrigger asChild isPinned isCloseButton>
+                    <Button variant="senary" className="c-btn--flush-r">
+                        Enrol now <Icon id="chevron-right" />
+                    </Button>
+                </DrawerTrigger>
+
+                <VisuallyHidden>
+                    <DrawerTitle>Enrol now</DrawerTitle>
+                </VisuallyHidden>
+
+                <ProductForm />
+            </DrawerContent>
+        </Drawer>
+    );
+};

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductFormDrawer.tsx
@@ -36,7 +36,9 @@ export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
                 <Button
                     variant="senary"
                     className={`${
-                        showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'
+                        showOnGreaterThanTab
+                            ? 'c-btn--flush-r c-btn--anim-icon-l'
+                            : 'c-btn--flush-b'
                     } u-w-max`}
                 >
                     {BUTTON_TEXT} <Icon id={showOnGreaterThanTab ? 'chevron-left' : 'chevron-up'} />
@@ -47,7 +49,9 @@ export const ProductFormDrawer = (props: ProductFormDrawerProps) => {
                     <Button
                         variant="senary"
                         className={`${
-                            showOnGreaterThanTab ? 'c-btn--flush-r' : 'c-btn--flush-b'
+                            showOnGreaterThanTab
+                                ? 'c-btn--flush-r c-btn--anim-icon-r'
+                                : 'c-btn--flush-b'
                         } c-btn--b-img-none`}
                     >
                         {BUTTON_TEXT}{' '}

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/product-form.scss
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/product-form.scss
@@ -25,7 +25,6 @@
         border: $product-form-border-width solid;
         border-image-slice: 1;
         border-image-source: $product-form-gradient;
-        border-right: none;
 
         @include mq($mq-tab) {
             position: sticky;
@@ -33,12 +32,25 @@
             padding: $space-2xl $space-4xl $space-2xl $space-2xl;
         }
 
-        @include mq(($mq-mob-l, $mq-tab)) {
+        &--right {
+            border-right: none;
+        }
+
+        &--bottom {
+            border-bottom: none;
+        }
+
+        @include mq(($mq-mob-l, $mq-tab - 1)) {
             border-right: $product-form-border-width solid;
         }
 
         @include mq($product-form-mq-l) {
             border-right: $product-form-border-width solid;
+
+            /* stylelint-disable-next-line plugin/selector-bem-pattern, selector-class-pattern */
+            .c-drawer__content & {
+                border-right: none;
+            }
         }
 
         &.is-loading {

--- a/packages/osc-ecommerce/app/root.tsx
+++ b/packages/osc-ecommerce/app/root.tsx
@@ -16,6 +16,7 @@ import { SkipLink } from 'osc-ui';
 import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import oscUiAccordionStyles from 'osc-ui/dist/src-components-Accordion-accordion.css';
 import oscUiBurgerStyles from 'osc-ui/dist/src-components-Burger-burger.css';
+import oscUiDrawerStyles from 'osc-ui/dist/src-components-Drawer-drawer.css';
 import oscFooterStyles from 'osc-ui/dist/src-components-Footer-footer.css';
 import oscHeaderStyles from 'osc-ui/dist/src-components-Header-header.css';
 import oscLogoStyles from 'osc-ui/dist/src-components-Logo-logo.css';
@@ -55,6 +56,7 @@ export const links: LinksFunction = () => {
         { rel: 'stylesheet', href: oscUiBurgerStyles },
         { rel: 'stylesheet', href: oscUiAccordionStyles },
         { rel: 'stylesheet', href: oscFooterStyles },
+        { rel: 'stylesheet', href: oscUiDrawerStyles },
         {
             rel: 'preconnect',
             href: 'https://cdn.shopify.com',

--- a/packages/osc-ecommerce/app/routes/courses/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/courses/$slug.tsx
@@ -14,6 +14,7 @@ import { lazy } from 'react';
 import type { DynamicLinksFunction } from 'remix-utils';
 import invariant from 'tiny-invariant';
 import { ProductForm } from '~/components/Forms/ProductForm/ProductForm';
+import { ProductFormDrawer } from '~/components/Forms/ProductForm/ProductFormDrawer';
 import productFormStyles from '~/components/Forms/ProductForm/product-form.css';
 import { getComponentStyles } from '~/components/Module';
 import { PageContent, PageContentUpper } from '~/components/PageContent';
@@ -185,15 +186,17 @@ export default function Index() {
 
                     <div className="c-product-form__container o-grid__col o-grid__col--12 o-grid__col--start-8@tab o-grid__col--6@tab o-grid__col--start-7@desk o-grid__col--start-8@desk-med">
                         <ProductForm />
+                        <ProductFormDrawer />
                     </div>
 
-                {isPreviewMode ? (
-                    <PreviewSuspense fallback={<PageContent {...page} />}>
-                        <PagePreview query={query} params={params} Component={PageContent} />
-                    </PreviewSuspense>
-                ) : (
-                    <PageContent {...page} />
-                )}
+                    {isPreviewMode ? (
+                        <PreviewSuspense fallback={<PageContent {...page} />}>
+                            <PagePreview query={query} params={params} Component={PageContent} />
+                        </PreviewSuspense>
+                    ) : (
+                        <PageContent {...page} />
+                    )}
+                </div>
             </div>
         </>
     );

--- a/packages/osc-ecommerce/app/routes/courses/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/courses/$slug.tsx
@@ -131,8 +131,23 @@ export const meta: MetaFunction = ({ data, parentsData }) => {
 };
 
 export default function Index() {
-    const { page, product, isPreview, query, params } = useLoaderData<typeof loader>();
+    const { page, product, isPreview, query } = useLoaderData<typeof loader>();
+    const params = useParams();
+    const intersectionRef = useRef<HTMLDivElement>(null);
     const isPreviewMode = isPreview && query && params;
+
+    const productFormIntersection = useIntersectionObserver(intersectionRef, {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0,
+    });
+    const formIsIntersecting = productFormIntersection?.isIntersecting;
+
+    // If `preview` mode is active, its component updates this state for us
+    const [data, setData] = useState<SanityProduct>(page);
+
+    // Make sure to update the page state if the IDs are different!
+    if (page?._id !== data?._id) setData(page);
 
     // Due how the data is setup in Shopify there are times where we might return the same SKU multiple times
     // Here we are checking if there are any SKUs and then filtering out duplicates
@@ -185,8 +200,9 @@ export default function Index() {
                     ) : null}
 
                     <div className="c-product-form__container o-grid__col o-grid__col--12 o-grid__col--start-8@tab o-grid__col--6@tab o-grid__col--start-7@desk o-grid__col--start-8@desk-med">
-                        <ProductForm />
-                        <ProductFormDrawer />
+                        <ProductForm ref={intersectionRef} />
+
+                        <ProductFormDrawer hideTrigger={formIsIntersecting} />
                     </div>
 
                     {isPreviewMode ? (

--- a/packages/osc-ecommerce/app/routes/courses/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/courses/$slug.tsx
@@ -200,7 +200,7 @@ export default function Index() {
                     ) : null}
 
                     <div className="c-product-form__container o-grid__col o-grid__col--12 o-grid__col--start-8@tab o-grid__col--6@tab o-grid__col--start-7@desk o-grid__col--start-8@desk-med">
-                        <ProductForm direction="right" ref={intersectionRef} />
+                        <ProductForm id="main" direction="right" ref={intersectionRef} />
 
                         <ProductFormDrawer hideTrigger={formIsIntersecting} />
                     </div>

--- a/packages/osc-ecommerce/app/routes/courses/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/courses/$slug.tsx
@@ -184,9 +184,8 @@ export default function Index() {
                     ) : null}
 
                     <div className="c-product-form__container o-grid__col o-grid__col--12 o-grid__col--start-8@tab o-grid__col--6@tab o-grid__col--start-7@desk o-grid__col--start-8@desk-med">
-                        <ProductForm product={product} />
+                        <ProductForm />
                     </div>
-                </div>
 
                 {isPreviewMode ? (
                     <PreviewSuspense fallback={<PageContent {...page} />}>

--- a/packages/osc-ecommerce/app/routes/courses/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/courses/$slug.tsx
@@ -200,7 +200,7 @@ export default function Index() {
                     ) : null}
 
                     <div className="c-product-form__container o-grid__col o-grid__col--12 o-grid__col--start-8@tab o-grid__col--6@tab o-grid__col--start-7@desk o-grid__col--start-8@desk-med">
-                        <ProductForm ref={intersectionRef} />
+                        <ProductForm direction="right" ref={intersectionRef} />
 
                         <ProductFormDrawer hideTrigger={formIsIntersecting} />
                     </div>

--- a/packages/osc-ui/src/components/Button/Button.stories.tsx
+++ b/packages/osc-ui/src/components/Button/Button.stories.tsx
@@ -118,10 +118,11 @@ export const Senary = Template.bind({});
 Senary.args = {
     children: (
         <>
-            Enrol now <Icon id="chevron-down" />
+            Enrol now <Icon id="chevron-left" />
         </>
     ),
     variant: 'senary',
+    className: 'c-btn--flush-r c-btn--anim-icon-l',
 };
 Senary.parameters = {
     docs: {

--- a/packages/osc-ui/src/components/Button/button.scss
+++ b/packages/osc-ui/src/components/Button/button.scss
@@ -321,6 +321,11 @@
                     border: 6px solid $btn-color-theme;
                     border-image-slice: 1;
                     border-image-source: $btn-border-theme;
+                    transition: border-image $timing-m $ease-in-out;
+
+                    &:hover {
+                        border-image-slice: 1 100;
+                    }
 
                     svg {
                         font-size: 1em;

--- a/packages/osc-ui/src/components/Button/button.scss
+++ b/packages/osc-ui/src/components/Button/button.scss
@@ -18,6 +18,7 @@
     $btn-radius: $rad-l;
     $btn-color-theme: var(--btn-theme-color, var(--color-primary)); /* [1] */
     $btn-border-theme: var(--btn-theme-gradient, var(--color-gradient-primary-270)); /* [2] */
+    $btn-icon-transition-distance: 0.2em;
     $btn-properties: (
         primary: (
             bg-color: var(--color-secondary),
@@ -251,6 +252,7 @@
             width: 1em; // Make sure svg scales with the font-size
             height: 1em; // Make sure svg scales with the font-size
             font-size: 1.4em;
+            transition: transform $timing-s $ease-in-out;
         }
 
         &--no-shadow {
@@ -322,10 +324,6 @@
                     border-image-slice: 1;
                     border-image-source: $btn-border-theme;
                     transition: border-image $timing-m $ease-in-out;
-
-                    &:hover {
-                        border-image-slice: 1 100;
-                    }
 
                     svg {
                         font-size: 1em;
@@ -499,6 +497,24 @@
 
         &--b-img-none {
             border-image-source: none;
+        }
+
+        &--anim-icon-l {
+            &:hover,
+            &:active {
+                svg {
+                    transform: translateX(-$btn-icon-transition-distance);
+                }
+            }
+        }
+
+        &--anim-icon-r {
+            &:hover,
+            &:active {
+                svg {
+                    transform: translateX($btn-icon-transition-distance);
+                }
+            }
         }
     }
 

--- a/packages/osc-ui/src/components/Button/button.scss
+++ b/packages/osc-ui/src/components/Button/button.scss
@@ -7,7 +7,8 @@
 /*
  * Some elements/modifiers of the button are themeable. This is handled by the --btn-theme-color custom property
  *
- * [1] Set the gradient to the --btn-theme-gradient and fallback to the primary gradient if it doesn't exist
+ * [1] Set the color to the --btn-theme-color and fallback to the primary color if it doesn't exist
+ * [2] Set the gradient to the --btn-theme-gradient and fallback to the primary gradient if it doesn't exist
  *     Only used on the senary variant currently.
  */
 
@@ -15,7 +16,8 @@
     $btn-primary-border: solid 3px var(--color-secondary);
     $btn-primary-offset: 6px;
     $btn-radius: $rad-l;
-    $btn-border-theme: var(--btn-theme-gradient, var(--color-gradient-primary-270));
+    $btn-color-theme: var(--btn-theme-color, var(--color-primary)); /* [1] */
+    $btn-border-theme: var(--btn-theme-gradient, var(--color-gradient-primary-270)); /* [2] */
     $btn-properties: (
         primary: (
             bg-color: var(--color-secondary),
@@ -316,7 +318,7 @@
                 }
 
                 @if $class == "senary" {
-                    border: 6px solid;
+                    border: 6px solid $btn-color-theme;
                     border-image-slice: 1;
                     border-image-source: $btn-border-theme;
 
@@ -488,6 +490,10 @@
 
         &--flush-l {
             border-left: 0;
+        }
+
+        &--b-img-none {
+            border-image-source: none;
         }
     }
 

--- a/packages/osc-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/osc-ui/src/components/Drawer/Drawer.tsx
@@ -159,12 +159,17 @@ export interface DrawerContentProps
      * @default false
      */
     isFull?: boolean;
+    /**
+     * Custom classes to be passed to the inner div
+     */
+    innerClassName?: string;
 }
 
 export const DrawerContent = (props: DrawerContentProps) => {
     const {
         children,
         className,
+        innerClassName,
         container,
         showOverlay = true,
         size = 'md',
@@ -184,6 +189,7 @@ export const DrawerContent = (props: DrawerContentProps) => {
         isFull && 'is-full',
         className
     );
+    const innerClasses = classNames('c-drawer__content-inner', innerClassName);
 
     return (
         <Dialog.Portal container={container}>
@@ -197,7 +203,7 @@ export const DrawerContent = (props: DrawerContentProps) => {
                     ['--drawer-trigger-height' as string]: `${triggerHeight}px`,
                 }}
             >
-                <div className="c-drawer__content-inner">{children}</div>
+                <div className={innerClasses}>{children}</div>
             </Dialog.Content>
         </Dialog.Portal>
     );

--- a/packages/osc-ui/src/components/Drawer/drawer.scss
+++ b/packages/osc-ui/src/components/Drawer/drawer.scss
@@ -4,7 +4,8 @@
 @layer components {
     $drawer-directions: (top, right, bottom, left);
     $drawer-trigger-height: var(--drawer-trigger-height); // Value is generated on the component
-    $drawer-width-m: 610px;
+    $drawer-width-l: 610px;
+    $drawer-width-m: 566px;
     $drawer-width-s: 370px;
     $drawer-max-height: 750px;
     $drawer-max-height-m: 500px;
@@ -123,8 +124,20 @@
             // *----------------------------------*/
             //  Sizes
             // *----------------------------------*/
-            &--sm {
+            &--sm,
+            &--md,
+            &--lg {
                 width: 100%;
+            }
+
+            &--md,
+            &--lg {
+                @include mq(strip-unit($drawer-max-height), max, height) {
+                    max-height: $drawer-max-height-m;
+                }
+            }
+
+            &--sm {
                 padding: $space-s $space-m;
 
                 @include mq($mq-tab) {
@@ -133,14 +146,14 @@
             }
 
             &--md {
-                width: 100%;
-
-                @include mq(strip-unit($drawer-max-height), max, height) {
-                    max-height: $drawer-max-height-m;
-                }
-
                 @include mq($mq-tab) {
                     max-width: $drawer-width-m;
+                }
+            }
+
+            &--lg {
+                @include mq($mq-tab) {
+                    max-width: $drawer-width-l;
                 }
             }
 

--- a/packages/osc-ui/src/components/Drawer/drawer.scss
+++ b/packages/osc-ui/src/components/Drawer/drawer.scss
@@ -209,12 +209,20 @@
                     }
 
                     @if $dir == top {
+                        &.is-hidden {
+                            transform: translate(-50%, -100%);
+                        }
+
                         &#{$self}--close {
                             top: 100%;
                         }
                     }
 
                     @if $dir == bottom {
+                        &.is-hidden {
+                            transform: translate(-50%, 100%);
+                        }
+
                         &#{$self}--close {
                             bottom: 100%;
                         }
@@ -223,6 +231,10 @@
                     @if $dir == right {
                         left: 100%; /* [1] */
                         transform: translateX(-100%);
+
+                        &.is-hidden {
+                            transform: translateX(100%);
+                        }
 
                         &#{$self}--close {
                             top: 0;
@@ -233,6 +245,10 @@
                     @if $dir == left {
                         right: 100%; /* [1] */
                         transform: translateX(100%);
+
+                        &.is-hidden {
+                            transform: translateX(-100%);
+                        }
 
                         &#{$self}--close {
                             top: 0;

--- a/packages/osc-ui/src/components/Drawer/drawer.scss
+++ b/packages/osc-ui/src/components/Drawer/drawer.scss
@@ -91,7 +91,7 @@
                                 max,
                                 height
                             ) {
-                                top: 0;
+                                top: calc($drawer-offset / 2);
                             }
                         }
                     }
@@ -269,7 +269,7 @@
                                 max,
                                 height
                             ) {
-                                top: 0;
+                                top: calc($drawer-offset / 2);
                             }
                         }
                     }
@@ -303,7 +303,7 @@
                                 max,
                                 height
                             ) {
-                                top: 0;
+                                top: calc($drawer-offset / 2);
                             }
                         }
 

--- a/packages/osc-ui/src/components/Drawer/drawer.scss
+++ b/packages/osc-ui/src/components/Drawer/drawer.scss
@@ -58,10 +58,6 @@
 
             @include z-index(modal);
 
-            @include mq($mq-tab, max, height) {
-                height: 100%;
-            }
-
             // *----------------------------------*/
             //  Direction modifiers
             // *----------------------------------*/

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -38,6 +38,15 @@ export { ContentMedia, ContentMediaBlock } from './components/ContentMedia/Conte
 export { CountdownClock } from './components/CountdownClock/CountdownClock';
 export { DatePicker } from './components/DatePicker/DatePicker/DatePicker';
 export {
+    Drawer,
+    DrawerCloseButton,
+    DrawerContainer,
+    DrawerContent,
+    DrawerDescription,
+    DrawerTitle,
+    DrawerTrigger,
+} from './components/Drawer/Drawer';
+export {
     Footer,
     FooterBottom,
     FooterGroup,

--- a/packages/osc-ui/src/index.tsx
+++ b/packages/osc-ui/src/index.tsx
@@ -100,6 +100,7 @@ export { Trustpilot } from './components/Trustpilot/Trustpilot';
 export { VideoPlayer } from './components/VideoPlayer/VideoPlayer';
 export { VisuallyHidden } from './components/VisuallyHidden/VisuallyHidden';
 // Hooks
+export { useIntersectionObserver } from './hooks/useIntersectionObserver';
 export { useMediaQuery } from './hooks/useMediaQuery';
 export { useModifier } from './hooks/useModifier';
 export { useSpacing } from './hooks/useSpacing';

--- a/packages/osc-ui/src/styles/utilities/_util.scss
+++ b/packages/osc-ui/src/styles/utilities/_util.scss
@@ -174,7 +174,8 @@ $osc-config: (
         prefix: "w",
         values: (
             "fit": fit-content,
-            "full": 100%
+            "full": 100%,
+            "max": max-content
         )
     )
 );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Integrates the drawer into the product page so we have a slide out form. It uses an intersection observer to watch the `ProductForm` and fires when the form is scrolled into or out of view. I've set the threshold to `0` so the entire form has to be out of view for the trigger to appear, and it will disappear again as soon as some of the form is back in the viewport.

To keep the form in the drawer and in the page in sync I've extracted the options `RadioGroup` into an `Options` component and assigned it a `key` which updates along with the `searchParams`. When the value of the key updates it allows React to rerender the `Options` and keeps the two forms in sync.

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

- Exports `Drawer` from `osc-ui`
- Exports `useIntersectionObserver` from `osc-ui`
- Adds `ProductFormDrawer` component
- Updates drawer sizes
- Forwards ref to `ProductForm`
- Moves `ProductForm` radio groups into `Options` component


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
For testing http://localhost:2000/courses/aat-level-2-and-3-accounting has the most stuff on it so will allow you to scroll far enough down to fire the intersection observer.

A couple of things to note:

- There's a weird bug in Safari where the form in the `Drawer` is expanded when the drawer opens and pings back into place as soon as you interact with it. It's a bit weird as you can't really inspect it very easily with the dev tools as the behaviour changes once you select an element
https://user-images.githubusercontent.com/23461173/234591836-38a0ca4b-e18a-4045-a68f-a16e14ce4093.mov
I'll open an issue for this and try and tackle it separately
- When you first load a page you might see the drawer trigger transition across the page. Unfortunately this is because it takes a second or so to reach the conditional so the initial styles don't get applied straight away. I think it's related to our bundle size getting a bit big see: https://github.com/Open-Study-College/osc/issues/775
