### PR TITLE
Bugfix/accordion modifier styles

### DIFF
--- a/packages/osc-ui/src/components/Accordion/Accordion.spec.tsx
+++ b/packages/osc-ui/src/components/Accordion/Accordion.spec.tsx
@@ -117,6 +117,16 @@ test('changes the icon to a chevron', () => {
 });
 
 test('renders the correct variant classname', () => {
+    const classes = [
+        'c-accordion',
+        'c-accordion__icon',
+        'c-accordion__header',
+        'c-accordion__trigger',
+        'c-accordion__item',
+        'c-accordion__content',
+        'c-accordion__text',
+    ];
+
     const { rerender } = render(
         <Accordion type="single" variant="secondary">
             <AccordionItem value="O">
@@ -131,8 +141,9 @@ test('renders the correct variant classname', () => {
         </Accordion>
     );
 
-    const accordion = document.querySelector('.c-accordion');
-    expect(accordion).toHaveClass('c-accordion--secondary');
+    classes.forEach((className) => {
+        expect(document.querySelector(`.${className}`)).toHaveClass(`${className}--secondary`);
+    });
 
     rerender(
         <Accordion type="single" variant="tertiary">
@@ -148,5 +159,7 @@ test('renders the correct variant classname', () => {
         </Accordion>
     );
 
-    expect(accordion).toHaveClass('c-accordion--tertiary');
+    classes.forEach((className) => {
+        expect(document.querySelector(`.${className}`)).toHaveClass(`${className}--tertiary`);
+    });
 });

--- a/packages/osc-ui/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/osc-ui/src/components/Accordion/Accordion.stories.tsx
@@ -162,9 +162,20 @@ const NestedTemplate: Story<AccordionProps> = ({ children, ...args }) => (
                           {child.title}
                       </AccordionHeader>
                       <AccordionPanel>
-                          <Accordion type="single" variant="tertiary">
-                              <AccordionItem value="child">
-                                  <AccordionHeader icon="chevron" asChild={true} as="h3">
+                          <Accordion type="single" defaultValue="child-0" collapsible>
+                              <AccordionItem value="child-0">
+                                  <AccordionHeader icon="plusMinus" asChild={true} as="h3">
+                                      Heading
+                                  </AccordionHeader>
+                                  <AccordionPanel>
+                                      Lorem ipsum dolor sit, amet consectetur adipisicing elit. Sunt
+                                      ipsam temporibus et veniam eveniet dolorum? Eaque alias
+                                      voluptate quis perferendis repellat omnis temporibus maiores
+                                      dolores ad, amet, rerum sed nesciunt!
+                                  </AccordionPanel>
+                              </AccordionItem>
+                              <AccordionItem value="child-1">
+                                  <AccordionHeader icon="plusMinus" asChild={true} as="h3">
                                       Heading
                                   </AccordionHeader>
                                   <AccordionPanel>

--- a/packages/osc-ui/src/components/Accordion/accordion.scss
+++ b/packages/osc-ui/src/components/Accordion/accordion.scss
@@ -20,16 +20,7 @@
     $accordion-transition-timing-func: cubic-bezier(0.87, 0, 0.13, 1);
 
     .c-accordion {
-        --accordion-icon-size: 1.1rem;
-        --accordion-trigger-font-size: #{rem($base-fs * 1.25)}; // design has this fixed across breakpoints
-        --accordion-trigger-grid-columns: 1fr auto;
-
-        &__item {
-            &:not(:last-child) {
-                padding-bottom: $accordion-trigger-padding;
-                border-bottom: $accordion-item-border;
-            }
-        }
+        $self: &;
 
         &__header {
             margin-bottom: 0;
@@ -40,33 +31,54 @@
             width: $accordion-icon-base-size;
             height: $accordion-icon-base-size;
             margin-top: 0.125em; // align the icon with the middle of the text
-            color: $accordion-icon-color;
             font-size: var(--accordion-icon-size);
 
             &--plusminus > :first-child {
+                // prettier-ignore
                 transition:
                     opacity $accordion-transition-duration $accordion-transition-timing-func,
                     visibility $accordion-transition-duration $accordion-transition-timing-func;
             }
 
             &--chevron {
-                transition: transform $accordion-transition-duration $accordion-transition-timing-func;
+                // prettier-ignore
+                transition:
+                    transform $accordion-transition-duration
+                    $accordion-transition-timing-func;
+            }
+
+            &--primary {
+                --accordion-icon-size: 1.1rem;
+
+                color: $accordion-icon-color;
+            }
+
+            &--secondary {
+                --accordion-icon-size: 1.6em;
+
+                grid-column: 3 / -1;
+                color: currentcolor;
+            }
+
+            &--tertiary {
+                @include mq($mq-mob, max) {
+                    display: none;
+                }
             }
         }
 
         &__trigger {
             position: relative;
             display: grid;
+            grid-template-columns: 1fr auto;
             align-items: center;
             box-sizing: border-box;
             width: 100%;
-            padding: $accordion-trigger-padding 0 0;
             font-size: var(--accordion-trigger-font-size);
             font-weight: $fw-bold;
             text-align: left;
             transition: color $accordion-transition-duration $accordion-transition-timing-func;
             cursor: pointer;
-            grid-template-columns: var(--accordion-trigger-grid-columns);
 
             @include mq($mq-mob) {
                 gap: $space-2xl;
@@ -93,49 +105,19 @@
             > span {
                 grid-column: 1 / 2;
             }
-        }
 
-        &__content {
-            max-width: 64ch;
-            overflow: hidden;
-            font-size: $accordion-content-font-size;
-            font-weight: $fw-light;
+            &--primary {
+                --accordion-trigger-font-size: #{rem($base-fs * 1.25)}; // design has this fixed across breakpoints
 
-            &[data-state="open"] {
-                animation: slide-down $accordion-transition-duration $accordion-transition-timing-func;
+                padding: $accordion-trigger-padding 0 0;
             }
 
-            &[data-state="closed"] {
-                height: 0;
-                animation: slide-up $accordion-transition-duration $accordion-transition-timing-func;
-            }
-        }
+            &--secondary {
+                --accordion-icon-size: 1.6em;
+                --accordion-trigger-font-size: #{$fs-s};
 
-        &__text {
-            padding: $space-xs 0;
-        }
-
-        // *----------------------------------*/
-        //  Variants
-        // --primary not included as it would be the default
-        // *----------------------------------*/
-        &--secondary {
-            --accordion-icon-size: 1.6em;
-            --accordion-trigger-font-size: #{$fs-s};
-
-            // Add new column to the grid so we can centre the text accurately
-            --accordion-trigger-grid-columns: minmax(0, var(--accordion-icon-size)) 1fr auto;
-
-            .c-accordion__item {
-                border: $accordion-item-border;
-
-                &:not(:last-child) {
-                    padding-bottom: 0;
-                    border-bottom: none;
-                }
-            }
-
-            .c-accordion__trigger {
+                // Add new column to the grid so we can centre the text accurately
+                grid-template-columns: minmax(0, var(--accordion-icon-size)) 1fr auto;
                 padding: $space-l $space-xl;
                 text-align: center;
                 text-transform: uppercase;
@@ -155,45 +137,19 @@
                 }
             }
 
-            /* stylelint-disable-next-line no-descending-specificity */
-            .c-accordion__icon {
-                grid-column: 3 / -1;
-                color: currentcolor;
-            }
+            &--tertiary {
+                --accordion-trigger-font-size: #{rem($base-fs * 1.5)}; // design has this fixed across breakpoints
 
-            .c-accordion__content {
-                max-width: 100%;
-            }
-
-            .c-accordion__text {
-                padding: 0 $space-xl $space-xl;
-            }
-        }
-
-        &--tertiary {
-            --accordion-trigger-font-size: #{rem($base-fs * 1.5)}; // design has this fixed across breakpoints
-            --accordion-trigger-grid-columns: 1fr auto;
-
-            /* stylelint-disable-next-line no-descending-specificity */
-            .c-accordion__item {
-                padding-bottom: 0;
-                border: $accordion-item-border;
-            }
-
-            .c-accordion__item + .c-accordion__item {
-                margin-top: $space-2xl;
-            }
-
-            .c-accordion__trigger {
+                grid-template-columns: 1fr auto;
                 padding: $space-2xs $space-l;
                 background-color: var(--color-neutral-200);
                 color: var(--color-quaternary);
                 text-align: left;
                 text-transform: none;
                 letter-spacing: normal;
-                transition:
-                    background-color $accordion-transition-duration
-                    $accordion-transition-timing-func;
+
+                // prettier-ignore
+                transition: background-color $accordion-transition-duration $accordion-transition-timing-func;
 
                 &:hover {
                     background-color: var(--color-quinary);
@@ -204,19 +160,66 @@
                     grid-column: 1 / 2;
                 }
             }
+        }
 
-            /* stylelint-disable-next-line no-descending-specificity */
-            .c-accordion__icon {
-                @include mq($mq-mob, max) {
-                    display: none;
+        &__item {
+            &--primary {
+                &:not(:last-child) {
+                    padding-bottom: $accordion-trigger-padding;
+                    border-bottom: $accordion-item-border;
                 }
             }
 
-            .c-accordion__content {
-                max-width: 100%;
+            &--secondary {
+                border: $accordion-item-border;
+
+                &:not(:last-child) {
+                    padding-bottom: 0;
+                    border-bottom: none;
+                }
             }
 
-            .c-accordion__text {
+            &--tertiary {
+                padding-bottom: 0;
+                border: $accordion-item-border;
+
+                + #{$self}__item {
+                    margin-top: $space-2xl;
+                }
+            }
+        }
+
+        &__content {
+            max-width: 100%;
+            overflow: hidden;
+            font-size: $accordion-content-font-size;
+            font-weight: $fw-light;
+
+            &[data-state="open"] {
+                // prettier-ignore
+                animation: slide-down $accordion-transition-duration $accordion-transition-timing-func;
+            }
+
+            &[data-state="closed"] {
+                height: 0;
+                animation: slide-up $accordion-transition-duration $accordion-transition-timing-func;
+            }
+
+            &--primary {
+                max-width: 64ch;
+            }
+        }
+
+        &__text {
+            &--primary {
+                padding: $space-xs 0;
+            }
+
+            &--secondary {
+                padding: 0 $space-xl $space-xl;
+            }
+
+            &--tertiary {
                 padding: $space-2xl;
             }
         }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes https://github.com/Open-Study-College/osc/issues/823
- Closes https://github.com/Open-Study-College/osc/issues/851

## 📝 Description

Adds a context provider to the the accordion which passes the variant prop through to the subelements. This allows us to apply the same variant modifier across the board, in turn lets us style that modifier directly rather than relying on the cascade. This fixes the issue outlined in #823 as the `--secondary` and `--tertiary` modifiers would override `--primary` if it was nested as they were lower in the cascade. This was then leading to some pages to overflow as the nested accordion wasn't inheriting the correct styles and so the font was too big.

You can now see this working here on a product page in ecommerce
<img width="475" alt="image" src="https://user-images.githubusercontent.com/23461173/234858750-6b60611c-b672-44fc-935e-c1a20e50b4e0.png">


## ⛳️ Current behavior (updates)

- `Accordion` styles rely solely on parent accordion variant modifier class

## 🚀 New behavior

- `Accordion` has a context provider
- Subelements each have their own variant modifier we can style against

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
