### PR TITLE
Feature/sanity image controls

### DIFF
--- a/packages/osc-ecommerce/app/components/Cards/BlogCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/BlogCard.tsx
@@ -33,23 +33,24 @@ export const BlogCard = (props: Props) => {
                 heroData?.backgroundColor ? `u-bg-color-${heroData?.backgroundColor}` : ''
             } ${heroData?.titleColor ? `u-color-${heroData?.titleColor}` : ''}`}
         >
-            {/* // TODO: This data should come from the CMS */}
-            <CardImage>
-                <Image
-                    src={heroData?.image?.src ? heroData?.image?.src : ''}
-                    alt={heroData?.image?.alt ? heroData?.image?.alt : ''}
-                    width={heroData?.image?.width ? heroData?.image?.width : 0}
-                    height={heroData?.image?.height ? heroData?.image?.height : 0}
-                    fit="cover"
-                    overlayColor={
-                        heroData?.image?.imageStyles?.overlayColor
-                            ? heroData?.image?.imageStyles?.overlayColor
-                            : theme?.color
-                    }
-                    isGrayScale={heroData?.image?.imageStyles?.grayscale}
-                    hasTransparency={heroData?.image?.imageStyles?.opacity}
-                />
-            </CardImage>
+            {heroData?.image?.src ? (
+                <CardImage>
+                    <Image
+                        src={heroData?.image?.src ? heroData?.image?.src : ''}
+                        alt={heroData?.image?.alt ? heroData?.image?.alt : ''}
+                        width={heroData?.image?.width ? heroData?.image?.width : 0}
+                        height={heroData?.image?.height ? heroData?.image?.height : 0}
+                        fit="cover"
+                        overlayColor={
+                            heroData?.image?.imageStyles?.overlayColor
+                                ? heroData?.image?.imageStyles?.overlayColor
+                                : theme?.color
+                        }
+                        isGrayScale={heroData?.image?.imageStyles?.grayscale}
+                        hasTransparency={heroData?.image?.imageStyles?.opacity}
+                    />
+                </CardImage>
+            ) : null}
 
             <CardInner>
                 <CardHeader>

--- a/packages/osc-ecommerce/app/components/Cards/BlogCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/BlogCard.tsx
@@ -9,7 +9,6 @@ import {
     Image,
     BlogCard as OSCBlogCard,
 } from 'osc-ui';
-import { PATHS } from '~/constants';
 import type { postCardModule } from '~/types/sanity';
 
 interface Props {
@@ -17,30 +16,44 @@ interface Props {
 }
 
 export const BlogCard = (props: Props) => {
-    const data = props?.data?.reference;
+    const { data } = props;
+    const { theme } = data?.reference;
+    const heroData = data?.reference?.modules && data?.reference?.modules[0].slides;
+
+    if (!heroData) {
+        console.warn(`No hero set on post ${data?.reference?.title}`);
+    }
 
     return (
         <OSCBlogCard
             variant="featured"
             blockLink
-            isFull={props?.data?.fullWidth}
-            className={
-                props?.data?.backgroundColor ? `u-bg-color-${props?.data?.backgroundColor}` : ''
-            }
+            isFull={data?.fullWidth}
+            className={`${
+                heroData?.backgroundColor ? `u-bg-color-${heroData?.backgroundColor}` : ''
+            } ${heroData?.titleColor ? `u-color-${heroData?.titleColor}` : ''}`}
         >
             {/* // TODO: This data should come from the CMS */}
             <CardImage>
                 <Image
-                    src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1674744069/db8cdf9db0ec39f88706516410a64ed7_kxoiou.png"
-                    alt=""
-                    width={400}
-                    height={460}
+                    src={heroData?.image?.src ? heroData?.image?.src : ''}
+                    alt={heroData?.image?.alt ? heroData?.image?.alt : ''}
+                    width={heroData?.image?.width ? heroData?.image?.width : 0}
+                    height={heroData?.image?.height ? heroData?.image?.height : 0}
+                    fit="cover"
+                    overlayColor={
+                        heroData?.image?.imageStyles?.overlayColor
+                            ? heroData?.image?.imageStyles?.overlayColor
+                            : theme?.color
+                    }
+                    isGrayScale={heroData?.image?.imageStyles?.grayscale}
+                    hasTransparency={heroData?.image?.imageStyles?.opacity}
                 />
             </CardImage>
 
             <CardInner>
                 <CardHeader>
-                    <CardTitle>{data?.title}</CardTitle>
+                    <CardTitle>{data?.reference?.title}</CardTitle>
 
                     {/* // TODO: This data should come from the CMS */}
                     <CardTitle as="h3" subtitle>
@@ -52,13 +65,11 @@ export const BlogCard = (props: Props) => {
                 <CardBody>Lorem ipsum dolor sit amet consectetur adipisicing elit.</CardBody>
 
                 <CardFooter>
-                    <Button
-                        variant="quinary"
-                        as="link"
-                        to={`/${PATHS.BLOG}/${data?.slug?.current}`}
-                    >
-                        Read more
-                    </Button>
+                    {data?.reference?.slug ? (
+                        <Button variant="quinary" as="link" to={data?.reference?.slug}>
+                            Read more
+                        </Button>
+                    ) : null}
                 </CardFooter>
             </CardInner>
         </OSCBlogCard>

--- a/packages/osc-ecommerce/app/components/Cards/BlogCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/BlogCard.tsx
@@ -18,7 +18,7 @@ interface Props {
 export const BlogCard = (props: Props) => {
     const { data } = props;
     const { theme } = data?.reference;
-    const heroData = data?.reference?.modules && data?.reference?.modules[0].slides;
+    const heroData = data?.reference?.modules && data?.reference?.modules[0]?.slides;
 
     if (!heroData) {
         console.warn(`No hero set on post ${data?.reference?.title}`);

--- a/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
@@ -6,9 +6,9 @@ import {
     CardImage,
     CardInner,
     CardTitle,
-    CollectionCard as OSCCollectionCard,
     Icon,
     Image,
+    CollectionCard as OSCCollectionCard,
 } from 'osc-ui';
 import type { collectionCardModule } from '~/types/sanity';
 
@@ -19,54 +19,25 @@ interface Props {
 // TODO: Update this to use Shopify storekit helpers
 export const CollectionCard = (props: Props) => {
     const { data } = props;
-    const store = data?.reference?.store;
-
-    if (data?.variant === 'sm') {
-        return (
-            <OSCCollectionCard size={data?.variant}>
-                <CardImage>
-                    {/* // TODO: This data should come from the CMS */}
-                    <Image
-                        src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1674577946/cat-img_rwumo5.png"
-                        alt=""
-                        width={610}
-                        height={557}
-                    />
-                </CardImage>
-                <CardInner>
-                    <CardHeader>
-                        <CardTitle>{store?.title}</CardTitle>
-                    </CardHeader>
-
-                    <CardBody>
-                        {/* // TODO: This data should come from the CMS */}
-                        <p>
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Viverra duis
-                            vehicula justo, sagittis quam nam nisi.
-                        </p>
-                    </CardBody>
-
-                    <CardFooter>
-                        <span className="u-text-bold">23 courses</span>
-                        <Button variant="quaternary">
-                            Find our more
-                            <Icon id="chevron-right" />
-                        </Button>
-                    </CardFooter>
-                </CardInner>
-            </OSCCollectionCard>
-        );
-    }
+    const { store } = data?.reference;
+    const { theme, featuredImage } = data?.reference;
 
     return (
         <OSCCollectionCard size={data?.variant}>
             <CardImage>
-                {/* // TODO: This data should come from the CMS */}
                 <Image
-                    src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1674577946/cat-img_rwumo5.png"
-                    alt=""
+                    src={featuredImage?.src ? featuredImage?.src : ''}
+                    alt={featuredImage?.alt ? featuredImage?.alt : ''}
                     width={610}
                     height={557}
+                    fit="cover"
+                    overlayColor={
+                        featuredImage?.imageStyles?.overlayColor
+                            ? featuredImage?.imageStyles?.overlayColor
+                            : theme?.color
+                    }
+                    isGrayScale={featuredImage?.imageStyles?.grayscale}
+                    hasTransparency={featuredImage?.imageStyles?.opacity}
                 />
             </CardImage>
             <CardInner>
@@ -80,8 +51,22 @@ export const CollectionCard = (props: Props) => {
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Viverra duis
                         vehicula justo, sagittis quam nam nisi.
                     </p>
-                    <Button isFull>23 Courses</Button>
+
+                    {/* TODO: Needs to get number of courses */}
+                    {data?.variant !== 'sm' ? <Button isFull>23 Courses</Button> : null}
                 </CardBody>
+
+                {data?.variant === 'sm' ? (
+                    <CardFooter>
+                        <span className="u-text-bold">23 courses</span>
+                        {data?.reference?.slug ? (
+                            <Button as="link" to={data?.reference?.slug} variant="quaternary">
+                                Find our more
+                                <Icon id="chevron-right" />
+                            </Button>
+                        ) : null}
+                    </CardFooter>
+                ) : null}
             </CardInner>
         </OSCCollectionCard>
     );

--- a/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
@@ -24,22 +24,25 @@ export const CollectionCard = (props: Props) => {
 
     return (
         <OSCCollectionCard size={data?.variant}>
-            <CardImage>
-                <Image
-                    src={featuredImage?.src ? featuredImage?.src : ''}
-                    alt={featuredImage?.alt ? featuredImage?.alt : ''}
-                    width={610}
-                    height={557}
-                    fit="cover"
-                    overlayColor={
-                        featuredImage?.imageStyles?.overlayColor
-                            ? featuredImage?.imageStyles?.overlayColor
-                            : theme?.color
-                    }
-                    isGrayScale={featuredImage?.imageStyles?.grayscale}
-                    hasTransparency={featuredImage?.imageStyles?.opacity}
-                />
-            </CardImage>
+            {featuredImage?.src ? (
+                <CardImage>
+                    <Image
+                        src={featuredImage?.src ? featuredImage?.src : ''}
+                        alt={featuredImage?.alt ? featuredImage?.alt : ''}
+                        width={610}
+                        height={432}
+                        fit="cover"
+                        overlayColor={
+                            featuredImage?.imageStyles?.overlayColor
+                                ? featuredImage?.imageStyles?.overlayColor
+                                : theme?.color
+                        }
+                        isGrayScale={featuredImage?.imageStyles?.grayscale}
+                        hasTransparency={featuredImage?.imageStyles?.opacity}
+                    />
+                </CardImage>
+            ) : null}
+
             <CardInner>
                 <CardHeader>
                     <CardTitle>{store?.title}</CardTitle>

--- a/packages/osc-ecommerce/app/components/Cards/SimpleCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/SimpleCard.tsx
@@ -33,6 +33,10 @@ export const SimpleCard = (props: Props) => {
                             alt={data?.image?.alt}
                             width={data?.image?.image?.width}
                             height={data?.image?.image?.height}
+                            fit="cover"
+                            overlayColor={data?.image?.imageStyles?.overlayColor}
+                            isGrayScale={data?.image?.imageStyles?.grayscale}
+                            hasTransparency={data?.image?.imageStyles?.opacity}
                         />
                     ) : null}
                 </CardImage>

--- a/packages/osc-ecommerce/app/components/Carousel/Carousel.tsx
+++ b/packages/osc-ecommerce/app/components/Carousel/Carousel.tsx
@@ -52,6 +52,9 @@ export const CarouselModule = (props: { module: carouselModule }) => {
                                 ? slide?.image?.responsiveImages
                                 : undefined
                         }
+                        overlayColor={slide?.image?.imageStyles?.overlayColor}
+                        isGrayScale={slide?.image?.imageStyles?.grayscale}
+                        hasTransparency={slide?.image?.imageStyles?.opacity}
                         className="o-img--contain"
                     />
                 ) : null

--- a/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
+++ b/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
@@ -200,7 +200,10 @@ const ContentMediaBlockModule = (props: ContentMediaBlockProps) => {
                                 width={media?.image?.width}
                                 height={media?.image?.height}
                                 alt={media?.image?.alt}
-                                className={`o-img--${media?.imageFit}`}
+                                fit={media?.imageFit}
+                                overlayColor={media?.image?.imageStyles?.overlayColor}
+                                isGrayScale={media?.image?.imageStyles?.grayscale}
+                                hasTransparency={media?.image?.imageStyles?.opacity}
                                 key={media?.image?._key}
                             />
                         );
@@ -220,7 +223,10 @@ const ContentMediaBlockModule = (props: ContentMediaBlockProps) => {
                     width={media?.mediaType[0]?.image?.width}
                     height={media?.mediaType[0]?.image?.height}
                     alt={media?.mediaType[0]?.image?.alt}
-                    className={`o-img--${media?.mediaType[0]?.imageFit}`}
+                    fit={media?.imageFit}
+                    overlayColor={media?.mediaType[0]?.image?.imageStyles?.overlayColor}
+                    isGrayScale={media?.mediaType[0]?.image?.imageStyles?.grayscale}
+                    hasTransparency={media?.mediaType[0]?.image?.imageStyles?.opacity}
                 />
             );
         } else if (media?.mediaType[0]?._type === 'module.forms') {

--- a/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
+++ b/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
@@ -223,7 +223,7 @@ const ContentMediaBlockModule = (props: ContentMediaBlockProps) => {
                     width={media?.mediaType[0]?.image?.width}
                     height={media?.mediaType[0]?.image?.height}
                     alt={media?.mediaType[0]?.image?.alt}
-                    fit={media?.imageFit}
+                    fit={media?.mediaType[0]?.imageFit}
                     overlayColor={media?.mediaType[0]?.image?.imageStyles?.overlayColor}
                     isGrayScale={media?.mediaType[0]?.image?.imageStyles?.grayscale}
                     hasTransparency={media?.mediaType[0]?.image?.imageStyles?.opacity}

--- a/packages/osc-ecommerce/app/components/Hero/Hero.tsx
+++ b/packages/osc-ecommerce/app/components/Hero/Hero.tsx
@@ -1,13 +1,13 @@
 import {
     Carousel,
     Content,
-    Hero as OSCHero,
     HeroContent,
     HeroImage,
     HeroInner,
     HeroTitle,
     HeroTitleGroup,
     Image,
+    Hero as OSCHero,
     rem,
 } from 'osc-ui';
 import type { heroModule, heroSlide } from '~/types/sanity';
@@ -130,6 +130,9 @@ const Slide = (props: SlideProps) => {
                             artDirectedImages={
                                 image?.responsiveImages ? image?.responsiveImages : undefined
                             }
+                            overlayColor={image?.imageStyles?.overlayColor}
+                            isGrayScale={image?.imageStyles?.grayscale}
+                            hasTransparency={image?.imageStyles?.opacity}
                         />
                     </HeroImage>
                 ) : null}

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -276,6 +276,9 @@ export default function Module(props: Props) {
                     alt={moduleImage.alt}
                     width={moduleImage.width}
                     height={moduleImage.height}
+                    overlayColor={moduleImage?.imageStyles?.overlayColor}
+                    isGrayScale={moduleImage?.imageStyles?.grayscale}
+                    hasTransparency={moduleImage?.imageStyles?.opacity}
                 />
             );
 

--- a/packages/osc-ecommerce/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/osc-ecommerce/app/components/VideoPlayer/VideoPlayer.tsx
@@ -21,10 +21,17 @@ export const VideoPlayerModule = (props: Props) => {
                 module?.videoImage?.src ? (
                     <Image
                         src={module?.videoImage?.src}
-                        artDirectedImages={module?.videoImage?.responsiveImages}
+                        artDirectedImages={
+                            module?.videoImage?.responsiveImages
+                                ? module?.videoImage?.responsiveImages
+                                : undefined
+                        }
                         alt={module?.videoImage?.alt}
                         width={module?.videoImage?.width}
                         height={module?.videoImage?.height}
+                        overlayColor={module?.videoImage?.imageStyles?.overlayColor}
+                        isGrayScale={module?.videoImage?.imageStyles?.grayscale}
+                        hasTransparency={module?.videoImage?.imageStyles?.opacity}
                     />
                 ) : undefined
             }

--- a/packages/osc-ecommerce/app/queries/sanity/collection.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/collection.ts
@@ -1,5 +1,6 @@
 import groq from 'groq';
 import { MODULES } from './fragments/modules';
+import { MODULE_IMAGES } from './fragments/modules/images';
 import { SEO } from './fragments/seo';
 
 export const COLLECTION_QUERY = groq`
@@ -8,6 +9,13 @@ export const COLLECTION_QUERY = groq`
         _rev,
         _type,
         store,
+        theme {
+            color,
+            pattern,
+        },
+        "featuredImage": {
+            ${MODULE_IMAGES}
+        },
         ${MODULES},
         ${SEO}
     }

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/card.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/card.ts
@@ -38,7 +38,27 @@ export const MODULE_CARDS = groq`
           _type,
           backgroundColor,
           fullWidth,
-          reference->
+          reference->{
+            title,
+            theme {
+                color
+            },
+            "featuredImage": {
+                ${MODULE_IMAGES}
+            },
+            modules[] {
+                (_type == "module.hero") => {
+                    slides[0] {
+                        titleColor,
+                        backgroundColor,
+                        "image": {
+                            ${MODULE_IMAGES}
+                        }
+                    }
+                }
+            },
+            "slug": "/${PATHS.BLOG}/" + slug.current,
+          },
         },
         _type == 'card.static' => {
             _key,

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/card.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/card.ts
@@ -1,6 +1,8 @@
 import groq from 'groq';
+import { PATHS } from '~/constants';
 import { LINK_EXTERNAL } from '../linkExternal';
 import { LINK_INTERNAL } from '../linkInternal';
+import { MODULE_IMAGES } from './images';
 
 export const MODULE_CARDS = groq`
     ...,
@@ -19,7 +21,17 @@ export const MODULE_CARDS = groq`
           _key,
           _type,
           variant,
-          reference->
+          reference->{
+            store,
+            theme {
+                color,
+                pattern,
+            },
+            "featuredImage": {
+                ${MODULE_IMAGES}
+            },
+            "slug": "/${PATHS.COLLECTIONS}/" + store.slug.current,
+          }
         },
         _type == 'card.post' => {
           _key,

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/images.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/images.ts
@@ -13,5 +13,6 @@ export const MODULE_IMAGES = groq`
         "src": coalesce(image.derived[0].secure_url, image.secure_url),
         "width": image.width,
         "height": image.height,
-    }
+    },
+    "imageStyles": image.imageStyles
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/video.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/video.ts
@@ -14,7 +14,8 @@ export const MODULE_VIDEO = groq`
             "src": coalesce(derived[0].secure_url, secure_url),
             "width": width,
             "height": height,
-        }
+        },
+        imageStyles
     },
     videoSettings,
     videoType,

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -167,8 +167,13 @@ export interface courseCardModule extends module {
 }
 
 export interface collectionCardModule extends module {
-    reference?: {
+    reference: {
         store?: shopifyCollection;
+        theme?: {
+            color?: string;
+        };
+        featuredImage?: imageModule<HTMLImageElement>;
+        slug: string;
     };
     variant?: 'sm' | 'md' | 'lg';
 }

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -196,6 +196,11 @@ export interface staticCardModule extends module {
     image?: {
         alt: string;
         image?: Omit<imageModule<HTMLImageElement>, 'alt' | 'src'>;
+        imageStyles?: {
+            overlayColor?: string;
+            grayscale?: boolean;
+            opacity?: boolean;
+        };
     };
     showFooter?: boolean;
     showSubHeading?: boolean;

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -98,13 +98,14 @@ export interface contentMediaSlide extends module {
     media: {
         carouselName: Maybe<string>;
         carouselSettings: carouselModuleSettings;
+        imageFit?: 'cover' | 'contain';
         mediaType: {
-            image?: imageModule<HTMLImageElement>;
-            imageFit?: 'cover' | 'contain';
             _key?: string;
             _type?: string;
             formId?: string;
             formName?: string;
+            imageFit?: 'cover' | 'contain';
+            image?: imageModule<HTMLImageElement>;
         }[];
     };
 }

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -37,6 +37,11 @@ export interface imageModule<T> extends SanityImage<T> {
     }[];
     secure_url?: string;
     sizes?: string | undefined;
+    imageStyles?: {
+        overlayColor?: string;
+        grayscale?: boolean;
+        opacity?: boolean;
+    };
 }
 
 export interface module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -181,10 +181,18 @@ export interface collectionCardModule extends module {
 export interface postCardModule extends module {
     fullWidth?: boolean;
     backgroundColor?: string;
-    reference?: {
-        slug?: {
-            current: string;
+    reference: {
+        theme?: {
+            color?: string;
         };
+        modules?: {
+            slides?: {
+                backgroundColor?: string;
+                titleColor?: string;
+                image?: imageModule<HTMLImageElement>;
+            };
+        }[];
+        slug: string;
         title?: string;
     };
 }

--- a/packages/osc-studio/schemas/documents/collection.tsx
+++ b/packages/osc-studio/schemas/documents/collection.tsx
@@ -3,6 +3,7 @@ import pluralize from 'pluralize';
 import { defineField, defineType } from 'sanity';
 import ShopifyIcon from '../../components/icons/Shopify';
 import CollectionHiddenInput from '../../components/inputs/CollectionHidden';
+import { ColorPicker } from '../../components/inputs/ColorPicker';
 import ShopifyDocumentStatus from '../../components/media/ShopifyDocumentStatus';
 import { MODULES } from '../../constants.js';
 
@@ -11,6 +12,10 @@ const GROUPS = [
         default: true,
         name: 'editorial',
         title: 'Editorial',
+    },
+    {
+        name: 'settings',
+        title: 'Settings',
     },
     {
         name: 'shopifySync',
@@ -57,14 +62,6 @@ export default defineType({
             type: 'proxyString',
             options: { field: 'store.slug.current' },
         }),
-        // Show hero
-        defineField({
-            name: 'showHero',
-            title: 'Show hero',
-            type: 'boolean',
-            description: 'If disabled, page title will be displayed instead',
-            group: 'editorial',
-        }),
         // Modules
         defineField({
             name: 'modules',
@@ -87,6 +84,29 @@ export default defineType({
             title: 'SEO',
             type: 'seo.shopify',
             group: 'seo',
+        }),
+        defineField({
+            name: 'theme',
+            title: 'Theme',
+            type: 'object',
+            fields: [
+                defineField({
+                    name: 'color',
+                    title: 'Colour',
+                    type: 'string',
+                    initialValue: 'tertiary',
+                    components: {
+                        input: ColorPicker,
+                    },
+                }),
+            ],
+            group: 'settings',
+        }),
+        defineField({
+            name: 'image',
+            title: 'Featured Image',
+            type: 'image.desktop',
+            group: 'settings',
         }),
     ],
     orderings: [

--- a/packages/osc-studio/schemas/documents/collection.tsx
+++ b/packages/osc-studio/schemas/documents/collection.tsx
@@ -3,7 +3,6 @@ import pluralize from 'pluralize';
 import { defineField, defineType } from 'sanity';
 import ShopifyIcon from '../../components/icons/Shopify';
 import CollectionHiddenInput from '../../components/inputs/CollectionHidden';
-import { ColorPicker } from '../../components/inputs/ColorPicker';
 import ShopifyDocumentStatus from '../../components/media/ShopifyDocumentStatus';
 import { MODULES } from '../../constants.js';
 
@@ -85,21 +84,11 @@ export default defineType({
             type: 'seo.shopify',
             group: 'seo',
         }),
+        // SETTINGS
         defineField({
             name: 'theme',
             title: 'Theme',
-            type: 'object',
-            fields: [
-                defineField({
-                    name: 'color',
-                    title: 'Colour',
-                    type: 'string',
-                    initialValue: 'tertiary',
-                    components: {
-                        input: ColorPicker,
-                    },
-                }),
-            ],
+            type: 'theme',
             group: 'settings',
         }),
         defineField({

--- a/packages/osc-studio/schemas/documents/post.ts
+++ b/packages/osc-studio/schemas/documents/post.ts
@@ -10,13 +10,13 @@ export default defineType({
     icon: DocumentIcon,
     groups: [
         {
-            name: 'theme',
-            title: 'Theme',
-        },
-        {
             default: true,
             name: 'editorial',
             title: 'Editorial',
+        },
+        {
+            name: 'settings',
+            title: 'Settings',
         },
         {
             name: 'seo',
@@ -61,6 +61,13 @@ export default defineType({
             title: 'SEO',
             type: 'seo.page',
             group: 'seo',
+        }),
+        // SETTINGS
+        defineField({
+            name: 'theme',
+            title: 'Theme',
+            type: 'theme',
+            group: 'settings',
         }),
     ],
     preview: {

--- a/packages/osc-studio/schemas/objects/module/cardPost.ts
+++ b/packages/osc-studio/schemas/objects/module/cardPost.ts
@@ -1,5 +1,4 @@
 import { defineField, defineType } from 'sanity';
-import { ColorPicker } from '../../../components/inputs/ColorPicker';
 
 export default defineType({
     name: 'card.post',
@@ -14,15 +13,6 @@ export default defineType({
             options: {
                 disableNew: true,
             },
-        }),
-        defineField({
-            name: 'backgroundColor',
-            title: 'Background Colour',
-            type: 'string',
-            components: {
-                input: ColorPicker,
-            },
-            validation: (Rule) => Rule.required(),
         }),
         defineField({
             name: 'fullWidth',

--- a/packages/osc-studio/schemas/objects/module/image.tsx
+++ b/packages/osc-studio/schemas/objects/module/image.tsx
@@ -1,5 +1,6 @@
 import { ImageIcon } from '@sanity/icons';
 import { defineField, defineType } from 'sanity';
+import { ColorPicker } from '../../../components/inputs/ColorPicker';
 
 export default defineType({
     name: 'image.desktop',
@@ -40,6 +41,37 @@ export default defineType({
             title: 'Alt text',
             type: 'string',
             validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: 'imageStyles',
+            title: 'Image Styles',
+            description: 'Apply some art directed styles to your image.',
+            type: 'object',
+            fields: [
+                defineField({
+                    name: 'grayscale',
+                    title: 'Grayscale',
+                    type: 'boolean',
+                    initialValue: false,
+                }),
+                defineField({
+                    name: 'opacity',
+                    title: 'Opacity',
+                    type: 'boolean',
+                    initialValue: false,
+                }),
+                defineField({
+                    name: 'overlayColor',
+                    title: 'Overlay Color',
+                    type: 'string',
+                    components: {
+                        input: ColorPicker,
+                    },
+                }),
+            ],
+            options: {
+                columns: 2,
+            },
         }),
     ],
     preview: {

--- a/packages/osc-studio/schemas/objects/theme.ts
+++ b/packages/osc-studio/schemas/objects/theme.ts
@@ -1,0 +1,19 @@
+import { defineField, defineType } from 'sanity';
+import { ColorPicker } from '../../components/inputs/ColorPicker';
+
+export default defineType({
+    name: 'theme',
+    title: 'Theme',
+    type: 'object',
+    fields: [
+        defineField({
+            name: 'color',
+            title: 'Colour',
+            type: 'string',
+            initialValue: 'tertiary',
+            components: {
+                input: ColorPicker,
+            },
+        }),
+    ],
+});

--- a/packages/osc-studio/schemas/schema.ts
+++ b/packages/osc-studio/schemas/schema.ts
@@ -77,6 +77,7 @@ import shopifyProductVariant from './objects/shopifyProductVariant';
 import social from './objects/social';
 import tabItem from './objects/tabItem';
 import textGridItem from './objects/textGridItem';
+import theme from './objects/theme';
 
 // Build the schemas and export to the Sanity Studio app
 export const schemaTypes: SchemaTypeDefinition[] = [
@@ -133,6 +134,7 @@ export const schemaTypes: SchemaTypeDefinition[] = [
     shopifyCollection,
     shopifyProduct,
     shopifyProductVariant,
+    theme,
     moduleButton,
     moduleButtons,
     moduleAccordion,

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -284,10 +284,15 @@ $card-fs-3xl: $fs-3xl;
                 color: var(--color-septenary);
                 grid-template-rows: 1fr;
 
+                &:not(.is-full) {
+                    min-height: 460px;
+                }
+
                 #{$self}__img {
                     grid-row: 1;
                     grid-column: 1;
                     align-self: stretch;
+                    mix-blend-mode: multiply;
 
                     &,
                     .o-img {
@@ -328,7 +333,7 @@ $card-fs-3xl: $fs-3xl;
                 }
 
                 #{$self}__subttl {
-                    color: var(--color-septenary);
+                    color: inherit;
                 }
 
                 #{$self}__footer {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I _think_ this hooks the image controls up to all of the images throughout the site. I've added the image controls to the image object in Sanity and fed that through to the components it's used in. I've also taken the opportunity to add a `theme` setting to collections and posts as well as a "featured image" to be used on Collections, I'm imagining this powering the Hero on that page (as it has to pull data from Shopify/algolia we won't want Marketing to edit it really) and passing through to the cards.
I've updated the Featured blog cards to take the data from the Hero on the blog pages (image, colours etc.) and set a `min-height` for that card as the image height is going to be more dynamic now.

I've not updated the course cards colours in here like the others as I was focusing solely on images, and there's some work in #841 which sets up the groundwork for this.

## ⛳️ Current behavior (updates)

- Image colours are handled outside of CMS
- BlogCard is completely hard coded
- CollectionsCard is completely hard coded

## 🚀 New behavior

- Adds theme settings to collections & post documents
- Updates Blog and Collections cards to dynamically pull image / colour data from Sanity
- Adds image style controls into Sanity
- Adds props to ecommerce components pulling style data from Sanity
- Updates types to account for new fields

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
