### PR TITLE
feat: add remix routes for awards and create Sanity query

### DIFF
--- a/packages/osc-ecommerce/app/constants.ts
+++ b/packages/osc-ecommerce/app/constants.ts
@@ -4,4 +4,5 @@ export const PATHS = {
     BLOG: 'blog',
     COLLECTIONS: 'collections',
     PRODUCTS: 'courses',
+    AWARDS: 'awards',
 } as const;

--- a/packages/osc-ecommerce/app/lib/sanity/config.ts
+++ b/packages/osc-ecommerce/app/lib/sanity/config.ts
@@ -29,7 +29,7 @@ export const previewConfig: PreviewConfig = {
     // It's 3000 by default, increase or decrease as needed and use `includeTypes` to further optimize the performance
     documentLimit: 3000,
     // Optional allow list filter for document types. You can use this to limit the amount of documents by declaring the types you want to sync. Note that since you're fetching a subset of your dataset, queries that works against your Content Lake might not work against the local groq-store.
-    includeTypes: ['home', 'blog', 'collection', 'page', 'post', 'product'],
+    includeTypes: ['home', 'blog', 'collection', 'page', 'post', 'product', 'award'],
     // By default documents that are "draft" are overlayed with their published counterparts.
     // This lets you simulate what your app will look like after the drafts are published.
     // If your queries are already equipped to handle drafts vs published

--- a/packages/osc-ecommerce/app/queries/sanity/award.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/award.ts
@@ -2,8 +2,8 @@ import groq from 'groq';
 import { MODULES } from './fragments/modules';
 import { SEO } from './fragments/seo';
 
-export const AWARDING_BODIES_QUERY = groq`
-    *[ _type == "awardingBodyPages" && slug.current == $slug && !(_id in path("drafts.**")) ] {
+export const AWARD_QUERY = groq`
+    *[ _type == "award" && slug.current == $slug && !(_id in path("drafts.**")) ] {
         _id,
         _rev,
         _type,

--- a/packages/osc-ecommerce/app/queries/sanity/awardingbodies.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/awardingbodies.ts
@@ -1,0 +1,14 @@
+import groq from 'groq';
+import { MODULES } from './fragments/modules';
+import { SEO } from './fragments/seo';
+
+export const AWARDING_BODIES_QUERY = groq`
+    *[ _type == "awardingBodyPages" && slug.current == $slug && !(_id in path("drafts.**")) ] {
+        _id,
+        _rev,
+        _type,
+        title,
+        ${MODULES},
+        ${SEO}
+    }
+`;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/buildUrls.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/buildUrls.ts
@@ -21,6 +21,6 @@ export const buildUrls = groq`
         "slug": "/${PATHS.PRODUCTS}/" + store.slug.current,
     },
     (_type == "award") => {
-        "slug": "/${PATHS.AWARDS}/" + store.slug.current,
+        "slug": "/${PATHS.AWARDS}/" + slug.current,
     }
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/buildUrls.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/buildUrls.ts
@@ -19,5 +19,8 @@ export const buildUrls = groq`
     },
     (_type == "product") => {
         "slug": "/${PATHS.PRODUCTS}/" + store.slug.current,
+    },
+    (_type == "award") => {
+        "slug": "/${PATHS.AWARDS}/" + store.slug.current,
     }
 `;

--- a/packages/osc-ecommerce/app/routes/awards/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/awards/$slug.tsx
@@ -1,0 +1,99 @@
+import type { LoaderFunction, MetaFunction } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+import { PreviewSuspense } from '@sanity/preview-kit';
+import { lazy } from 'react';
+import type { DynamicLinksFunction } from 'remix-utils';
+import { getComponentStyles } from '~/components/Module';
+import { PageContent } from '~/components/PageContent';
+import { PreviewBanner } from '~/components/PreviewBanner';
+import getPageData, { shouldRedirect } from '~/models/sanity.server';
+import { AWARDING_BODIES_QUERY } from '~/queries/sanity/awardingbodies';
+import type { SanityPage } from '~/types/sanity';
+import { getHubspotForms } from '~/utils/hubspot.helpers';
+import { buildCanonicalUrl } from '~/utils/metaTags/buildCanonicalUrl';
+import { buildHtmlMetaTags } from '~/utils/metaTags/buildHtmlMetaTags';
+
+const PagePreview = lazy(() => import('~/components/PagePreview'));
+
+interface PageData {
+    page: SanityPage;
+    isPreview: boolean;
+}
+
+export const loader: LoaderFunction = async ({ request, params }) => {
+    if (!params.slug) throw new Error('Missing slug');
+    // Query the page data
+    const data = await getPageData({
+        request,
+        params,
+        query: AWARDING_BODIES_QUERY,
+    });
+
+    if (!data?.page) {
+        const redirect = await shouldRedirect(request);
+
+        if (redirect) {
+            return redirect;
+        } else {
+            throw new Response('Not found', { status: 404 });
+        }
+    }
+
+    const { page: awardingBody, isPreview }: PageData = data;
+
+    const hubspotFormData = await getHubspotForms(awardingBody);
+
+    const canonicalUrl = buildCanonicalUrl({
+        canonical: awardingBody?.seo?.canonicalUrl,
+        request,
+    });
+
+    return json({
+        awardingBody,
+        isPreview,
+        canonicalUrl,
+        hubspotFormData,
+        query: isPreview ? AWARDING_BODIES_QUERY : null,
+        params: isPreview ? params : null,
+    });
+};
+
+// https://github.com/sergiodxa/remix-utils#dynamiclinks
+const dynamicLinks: DynamicLinksFunction = ({ data }) => {
+    return getComponentStyles(data.awardingBody);
+};
+
+export const handle = { dynamicLinks };
+
+export const meta: MetaFunction = ({ data, parentsData }) => {
+    const globalSeoSettings = parentsData.root.siteSettings.seo;
+
+    const meta = buildHtmlMetaTags({
+        pageData: data.awardingBody,
+        globalData: globalSeoSettings,
+        canonicalUrl: data.canonicalUrl,
+    });
+
+    return meta;
+};
+
+export default function Index() {
+    const { awardingBody, isPreview, query, params } = useLoaderData<typeof loader>();
+
+    const isPreviewMode = isPreview && query && params;
+
+    return (
+        <>
+            {isPreviewMode ? <PreviewBanner /> : null}
+
+            {isPreviewMode ? (
+                <PreviewSuspense fallback={<PageContent {...awardingBody} />}>
+                    <PagePreview query={query} params={params} Component={PageContent} />
+                </PreviewSuspense>
+            ) : (
+                <PageContent {...awardingBody} />
+            )}
+        </>
+    );
+}

--- a/packages/osc-ecommerce/app/routes/awards/$slug.tsx
+++ b/packages/osc-ecommerce/app/routes/awards/$slug.tsx
@@ -8,7 +8,7 @@ import { getComponentStyles } from '~/components/Module';
 import { PageContent } from '~/components/PageContent';
 import { PreviewBanner } from '~/components/PreviewBanner';
 import getPageData, { shouldRedirect } from '~/models/sanity.server';
-import { AWARDING_BODIES_QUERY } from '~/queries/sanity/awardingbodies';
+import { AWARD_QUERY } from '~/queries/sanity/award';
 import type { SanityPage } from '~/types/sanity';
 import { getHubspotForms } from '~/utils/hubspot.helpers';
 import { buildCanonicalUrl } from '~/utils/metaTags/buildCanonicalUrl';
@@ -27,7 +27,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const data = await getPageData({
         request,
         params,
-        query: AWARDING_BODIES_QUERY,
+        query: AWARD_QUERY,
     });
 
     if (!data?.page) {
@@ -43,7 +43,6 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     const { page: awardingBody, isPreview }: PageData = data;
 
     const hubspotFormData = await getHubspotForms(awardingBody);
-
     const canonicalUrl = buildCanonicalUrl({
         canonical: awardingBody?.seo?.canonicalUrl,
         request,
@@ -54,7 +53,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
         isPreview,
         canonicalUrl,
         hubspotFormData,
-        query: isPreview ? AWARDING_BODIES_QUERY : null,
+        query: isPreview ? AWARD_QUERY : null,
         params: isPreview ? params : null,
     });
 };

--- a/packages/osc-ecommerce/app/routes/awards/index.tsx
+++ b/packages/osc-ecommerce/app/routes/awards/index.tsx
@@ -1,0 +1,6 @@
+import type { LoaderFunction } from '@remix-run/node';
+import { redirect } from '@remix-run/node';
+
+export const loader: LoaderFunction = async () => {
+    return redirect('/');
+};

--- a/packages/osc-ecommerce/app/utils/getPageType.ts
+++ b/packages/osc-ecommerce/app/utils/getPageType.ts
@@ -26,5 +26,9 @@ export const getPageType = (location: Location) => {
         return PATHS.BLOG;
     }
 
+    if (pathname.includes(PATHS.AWARDS)) {
+        return PATHS.AWARDS;
+    }
+
     return undefined;
 };

--- a/packages/osc-studio/constants.js
+++ b/packages/osc-studio/constants.js
@@ -62,4 +62,5 @@ export const PATHS = {
     BLOG: 'blog',
     COLLECTIONS: 'collections',
     PRODUCTS: 'courses',
+    AWARDS: 'awards',
 };

--- a/packages/osc-studio/desk/awardingBodyPages.ts
+++ b/packages/osc-studio/desk/awardingBodyPages.ts
@@ -1,7 +1,4 @@
 import type { StructureBuilder } from 'sanity/desk';
 
 export const awardingBodyPages = (S: StructureBuilder) =>
-    S.listItem()
-        .title('Awarding Body Pages')
-        .schemaType('award')
-        .child(S.documentTypeList('award'));
+    S.listItem().title('Awarding Bodies').schemaType('award').child(S.documentTypeList('award'));

--- a/packages/osc-studio/desk/awardingBodyPages.ts
+++ b/packages/osc-studio/desk/awardingBodyPages.ts
@@ -3,5 +3,5 @@ import type { StructureBuilder } from 'sanity/desk';
 export const awardingBodyPages = (S: StructureBuilder) =>
     S.listItem()
         .title('Awarding Body Pages')
-        .schemaType('awardingBodyPages')
-        .child(S.documentTypeList('awardingBodyPages'));
+        .schemaType('award')
+        .child(S.documentTypeList('award'));

--- a/packages/osc-studio/schemas/documents/awardingBodyPages.tsx
+++ b/packages/osc-studio/schemas/documents/awardingBodyPages.tsx
@@ -4,7 +4,7 @@ import { defineField, defineType } from 'sanity';
 import { validateSlug } from '../../utils/validateSlug';
 
 export default defineType({
-    name: 'awardingBodyPages',
+    name: 'award',
     title: 'Awarding Body Pages',
     type: 'document',
     icon: StarIcon,

--- a/packages/osc-studio/schemas/documents/awardingBodyPages.tsx
+++ b/packages/osc-studio/schemas/documents/awardingBodyPages.tsx
@@ -5,7 +5,7 @@ import { validateSlug } from '../../utils/validateSlug';
 
 export default defineType({
     name: 'award',
-    title: 'Awarding Body Pages',
+    title: 'Awarding Bodies',
     type: 'document',
     icon: StarIcon,
     groups: [

--- a/packages/osc-studio/utils/resolveProductionUrl.ts
+++ b/packages/osc-studio/utils/resolveProductionUrl.ts
@@ -53,6 +53,9 @@ export function resolveProductionUrl(doc: SanityDocumentWithSlug) {
         case 'product':
             url.pathname = `${PATHS.PRODUCTS}/${slug}`;
             break;
+        case 'award':
+            url.pathname = `${PATHS.PRODUCTS}/${slug}`;
+            break;
 
         default:
             url.search = `?${param}=${slug}`;

--- a/packages/osc-studio/utils/resolveProductionUrl.ts
+++ b/packages/osc-studio/utils/resolveProductionUrl.ts
@@ -54,7 +54,7 @@ export function resolveProductionUrl(doc: SanityDocumentWithSlug) {
             url.pathname = `${PATHS.PRODUCTS}/${slug}`;
             break;
         case 'award':
-            url.pathname = `${PATHS.PRODUCTS}/${slug}`;
+            url.pathname = `${PATHS.AWARDS}/${slug}`;
             break;
 
         default:


### PR DESCRIPTION
## 📝 Description

Create new Remix routes for handling the award pages

## ⛳️ Current behavior (updates)

No route for handling Awarding bodies

## 🚀 New behavior

2 new routes:
- awards/index.tsx
- awards/$slug.tsx

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information

The `index.tsx` is simply redirecting to the homepage as this page is not needed