### PR TITLE
fix: add ternary to ensure textToCopy always has text

### DIFF
--- a/packages/osc-ecommerce/app/components/Button/Button.tsx
+++ b/packages/osc-ecommerce/app/components/Button/Button.tsx
@@ -103,10 +103,12 @@ export const Button = (props: Props) => {
             ) : null;
 
         case 'copy to clipboard':
-            return textToCopy ? (
+            const text = textToCopy ? textToCopy : label;
+
+            return text ? (
                 <CopyButton
                     key={_key}
-                    textToCopy={textToCopy}
+                    textToCopy={text}
                     isInversed={isInversed}
                     variant={variant}
                     {...rest}


### PR DESCRIPTION
Closes #857 


## 📝 Description

When adding a copy text button in Sanity but not adding text to copy it doesn't display a button

## ⛳️ Current behavior (updates)

See description

## 🚀 New behavior

Will render a copy button when copy text is empty but using the label text

## 💣 Is this a breaking change (Yes/No): No
