### PR TITLE
Bugfix/product import fixes

### DIFF
--- a/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
@@ -22,38 +22,40 @@ export const CollectionCard = (props: Props) => {
     const store = data?.reference?.store;
 
     if (data?.variant === 'sm') {
-        <OSCCollectionCard size={data?.variant}>
-            <CardImage>
-                {/* // TODO: This data should come from the CMS */}
-                <Image
-                    src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1674577946/cat-img_rwumo5.png"
-                    alt=""
-                    width={610}
-                    height={557}
-                />
-            </CardImage>
-            <CardInner>
-                <CardHeader>
-                    <CardTitle>{store?.title}</CardTitle>
-                </CardHeader>
-
-                <CardBody>
+        return (
+            <OSCCollectionCard size={data?.variant}>
+                <CardImage>
                     {/* // TODO: This data should come from the CMS */}
-                    <p>
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Viverra duis
-                        vehicula justo, sagittis quam nam nisi.
-                    </p>
-                </CardBody>
+                    <Image
+                        src="https://res.cloudinary.com/de2iu8gkv/image/upload/v1674577946/cat-img_rwumo5.png"
+                        alt=""
+                        width={610}
+                        height={557}
+                    />
+                </CardImage>
+                <CardInner>
+                    <CardHeader>
+                        <CardTitle>{store?.title}</CardTitle>
+                    </CardHeader>
 
-                <CardFooter>
-                    <span className="u-text-bold">23 courses</span>
-                    <Button variant="quaternary">
-                        Find our more
-                        <Icon id="chevron-right" />
-                    </Button>
-                </CardFooter>
-            </CardInner>
-        </OSCCollectionCard>;
+                    <CardBody>
+                        {/* // TODO: This data should come from the CMS */}
+                        <p>
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Viverra duis
+                            vehicula justo, sagittis quam nam nisi.
+                        </p>
+                    </CardBody>
+
+                    <CardFooter>
+                        <span className="u-text-bold">23 courses</span>
+                        <Button variant="quaternary">
+                            Find our more
+                            <Icon id="chevron-right" />
+                        </Button>
+                    </CardFooter>
+                </CardInner>
+            </OSCCollectionCard>
+        );
     }
 
     return (

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -220,7 +220,9 @@ export default function Module(props: Props) {
             return moduleContent.body ? (
                 <article
                     className={`o-container ${
-                        isFlush || moduleContent.fullWidth ? 'o-container--flush' : ''
+                        isFlush || moduleContent.fullWidth
+                            ? 'o-container--flush o-container--full'
+                            : ''
                     }`}
                 >
                     <Content

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -218,7 +218,11 @@ export default function Module(props: Props) {
             const moduleContent = module as contentModule;
 
             return moduleContent.body ? (
-                <article className={`o-container ${isFlush ? 'o-container--flush' : ''}`}>
+                <article
+                    className={`o-container ${
+                        isFlush || moduleContent.fullWidth ? 'o-container--flush' : ''
+                    }`}
+                >
                     <Content
                         align={moduleContent.horizontalAlignment}
                         backgroundColor={

--- a/packages/osc-studio/schemas/objects/module/accordion.ts
+++ b/packages/osc-studio/schemas/objects/module/accordion.ts
@@ -53,6 +53,10 @@ export default defineType({
 
                     const contentBody = content && content?.body;
 
+                    if (!contentBody) {
+                        return true;
+                    }
+
                     // @ts-ignore -- not actually sure why findLast does not exist?
                     const findLastHeading = contentBody.findLast(
                         (item: PortableTextBlock) =>


### PR DESCRIPTION
## 📝 Description

A few fixes related to importing the content from Wordpress to Sanity

## ⛳️ Current behavior (updates)

## 🚀 New behavior

- Fix Sanity validation error when content in Accordion is left empty
- Fix bug in CollectionCard.tsx where JSX isn't being returned 
- Enable content to inherit the `o-container--flush` class when fullWidth is set to true in Sanity

## 💣 Is this a breaking change (Yes/No): No

## 📝 Additional Information
