### PR TITLE
Feature/cart item card

### DIFF
--- a/packages/osc-ecommerce/app/components/Cards/BioCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/BioCard.tsx
@@ -22,7 +22,7 @@ export const BioCard = (props: Props) => {
         : data?.image?.image?.secure_url;
 
     return (
-        <Card>
+        <Card hasShadow>
             {data?.image ? (
                 <CardImage isRounded>
                     {src && data?.image?.image ? (

--- a/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/CollectionCard.tsx
@@ -23,7 +23,7 @@ export const CollectionCard = (props: Props) => {
     const { theme, featuredImage } = data?.reference;
 
     return (
-        <OSCCollectionCard size={data?.variant}>
+        <OSCCollectionCard size={data?.variant} hasShadow>
             {featuredImage?.src ? (
                 <CardImage>
                     <Image

--- a/packages/osc-ecommerce/app/components/Cards/CourseCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/CourseCard.tsx
@@ -71,7 +71,7 @@ export const CourseCard = (props: Props) => {
                     /> */}
 
                     <CardTitle isUnderlined>{title}</CardTitle>
-                    <CardTitle as="h3" subtitle isSmall>
+                    <CardTitle as="h3" subtitle isSmall isThemeable position="bottom">
                         {/* // TODO: This data should come from the SHOPIFY/CMS once packages/bundles are sorted */}
                         Single course
                     </CardTitle>

--- a/packages/osc-ecommerce/app/components/Cards/CourseCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/CourseCard.tsx
@@ -70,7 +70,7 @@ export const CourseCard = (props: Props) => {
                         onClick={() => setIsActive(!isActive)}
                     /> */}
 
-                    <CardTitle>{title}</CardTitle>
+                    <CardTitle isUnderlined>{title}</CardTitle>
                     <CardTitle as="h3" subtitle isSmall>
                         {/* // TODO: This data should come from the SHOPIFY/CMS once packages/bundles are sorted */}
                         Single course

--- a/packages/osc-ecommerce/app/components/Cards/CourseCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/CourseCard.tsx
@@ -60,7 +60,7 @@ export const CourseCard = (props: Props) => {
     };
 
     return (
-        <OSCCourseCard>
+        <OSCCourseCard hasShadow>
             <CardInner>
                 <CardHeader>
                     {/* // TODO: Reactivate when wishlist is enabled */}

--- a/packages/osc-ecommerce/app/components/Cards/SimpleCard.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/SimpleCard.tsx
@@ -24,7 +24,7 @@ export const SimpleCard = (props: Props) => {
         : data?.image?.image?.secure_url;
 
     return (
-        <Card>
+        <Card hasShadow>
             {data.image ? (
                 <CardImage>
                     {src && data?.image?.image ? (

--- a/packages/osc-ui/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/osc-ui/src/components/Accordion/Accordion.stories.tsx
@@ -242,6 +242,12 @@ Tertiary.args = {
     variant: 'tertiary',
 };
 
+export const Quaternary = Template.bind({});
+Quaternary.args = {
+    ...Primary.args,
+    variant: 'quaternary',
+};
+
 export const AllowMultiple = Template.bind({});
 AllowMultiple.args = {
     ...Primary.args,

--- a/packages/osc-ui/src/components/Accordion/Accordion.tsx
+++ b/packages/osc-ui/src/components/Accordion/Accordion.tsx
@@ -15,7 +15,7 @@ import { classNames } from '../../utils/classNames';
 import './accordion.scss';
 
 export type AccordionProps = (AccordionSingleProps | AccordionMultipleProps) & {
-    variant?: 'primary' | 'secondary' | 'tertiary';
+    variant?: 'primary' | 'secondary' | 'tertiary' | 'quaternary';
 } & RefAttributes<HTMLDivElement>;
 
 const AccordionContext = createContext<{ variant: AccordionProps['variant'] } | null>(null);

--- a/packages/osc-ui/src/components/Accordion/accordion.scss
+++ b/packages/osc-ui/src/components/Accordion/accordion.scss
@@ -160,6 +160,17 @@
                     grid-column: 1 / 2;
                 }
             }
+
+            &--quaternary {
+                --accordion-trigger-font-size: #{rem($base-fs)};
+
+                padding: $space-2xs $space-l;
+                font-weight: $fw-light;
+
+                &:hover {
+                    color: var(--color-secondary);
+                }
+            }
         }
 
         &__item {
@@ -170,7 +181,8 @@
                 }
             }
 
-            &--secondary {
+            &--secondary,
+            &--quaternary {
                 border: $accordion-item-border;
 
                 &:not(:last-child) {
@@ -221,6 +233,10 @@
 
             &--tertiary {
                 padding: $space-2xl;
+            }
+
+            &--quaternary {
+                padding: $space-2xs;
             }
         }
     }

--- a/packages/osc-ui/src/components/Button/button.scss
+++ b/packages/osc-ui/src/components/Button/button.scss
@@ -88,7 +88,7 @@
         tertiary: (
             bg-color: transparent,
             bg-hover-color: var(--color-secondary),
-            fg-color: var(--color-neutral-600),
+            fg-color: var(--color-neutral-700),
             fg-hover-color: var(--color-tertiary),
             font-weight: $fw-bold,
             letter-spacing: $ls-xs,

--- a/packages/osc-ui/src/components/Card/Card.stories.tsx
+++ b/packages/osc-ui/src/components/Card/Card.stories.tsx
@@ -161,6 +161,7 @@ const HasBlockLinkTemplate: Story<CardProps> = ({ ...args }) => (
 
 export const Primary = Template.bind({});
 Primary.args = {
+    hasShadow: true,
     style: { maxWidth: '400px' },
 };
 
@@ -192,6 +193,7 @@ export const BlockLink = HasBlockLinkTemplate.bind({});
 BlockLink.args = {
     ...Primary.args,
     blockLink: true,
+    hasShadow: false,
 };
 BlockLink.parameters = {
     docs: {

--- a/packages/osc-ui/src/components/Card/Card.tsx
+++ b/packages/osc-ui/src/components/Card/Card.tsx
@@ -30,15 +30,27 @@ export interface CardProps extends SharedCardProps, HTMLAttributes<HTMLDivElemen
      * @default false
      */
     blockLink?: boolean;
+    /**
+     * Whether the card should have a shadow.
+     * @default false
+     */
+    hasShadow?: boolean;
 }
 const CardContext = createContext(null);
 
 export const Card = (props: CardProps) => {
-    const { blockLink, children, className, ...attr } = props;
+    const { blockLink, children, className, hasShadow = false, ...attr } = props;
     const [cardInnerHeight, setCardInnerHeight] = useState<number>(null);
     const cardRef = useRef<HTMLDivElement>(null);
 
-    const classes = classNames('c-card', blockLink && 'is-block-link', className);
+    const shadowModifier = useModifier('c-card', 'shadow');
+
+    const classes = classNames(
+        'c-card',
+        blockLink && 'is-block-link',
+        hasShadow ? shadowModifier : '',
+        className
+    );
 
     const context = {
         cardInnerHeight,

--- a/packages/osc-ui/src/components/Card/Card.tsx
+++ b/packages/osc-ui/src/components/Card/Card.tsx
@@ -40,22 +40,37 @@ export interface CardProps extends SharedCardProps, HTMLAttributes<HTMLDivElemen
      * @default false
      */
     hasBorder?: boolean;
+    /**
+     * Whether the card should be transparent.
+     * @default false
+     */
+    isTransparent?: boolean;
 }
 const CardContext = createContext(null);
 
 export const Card = (props: CardProps) => {
-    const { blockLink, children, className, hasShadow = false, hasBorder = false, ...attr } = props;
+    const {
+        blockLink,
+        children,
+        className,
+        hasShadow = false,
+        hasBorder = false,
+        isTransparent = false,
+        ...attr
+    } = props;
     const [cardInnerHeight, setCardInnerHeight] = useState<number>(null);
     const cardRef = useRef<HTMLDivElement>(null);
 
     const shadowModifier = useModifier('c-card', 'shadow');
     const borderModifier = useModifier('c-card', 'bordered');
+    const transparentModifier = useModifier('c-card', 'transparent');
 
     const classes = classNames(
         'c-card',
         blockLink && 'is-block-link',
         hasShadow ? shadowModifier : '',
         hasBorder ? borderModifier : '',
+        isTransparent ? transparentModifier : '',
         className
     );
 

--- a/packages/osc-ui/src/components/Card/Card.tsx
+++ b/packages/osc-ui/src/components/Card/Card.tsx
@@ -35,20 +35,27 @@ export interface CardProps extends SharedCardProps, HTMLAttributes<HTMLDivElemen
      * @default false
      */
     hasShadow?: boolean;
+    /**
+     * Whether the card should have a border.
+     * @default false
+     */
+    hasBorder?: boolean;
 }
 const CardContext = createContext(null);
 
 export const Card = (props: CardProps) => {
-    const { blockLink, children, className, hasShadow = false, ...attr } = props;
+    const { blockLink, children, className, hasShadow = false, hasBorder = false, ...attr } = props;
     const [cardInnerHeight, setCardInnerHeight] = useState<number>(null);
     const cardRef = useRef<HTMLDivElement>(null);
 
     const shadowModifier = useModifier('c-card', 'shadow');
+    const borderModifier = useModifier('c-card', 'bordered');
 
     const classes = classNames(
         'c-card',
         blockLink && 'is-block-link',
         hasShadow ? shadowModifier : '',
+        hasBorder ? borderModifier : '',
         className
     );
 

--- a/packages/osc-ui/src/components/Card/Card.tsx
+++ b/packages/osc-ui/src/components/Card/Card.tsx
@@ -191,6 +191,7 @@ export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
     as?: Headings;
     /**
      * Sets the underline style of the title
+     * @default false
      */
     isUnderlined?: boolean;
     /**
@@ -203,6 +204,16 @@ export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
      * @default false
      */
     isSmall?: boolean;
+    /**
+     * Sets the position of the title, only works when subtitle is true
+     * @default top
+     */
+    position?: 'top' | 'bottom';
+    /**
+     * Changes the default colour and sets the themeable modifier
+     * @default false
+     */
+    isThemeable?: boolean;
 }
 
 export const CardTitle = (props: CardTitleProps) => {
@@ -210,9 +221,11 @@ export const CardTitle = (props: CardTitleProps) => {
         as: Component = 'h2',
         children,
         className,
-        isSmall,
-        isUnderlined,
-        subtitle,
+        subtitle = false,
+        position = 'top',
+        isSmall = false,
+        isUnderlined = false,
+        isThemeable = false,
         ...attr
     } = props;
 
@@ -220,11 +233,15 @@ export const CardTitle = (props: CardTitleProps) => {
 
     const underlined = useModifier(elementClass, 'underlined');
     const small = useModifier(elementClass, 'small');
+    const positionModifier = useModifier(elementClass, position);
+    const themeModifier = useModifier(elementClass, 'themeable');
 
     const classes = classNames(
         elementClass,
         isSmall ? small : '',
         isUnderlined ? underlined : '',
+        subtitle && position ? positionModifier : '',
+        isThemeable ? themeModifier : '',
         className
     );
 

--- a/packages/osc-ui/src/components/Card/Card.tsx
+++ b/packages/osc-ui/src/components/Card/Card.tsx
@@ -217,11 +217,13 @@ export const CardTitle = (props: CardTitleProps) => {
     } = props;
 
     const elementClass = subtitle ? 'c-card__subttl' : 'c-card__ttl';
-    const underlined = useModifier('c-card__ttl', 'underlined');
+
+    const underlined = useModifier(elementClass, 'underlined');
+    const small = useModifier(elementClass, 'small');
 
     const classes = classNames(
         elementClass,
-        isSmall && 'is-small',
+        isSmall ? small : '',
         isUnderlined ? underlined : '',
         className
     );

--- a/packages/osc-ui/src/components/Card/Card.tsx
+++ b/packages/osc-ui/src/components/Card/Card.tsx
@@ -156,6 +156,10 @@ export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
      */
     as?: Headings;
     /**
+     * Sets the underline style of the title
+     */
+    isUnderlined?: boolean;
+    /**
      * Set the style of the heading element
      * @default false
      */
@@ -168,10 +172,25 @@ export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
 }
 
 export const CardTitle = (props: CardTitleProps) => {
-    const { as: Component = 'h2', children, className, isSmall, subtitle, ...attr } = props;
+    const {
+        as: Component = 'h2',
+        children,
+        className,
+        isSmall,
+        isUnderlined,
+        subtitle,
+        ...attr
+    } = props;
 
     const elementClass = subtitle ? 'c-card__subttl' : 'c-card__ttl';
-    const classes = classNames(elementClass, isSmall && 'is-small', className);
+    const underlined = useModifier('c-card__ttl', 'underlined');
+
+    const classes = classNames(
+        elementClass,
+        isSmall && 'is-small',
+        isUnderlined ? underlined : '',
+        className
+    );
 
     return (
         <Component className={classes} {...attr}>

--- a/packages/osc-ui/src/components/Card/Card.tsx
+++ b/packages/osc-ui/src/components/Card/Card.tsx
@@ -255,11 +255,20 @@ export const CardTitle = (props: CardTitleProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Card Body
  * -----------------------------------------------------------------------------------------------*/
-export interface CardBodyProps extends SharedCardProps, HTMLAttributes<HTMLDivElement> {}
+export interface CardBodyProps extends SharedCardProps, HTMLAttributes<HTMLDivElement> {
+    /**
+     * Narrows the width of the card body to 44ch
+     * @default false
+     */
+    isNarrow?: boolean;
+}
 
 export const CardBody = (props: CardBodyProps) => {
-    const { children, className, ...attr } = props;
-    const classes = classNames('c-card__body', className);
+    const { children, className, isNarrow = false, ...attr } = props;
+
+    const widthModifier = useModifier('c-card__body', 'narrow');
+
+    const classes = classNames('c-card__body', isNarrow ? widthModifier : '', className);
 
     return (
         <div className={classes} {...attr}>

--- a/packages/osc-ui/src/components/Card/CartCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CartCard.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta, Story } from '@storybook/react';
-import React from 'react';
+import { mediaQueries as mq } from 'osc-design-tokens';
+import React, { useEffect, useState } from 'react';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
+import { rem } from '../../utils/rem';
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel } from '../Accordion/Accordion';
 import { Button, ButtonGroup } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
 import { Price } from '../Price/Price';
@@ -37,6 +41,46 @@ export default {
     },
 } as Meta;
 
+const Selects = () => (
+    <>
+        <Select
+            description={{ label: 'Course Options' }}
+            name="Course Options"
+            defaultValue="Course Material + Practical Training"
+            groupVariants={['secondary', 'inline-wrap']}
+            hasDarkLabel
+            triggerWidth="70"
+            className="u-justify-between"
+        >
+            <SelectItem value="Course Material + Practical Training">
+                Course Material + Practical Training
+            </SelectItem>
+        </Select>
+        <Select
+            description={{ label: 'Study Option' }}
+            name="Study Option"
+            defaultValue="Study pack"
+            groupVariants={['secondary', 'inline-wrap']}
+            hasDarkLabel
+            triggerWidth="70"
+            className="u-justify-between u-pt-xs"
+        >
+            <SelectItem value="Study pack">Study pack</SelectItem>
+        </Select>
+        <Select
+            description={{ label: 'Payment Option' }}
+            name="Payment Option"
+            defaultValue="Pay monthly"
+            groupVariants={['secondary', 'inline-wrap']}
+            hasDarkLabel
+            triggerWidth="70"
+            className="u-justify-between u-pt-xs"
+        >
+            <SelectItem value="Pay monthly">Pay monthly</SelectItem>
+        </Select>
+    </>
+);
+
 const Template: Story<CardProps> = ({ ...args }) => (
     <Card {...args} style={{ maxWidth: '610px' }}>
         <CardInner>
@@ -48,46 +92,12 @@ const Template: Story<CardProps> = ({ ...args }) => (
             </CardHeader>
 
             <CardBody isNarrow>
-                <p>
+                <p className="u-mb-l">
                     Offer information Lorem ipsum dolor sit amet, consectetur. Offer information
                     Lorem ipsum dolor sit amet, consectetur.
                 </p>
 
-                <Select
-                    description={{ label: 'Course Options' }}
-                    name="Course Options"
-                    defaultValue="Course Material + Practical Training"
-                    groupVariants={['secondary', 'inline-wrap']}
-                    hasDarkLabel
-                    triggerWidth="70"
-                    className="u-justify-between u-pt-l"
-                >
-                    <SelectItem value="Course Material + Practical Training">
-                        Course Material + Practical Training
-                    </SelectItem>
-                </Select>
-                <Select
-                    description={{ label: 'Study Option' }}
-                    name="Study Option"
-                    defaultValue="Study pack"
-                    groupVariants={['secondary', 'inline-wrap']}
-                    hasDarkLabel
-                    triggerWidth="70"
-                    className="u-justify-between u-pt-xs"
-                >
-                    <SelectItem value="Study pack">Study pack</SelectItem>
-                </Select>
-                <Select
-                    description={{ label: 'Payment Option' }}
-                    name="Payment Option"
-                    defaultValue="Pay monthly"
-                    groupVariants={['secondary', 'inline-wrap']}
-                    hasDarkLabel
-                    triggerWidth="70"
-                    className="u-justify-between u-pt-xs"
-                >
-                    <SelectItem value="Pay monthly">Pay monthly</SelectItem>
-                </Select>
+                <Selects />
             </CardBody>
 
             <CardFooter className="u-pt-xl">
@@ -110,8 +120,85 @@ const Template: Story<CardProps> = ({ ...args }) => (
     </Card>
 );
 
+const ResponsiveAccordionTemplate: Story<CardProps> = ({ ...args }) => {
+    const isGreaterThanTab = useMediaQuery(`(min-width: ${rem(mq.tab)}rem)`);
+    const [showOnGreaterThanTab, setShowOnGreaterThanTab] = useState(false);
+
+    // We need this useEffect to set the showOnTab state only when the window object exists
+    // Otherwise we will receive an SSR warning telling us the markup differs from the server
+    useEffect(() => {
+        setShowOnGreaterThanTab(isGreaterThanTab);
+    }, [isGreaterThanTab]);
+
+    return (
+        <Card {...args} style={{ maxWidth: '610px' }}>
+            <CardInner>
+                <CardHeader>
+                    <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
+                    <CardTitle as="h3" subtitle isSmall isThemeable position="bottom">
+                        Single course
+                    </CardTitle>
+                </CardHeader>
+
+                <CardBody isNarrow>
+                    {showOnGreaterThanTab ? (
+                        <p className="u-mb-l">
+                            Offer information Lorem ipsum dolor sit amet, consectetur. Offer
+                            information Lorem ipsum dolor sit amet, consectetur.
+                        </p>
+                    ) : null}
+
+                    {showOnGreaterThanTab ? (
+                        <Selects />
+                    ) : (
+                        <Accordion collapsible type="single" variant="quaternary">
+                            <AccordionItem value="0">
+                                <AccordionHeader asChild as="h2" icon="chevron">
+                                    View options
+                                </AccordionHeader>
+                                <AccordionPanel>
+                                    <Selects />
+                                </AccordionPanel>
+                            </AccordionItem>
+                        </Accordion>
+                    )}
+                </CardBody>
+
+                <CardFooter className="u-pt-xl">
+                    <ButtonGroup direction="column">
+                        <Button variant="tertiary" className="u-hidden-until@tab">
+                            Save for later <Icon id="heart" />
+                        </Button>
+                        <Button variant="quaternary" className="u-text-underline">
+                            Remove
+                        </Button>
+                    </ButtonGroup>
+
+                    <CardPriceTag className="u-self-end u-mt-0">
+                        <Price sku="OSC1279">
+                            <span className="u-text-bold">£23</span>/month
+                        </Price>
+                    </CardPriceTag>
+                </CardFooter>
+            </CardInner>
+        </Card>
+    );
+};
+
 export const Primary = Template.bind({});
 Primary.args = {
     hasBorder: true,
     isTransparent: true,
+};
+
+export const PrimaryWithResponsiveAccordion = ResponsiveAccordionTemplate.bind({});
+PrimaryWithResponsiveAccordion.args = {
+    ...Primary.args,
+};
+PrimaryWithResponsiveAccordion.parameters = {
+    docs: {
+        description: {
+            story: 'The cart card can be used with an accordion and a breakpoint to show and hide the content on different screen sizes.<br>Resize your window to see the accordion in action.',
+        },
+    },
 };

--- a/packages/osc-ui/src/components/Card/CartCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CartCard.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, Story } from '@storybook/react';
+import React from 'react';
+import { Button, ButtonGroup } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+import { Price } from '../Price/Price';
+import { Select, SelectItem } from '../Select/Select';
+import type { CardProps } from './Card';
+import {
+    Card,
+    CardBody,
+    CardFooter,
+    CardHeader,
+    CardImage,
+    CardInner,
+    CardPriceTag,
+    CardTitle,
+} from './Card';
+
+export default {
+    title: 'osc-ui/Cards/Cart Card',
+    component: Card,
+    subcomponents: { CardInner, CardImage, CardHeader, CardTitle, CardBody, CardFooter },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'The cart variant of the card is mainly used for product info in the cart.',
+            },
+        },
+    },
+    argTypes: {
+        variant: {
+            control: {
+                type: 'select',
+            },
+        },
+    },
+} as Meta;
+
+const Template: Story<CardProps> = ({ ...args }) => (
+    <Card {...args} style={{ maxWidth: '610px' }}>
+        <CardInner>
+            <CardHeader>
+                <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
+                <CardTitle as="h3" subtitle isSmall isThemeable position="bottom">
+                    Single course
+                </CardTitle>
+            </CardHeader>
+
+            <CardBody isNarrow>
+                <p>
+                    Offer information Lorem ipsum dolor sit amet, consectetur. Offer information
+                    Lorem ipsum dolor sit amet, consectetur.
+                </p>
+
+                <Select
+                    description={{ label: 'Course Options' }}
+                    name="Course Options"
+                    defaultValue="Course Material + Practical Training"
+                    groupVariants={['secondary', 'inline-wrap']}
+                    hasDarkLabel
+                    triggerWidth="70"
+                    className="u-justify-between u-pt-l"
+                >
+                    <SelectItem value="Course Material + Practical Training">
+                        Course Material + Practical Training
+                    </SelectItem>
+                </Select>
+                <Select
+                    description={{ label: 'Study Option' }}
+                    name="Study Option"
+                    defaultValue="Study pack"
+                    groupVariants={['secondary', 'inline-wrap']}
+                    hasDarkLabel
+                    triggerWidth="70"
+                    className="u-justify-between u-pt-xs"
+                >
+                    <SelectItem value="Study pack">Study pack</SelectItem>
+                </Select>
+                <Select
+                    description={{ label: 'Payment Option' }}
+                    name="Payment Option"
+                    defaultValue="Pay monthly"
+                    groupVariants={['secondary', 'inline-wrap']}
+                    hasDarkLabel
+                    triggerWidth="70"
+                    className="u-justify-between u-pt-xs"
+                >
+                    <SelectItem value="Pay monthly">Pay monthly</SelectItem>
+                </Select>
+            </CardBody>
+
+            <CardFooter className="u-pt-xl">
+                <ButtonGroup direction="column">
+                    <Button variant="tertiary" className="u-hidden-until@tab">
+                        Save for later <Icon id="heart" />
+                    </Button>
+                    <Button variant="quaternary" className="u-text-underline">
+                        Remove
+                    </Button>
+                </ButtonGroup>
+
+                <CardPriceTag className="u-self-end u-mt-0">
+                    <Price sku="OSC1279">£23/month</Price>
+                </CardPriceTag>
+            </CardFooter>
+        </CardInner>
+    </Card>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+    hasBorder: true,
+    isTransparent: true,
+};

--- a/packages/osc-ui/src/components/Card/CartCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CartCard.stories.tsx
@@ -101,7 +101,9 @@ const Template: Story<CardProps> = ({ ...args }) => (
                 </ButtonGroup>
 
                 <CardPriceTag className="u-self-end u-mt-0">
-                    <Price sku="OSC1279">£23/month</Price>
+                    <Price sku="OSC1279">
+                        <span className="u-text-bold">£23</span>/month
+                    </Price>
                 </CardPriceTag>
             </CardFooter>
         </CardInner>

--- a/packages/osc-ui/src/components/Card/CollectionCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CollectionCard.stories.tsx
@@ -125,15 +125,18 @@ const LargeTemplate: Story<CardProps> = ({ ...args }) => (
 export const Large = LargeTemplate.bind({});
 Large.args = {
     size: 'lg',
+    hasShadow: true,
     style: { maxWidth: '610px' },
 };
 export const Medium = MediumTemplate.bind({});
 Medium.args = {
     size: 'md',
+    hasShadow: true,
     style: { maxWidth: '610px' },
 };
 export const Small = SmallTemplate.bind({});
 Small.args = {
     size: 'sm',
+    hasShadow: true,
     style: { maxWidth: '452px' },
 };

--- a/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
@@ -63,7 +63,7 @@ const Template: Story<CardProps> = ({ ...args }) => {
                     />
 
                     <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
-                    <CardTitle as="h3" subtitle isSmall>
+                    <CardTitle as="h3" subtitle isSmall isThemeable position="bottom">
                         Single course
                     </CardTitle>
                 </CardHeader>
@@ -108,7 +108,7 @@ const HasCalloutTemplate: Story<CardProps> = ({ ...args }) => {
                     />
 
                     <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
-                    <CardTitle as="h3" subtitle isSmall>
+                    <CardTitle as="h3" subtitle isSmall isThemeable position="bottom">
                         Single course
                     </CardTitle>
                 </CardHeader>
@@ -178,7 +178,7 @@ const IsFullWidthTemplate: Story<CardProps> = ({ ...args }) => {
                         </Price>
                     </CardPriceTag>
                     <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
-                    <CardTitle as="h3" subtitle isSmall>
+                    <CardTitle as="h3" subtitle isSmall isThemeable position="bottom">
                         Single course
                     </CardTitle>
                 </CardHeader>
@@ -246,7 +246,7 @@ const HasFooterTemplate: Story<CardProps> = ({ ...args }) => (
         <CardInner>
             <CardHeader>
                 <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
-                <CardTitle as="h3" subtitle isSmall>
+                <CardTitle as="h3" subtitle isSmall isThemeable position="bottom">
                     Single course
                 </CardTitle>
             </CardHeader>

--- a/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
@@ -286,6 +286,7 @@ const HasFooterTemplate: Story<CardProps> = ({ ...args }) => (
 
 export const Primary = Template.bind({});
 Primary.args = {
+    hasShadow: true,
     style: { maxWidth: '400px' },
 };
 export const HasCallout = HasCalloutTemplate.bind({});
@@ -303,6 +304,7 @@ export const IsFullWidth = IsFullWidthTemplate.bind({});
 IsFullWidth.args = {
     ...Primary.args,
     isFull: true,
+    hasShadow: false,
     style: {
         maxWidth: '100%',
     },

--- a/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
@@ -305,6 +305,7 @@ IsFullWidth.args = {
     ...Primary.args,
     isFull: true,
     hasShadow: false,
+    hasBorder: true,
     style: {
         maxWidth: '100%',
     },

--- a/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
+++ b/packages/osc-ui/src/components/Card/CourseCard.stories.tsx
@@ -62,7 +62,7 @@ const Template: Story<CardProps> = ({ ...args }) => {
                         onClick={() => setIsActive(!isActive)}
                     />
 
-                    <CardTitle>AAT Level 3 Diploma in Accounting</CardTitle>
+                    <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
                     <CardTitle as="h3" subtitle isSmall>
                         Single course
                     </CardTitle>
@@ -107,7 +107,7 @@ const HasCalloutTemplate: Story<CardProps> = ({ ...args }) => {
                         onClick={() => setIsActive(!isActive)}
                     />
 
-                    <CardTitle>AAT Level 3 Diploma in Accounting</CardTitle>
+                    <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
                     <CardTitle as="h3" subtitle isSmall>
                         Single course
                     </CardTitle>
@@ -177,7 +177,7 @@ const IsFullWidthTemplate: Story<CardProps> = ({ ...args }) => {
                             or from <span className="u-text-bold">£849 in full</span>
                         </Price>
                     </CardPriceTag>
-                    <CardTitle>AAT Level 3 Diploma in Accounting</CardTitle>
+                    <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
                     <CardTitle as="h3" subtitle isSmall>
                         Single course
                     </CardTitle>
@@ -245,7 +245,7 @@ const HasFooterTemplate: Story<CardProps> = ({ ...args }) => (
     <CourseCard {...args}>
         <CardInner>
             <CardHeader>
-                <CardTitle>AAT Level 3 Diploma in Accounting</CardTitle>
+                <CardTitle isUnderlined>AAT Level 3 Diploma in Accounting</CardTitle>
                 <CardTitle as="h3" subtitle isSmall>
                     Single course
                 </CardTitle>

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -103,6 +103,12 @@ $card-fs-3xl: $fs-3xl;
         &__ttl {
             font-size: $card-fs-l;
 
+            &--underlined {
+                border-bottom: 1px solid var(--color-secondary);
+                padding-block-end: 0.2em;
+                margin-block-end: 0.2em;
+            }
+
             &.is-small {
                 font-size: $card-fs-m;
                 font-weight: $fw-reg;
@@ -557,12 +563,6 @@ $card-fs-3xl: $fs-3xl;
                 button {
                     justify-self: end;
                 }
-            }
-
-            #{$self}__ttl {
-                border-bottom: 1px solid var(--color-secondary);
-                padding-block-end: 0.2em;
-                margin-block-end: 0.2em;
             }
 
             #{$self}__subttl {

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -56,6 +56,10 @@ $card-fs-3xl: $fs-3xl;
             box-shadow: $card-shadow;
         }
 
+        &--bordered {
+            border: $card-border;
+        }
+
         &,
         &__inner,
         &__header {
@@ -587,8 +591,6 @@ $card-fs-3xl: $fs-3xl;
             }
 
             &.is-full {
-                border: 1px solid var(--color-neutral-400);
-
                 #{$self}__header {
                     #{$self}__ttl,
                     #{$self}__price-tag {

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -60,6 +60,10 @@ $card-fs-3xl: $fs-3xl;
             border: $card-border;
         }
 
+        &--transparent {
+            background-color: transparent;
+        }
+
         &,
         &__inner,
         &__header {

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -48,10 +48,13 @@ $card-fs-3xl: $fs-3xl;
         height: 100%;
         overflow: hidden;
         background-color: var(--color-tertiary);
-        box-shadow: $card-shadow;
         font-size: var(--font-scale-base);
         font-weight: $fw-light;
         line-height: 1.4;
+
+        &--shadow {
+            box-shadow: $card-shadow;
+        }
 
         &,
         &__inner,
@@ -220,7 +223,6 @@ $card-fs-3xl: $fs-3xl;
         // *----------------------------------*/
         &--blog {
             border-bottom: var(--card-border);
-            box-shadow: none;
             color: var(--color-secondary);
 
             #{$self}__inner {
@@ -586,7 +588,6 @@ $card-fs-3xl: $fs-3xl;
 
             &.is-full {
                 border: 1px solid var(--color-neutral-400);
-                box-shadow: none;
 
                 #{$self}__header {
                     #{$self}__ttl,

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -120,7 +120,7 @@ $card-fs-3xl: $fs-3xl;
                 margin-block-end: 0.2em;
             }
 
-            &.is-small {
+            &--small {
                 font-size: $card-fs-m;
                 font-weight: $fw-reg;
             }
@@ -131,7 +131,7 @@ $card-fs-3xl: $fs-3xl;
             font-size: var(--font-scale-base);
             grid-row: 1;
 
-            &.is-small {
+            &--small {
                 font-weight: $fw-reg;
             }
         }

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -160,6 +160,10 @@ $card-fs-3xl: $fs-3xl;
             &-inner {
                 margin-block-end: auto;
             }
+
+            &--narrow {
+                max-width: 44ch;
+            }
         }
 
         &__footer {

--- a/packages/osc-ui/src/components/Card/card.scss
+++ b/packages/osc-ui/src/components/Card/card.scss
@@ -124,15 +124,30 @@ $card-fs-3xl: $fs-3xl;
                 font-size: $card-fs-m;
                 font-weight: $fw-reg;
             }
+
+            &--themeable {
+                color: $card-color;
+            }
         }
 
         &__subttl {
             color: var(--color-neutral-700);
             font-size: var(--font-scale-base);
-            grid-row: 1;
 
             &--small {
                 font-weight: $fw-reg;
+            }
+
+            &--top {
+                grid-row: 1;
+            }
+
+            &--bottom {
+                grid-row: auto;
+            }
+
+            &--themeable {
+                color: $card-color;
             }
         }
 
@@ -573,11 +588,6 @@ $card-fs-3xl: $fs-3xl;
                 button {
                     justify-self: end;
                 }
-            }
-
-            #{$self}__subttl {
-                grid-row: auto;
-                color: $card-color;
             }
 
             #{$self}__body {

--- a/packages/osc-ui/src/components/Label/Label.tsx
+++ b/packages/osc-ui/src/components/Label/Label.tsx
@@ -13,15 +13,28 @@ export interface Props {
     required?: boolean;
     variants?: string[];
     size?: 'm' | 'xl';
+    /**
+     * Sets the label to use the secondary colour
+     * @default false
+     */
+    isDark?: boolean;
 }
-
 export const Label: FC<Props> = (props: Props) => {
-    const { hidden, htmlFor, onClickHandler, name, required = false, size = 'm', variants } = props;
+    const {
+        hidden,
+        htmlFor,
+        onClickHandler,
+        name,
+        required = false,
+        variants,
+        size = 'm',
+        isDark = false,
+    } = props;
 
     const modifier = useModifier('c-label', variants);
     const sizeModifier = useModifier('c-label', size);
-
-    const classes = classNames('c-label', sizeModifier, modifier);
+    const colourModifier = useModifier('c-label', 'dark');
+    const classes = classNames('c-label', sizeModifier, modifier, isDark ? colourModifier : '');
 
     if (hidden) {
         return (

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -16,6 +16,10 @@
             font-weight: $fw-bold;
         }
 
+        &--dark {
+            color: var(--color-secondary);
+        }
+
         &--m {
             font-weight: $fw-reg;
         }

--- a/packages/osc-ui/src/components/Select/Select.tsx
+++ b/packages/osc-ui/src/components/Select/Select.tsx
@@ -15,7 +15,7 @@ type Description = {
     icon?: string;
 };
 
-type GroupVariants = 'secondary' | 'tertiary' | 'inline' | 'bold';
+type GroupVariants = 'secondary' | 'tertiary' | 'inline' | 'inline-wrap' | 'bold';
 
 // type Ex1 = GroupVariants<{ firstName: string }>;
 export interface Props extends ComponentPropsWithRef<typeof SelectPrimitive.Root> {

--- a/packages/osc-ui/src/components/Select/Select.tsx
+++ b/packages/osc-ui/src/components/Select/Select.tsx
@@ -1,15 +1,14 @@
 import { CheckIcon } from '@radix-ui/react-icons';
 import * as SelectPrimitive from '@radix-ui/react-select';
-import type { ComponentPropsWithRef, Dispatch, ElementRef, SetStateAction } from 'react';
+import type { ComponentPropsWithRef, Dispatch, ElementRef, ReactNode, SetStateAction } from 'react';
 import React, { forwardRef, useEffect, useState } from 'react';
-import type { ReactNode } from 'react';
 import type { ZodObject, ZodRawShape } from 'zod';
 import { useModifier } from '../../hooks/useModifier';
 import { classNames } from '../../utils/classNames';
+import { clientSideValidation } from '../../utils/clientSideValidation';
 import { Icon } from '../Icon/Icon';
 import { Label } from '../Label/Label';
 import './select.scss';
-import { clientSideValidation } from '../../utils/clientSideValidation';
 
 type Description = {
     label?: string;
@@ -24,6 +23,10 @@ export interface Props extends ComponentPropsWithRef<typeof SelectPrimitive.Root
      * Description for the Select, can be a Label or an Icon
      */
     children: ReactNode;
+    /**
+     * Custom class
+     */
+    className?: string;
     /**
      * Description for the Select, can be a Label or an Icon
      */
@@ -52,6 +55,15 @@ export interface Props extends ComponentPropsWithRef<typeof SelectPrimitive.Root
      * Allows for client side validation once a server side error has been received
      */
     setErrors?: Dispatch<SetStateAction<any>>;
+    /**
+     * Sets the label to use the secondary colour
+     * @default false
+     */
+    hasDarkLabel?: boolean;
+    /**
+     * Sets the width of the trigger in %
+     */
+    triggerWidth?: '70';
 }
 
 export const Select = forwardRef<ElementRef<typeof SelectPrimitive.Trigger>, Props>(
@@ -67,6 +79,9 @@ export const Select = forwardRef<ElementRef<typeof SelectPrimitive.Trigger>, Pro
             name,
             schema,
             setErrors,
+            hasDarkLabel = false,
+            triggerWidth,
+            className,
         } = props;
         const [value, setValue] = useState('');
         const [isOpen, setIsOpen] = useState(false);
@@ -81,7 +96,13 @@ export const Select = forwardRef<ElementRef<typeof SelectPrimitive.Trigger>, Pro
         }, [value]);
 
         const modifiers = useModifier('c-select', groupVariants);
-        const selectClasses = classNames('c-select', modifiers);
+        const selectClasses = classNames('c-select', modifiers, className);
+
+        const triggerWidthModifier = useModifier('c-select__trigger', triggerWidth);
+        const triggerClasses = classNames(
+            'c-select__trigger',
+            triggerWidth ? triggerWidthModifier : ''
+        );
 
         const setDescription = (desc: Description) => {
             if (desc?.label)
@@ -91,6 +112,7 @@ export const Select = forwardRef<ElementRef<typeof SelectPrimitive.Trigger>, Pro
                         name={desc.label}
                         onClickHandler={() => setIsOpen(!isOpen)}
                         required={required}
+                        isDark={hasDarkLabel}
                     />
                 );
             if (desc?.icon) return <Icon id={desc.icon} />;
@@ -114,7 +136,7 @@ export const Select = forwardRef<ElementRef<typeof SelectPrimitive.Trigger>, Pro
                     <SelectPrimitive.Trigger
                         aria-invalid={errors ? true : false}
                         aria-describedby={errors ? `${name}-error` : undefined}
-                        className="c-select__trigger"
+                        className={triggerClasses}
                         id={name}
                         ref={forwardedRef}
                         aria-label={name}

--- a/packages/osc-ui/src/components/Select/select.scss
+++ b/packages/osc-ui/src/components/Select/select.scss
@@ -40,6 +40,10 @@
                 color: var(--color-neutral-500);
                 pointer-events: none;
             }
+
+            &--70 {
+                max-width: 70%;
+            }
         }
 
         &__content {

--- a/packages/osc-ui/src/components/Select/select.scss
+++ b/packages/osc-ui/src/components/Select/select.scss
@@ -42,7 +42,9 @@
             }
 
             &--70 {
-                max-width: 70%;
+                @include mq($mq-tab) {
+                    max-width: 70%;
+                }
             }
         }
 
@@ -93,10 +95,16 @@
             }
         }
 
+        &--inline-wrap,
         &--inline {
             display: flex;
             align-items: center;
             gap: $space-s;
+        }
+
+        &--inline-wrap {
+            flex-wrap: wrap;
+            gap: calc($space-xs / 2);
         }
 
         &--bold {

--- a/packages/osc-ui/src/styles/utilities/_util.scss
+++ b/packages/osc-ui/src/styles/utilities/_util.scss
@@ -170,6 +170,12 @@ $osc-config: (
             end
         )
     ),
+    justify-content: (
+        prefix: "justify",
+        values: (
+            "between": space-between
+        )
+    ),
     width: (
         prefix: "w",
         values: (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes: #917 
- Closes: #918 
- Closes: #919 

## 📝 Description

Adds the first cart component, this is the "line item" in the cart (cards on the left)
![image](https://github.com/Open-Study-College/osc/assets/23461173/3afd8eda-861b-4f20-91d9-f1b68513018e)

I've refactored a few elements in the cards, so they take new props/modifier classes to change the styles rather than being dependant on their parent. For example the `Card` now has a `hasShadow` and `hasBorder` prop which applies a modifier class, rather than the shadow or border coming from a specific card type. This has allowed me to build up this component by just changing props and adding a few utility classes here and there. I'm also thinking these modifier can potentially be added to Sanity to give CMS users a bit more control over styles (e.g. there are some cards on the homepage that don't have a shadow).

I've added a couple of modifiers to the `Select` and a new variant to the `Accordion` component to match up the design.

## ⛳️ Current behavior (updates)

- Shadows and borders are controlled by cart variant
- Small title styles are handled by `is-small` class
- Title and subtitle position/colour are handled by parent class

## 🚀 New behavior

- Shadow and borders are controlled by props/modifier classes
- Adds a transparent modifier class
- Replaces `is-small` with `--small` modifier
- Title and subtitle position/colour are now handled by modifier class
- `Select` now has a wrappable inline variant and the label can be darkened to the secondary colour
- Adds a quaternary variant to the accordion 

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information

This only adds the component to Storybook, will add it to the cart in osc-ecommerce once the other components are built and I start building out the page
