### PR TITLE
Bugfix/getHubspotForms causing pages without modules to crash

### DIFF
--- a/packages/osc-ecommerce/app/utils/hubspot.helpers.ts
+++ b/packages/osc-ecommerce/app/utils/hubspot.helpers.ts
@@ -142,9 +142,9 @@ export const validateAndSubmitHubspotForm = async (
 export const getHubspotForms = async (page: SanityPage) => {
     let forms: formModule[] = [];
 
-    // If contentMedia has any forms then push them to forms array
     if (!page.modules) return;
 
+    // If contentMedia has any forms then push them to forms array
     page.modules.forEach((module) => {
         const mod = module as contentMediaModule;
         if (module._type === 'module.contentMedia') {

--- a/packages/osc-ecommerce/app/utils/hubspot.helpers.ts
+++ b/packages/osc-ecommerce/app/utils/hubspot.helpers.ts
@@ -143,6 +143,8 @@ export const getHubspotForms = async (page: SanityPage) => {
     let forms: formModule[] = [];
 
     // If contentMedia has any forms then push them to forms array
+    if (!page.modules) return;
+
     page.modules.forEach((module) => {
         const mod = module as contentMediaModule;
         if (module._type === 'module.contentMedia') {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Noticed that if pages don't have any modules defined from Sanity then the `getHubspotForms` method throws an error

![image](https://github.com/Open-Study-College/osc/assets/23461173/1ca09f3e-139d-4d3a-b752-99d0394d7573)

Have added an early return if there are no modules which should get around this

## ⛳️ Current behavior (updates)

- Pages throw an error if there are no defined CMS modules

## 🚀 New behavior

- Early return in `getHubspotForms` will prevent error from being thrown

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
