### PR TITLE
Feature/checkbox size

### DIFF
--- a/packages/osc-ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/osc-ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -52,6 +52,7 @@ const Template: Story = ({ variations }) => {
                         ref={variation.ref ? selectRef : null}
                         value={variation.value}
                         variants={variation.variants}
+                        size={variation.size}
                     />
                 </CheckboxGroup>
             </div>
@@ -189,4 +190,48 @@ Validation.parameters = {
             story: 'Validation styling for the Checkbox',
         },
     },
+};
+
+XL.args = {
+    variations: [
+        {
+            id: 'call-1',
+            name: 'contact',
+            state: 'default',
+            value: 'Call me as soon as possible',
+            size: 'xl',
+        },
+        {
+            defaultChecked: true,
+            id: 'call-2',
+            name: 'contact',
+            state: 'selectedOption',
+            value: 'Call me as soon as possible',
+            size: 'xl',
+        },
+        {
+            id: 'call-3',
+            name: 'contact',
+            ref: true,
+            state: 'hasFocus',
+            value: 'Call me as soon as possible',
+            size: 'xl',
+        },
+        {
+            id: 'call-4',
+            name: 'contact',
+            required: true,
+            state: 'hasValidation',
+            value: 'Call me as soon as possible',
+            size: 'xl',
+        },
+        {
+            disabled: true,
+            id: 'call-5',
+            name: 'contact',
+            state: 'isDisabled',
+            value: 'Call me as soon as possible',
+            size: 'xl',
+        },
+    ],
 };

--- a/packages/osc-ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/osc-ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -93,16 +93,24 @@ const ValidationTemplate: Story = () => {
 export const Primary = Template.bind({});
 export const Secondary = Template.bind({});
 export const GroupLabel = Template.bind({});
+export const XL = Template.bind({});
 
 Primary.args = {
     variations: [
-        { id: 'call-1', name: 'contact', state: 'default', value: 'Call me as soon as possible' },
+        {
+            id: 'call-1',
+            name: 'contact',
+            state: 'default',
+            value: 'Call me as soon as possible',
+            size: 'm',
+        },
         {
             defaultChecked: true,
             id: 'call-2',
             name: 'contact',
             state: 'selectedOption',
             value: 'Call me as soon as possible',
+            size: 'm',
         },
         {
             id: 'call-3',
@@ -110,6 +118,7 @@ Primary.args = {
             ref: true,
             state: 'hasFocus',
             value: 'Call me as soon as possible',
+            size: 'm',
         },
         {
             id: 'call-4',
@@ -117,6 +126,7 @@ Primary.args = {
             required: true,
             state: 'hasValidation',
             value: 'Call me as soon as possible',
+            size: 'm',
         },
         {
             disabled: true,
@@ -124,6 +134,7 @@ Primary.args = {
             name: 'contact',
             state: 'isDisabled',
             value: 'Call me as soon as possible',
+            size: 'm',
         },
     ],
 };
@@ -136,6 +147,7 @@ Secondary.args = {
             state: 'default',
             value: 'Course replacement cover',
             variants: ['secondary'],
+            size: 'm',
         },
         {
             defaultChecked: true,
@@ -145,6 +157,7 @@ Secondary.args = {
             state: 'selectedOption',
             value: 'Course replacement cover',
             variants: ['secondary'],
+            size: 'm',
         },
         {
             icon: { id: 'check', className: 'is-checked' },
@@ -154,6 +167,7 @@ Secondary.args = {
             state: 'hasFocus',
             value: 'Course replacement cover',
             variants: ['secondary'],
+            size: 'm',
         },
         {
             icon: { id: 'check', className: 'is-checked' },
@@ -163,6 +177,7 @@ Secondary.args = {
             state: 'hasValidation',
             value: 'Course replacement cover',
             variants: ['secondary'],
+            size: 'm',
         },
     ],
 };
@@ -178,6 +193,7 @@ GroupLabel.args = {
             name: 'contact',
             state: 'groupLabel',
             value: 'Call me as soon as possible',
+            size: 'm',
         },
     ],
 };

--- a/packages/osc-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/osc-ui/src/components/Checkbox/Checkbox.tsx
@@ -38,6 +38,11 @@ export interface CheckboxProps extends ComponentPropsWithRef<typeof CheckboxPrim
      */
     setErrors?: Dispatch<SetStateAction<any>>;
     /**
+     * Sets the size of the checkbox and the label
+     * @default m
+     */
+    size?: 'm' | 'xl';
+    /**
      * The value given as data when submitted with a name.
      */
     value: string;
@@ -59,6 +64,7 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
             required,
             schema,
             setErrors,
+            size = 'm',
             value,
             variants,
         } = props;
@@ -76,20 +82,31 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
         }, [checked]);
 
         const modifiers = useModifier('c-checkbox__container', variants);
-        const checkboxClasses = classNames('c-checkbox__container', modifiers);
+        const containerSizeModifier = useModifier('c-checkbox__container', size);
+        const checkboxContainerClasses = classNames(
+            'c-checkbox__container',
+            containerSizeModifier,
+            modifiers
+        );
+
+        const checkboxSizeModifier = useModifier('c-checkbox', size);
+        const checkboxClasses = classNames('c-checkbox', checkboxSizeModifier);
+
+        const indicatorSizeModifier = useModifier('c-checkbox__indicator', size);
+        const indicatorClasses = classNames('c-checkbox__indicator', indicatorSizeModifier);
 
         return (
             <div
                 className={
                     errors && errors.length > 0
-                        ? `${checkboxClasses} c-checkbox__container--error`
-                        : `${checkboxClasses}`
+                        ? `${checkboxContainerClasses} c-checkbox__container--error`
+                        : `${checkboxContainerClasses}`
                 }
             >
                 <CheckboxPrimitive.Root
                     aria-label={value}
                     aria-describedby={`${id}-error`}
-                    className="c-checkbox"
+                    className={checkboxClasses}
                     defaultChecked={defaultChecked}
                     disabled={disabled}
                     id={id}
@@ -99,7 +116,7 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
                     required={required}
                     value={value}
                 >
-                    <CheckboxPrimitive.Indicator className="c-checkbox__indicator">
+                    <CheckboxPrimitive.Indicator className={indicatorClasses}>
                         {icon ? <Icon id={icon.id} className={icon.className} /> : null}
                     </CheckboxPrimitive.Indicator>
                 </CheckboxPrimitive.Root>

--- a/packages/osc-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/osc-ui/src/components/Checkbox/Checkbox.tsx
@@ -120,7 +120,7 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
                         {icon ? <Icon id={icon.id} className={icon.className} /> : null}
                     </CheckboxPrimitive.Indicator>
                 </CheckboxPrimitive.Root>
-                <Label name={value} htmlFor={id} />
+                <Label name={value} htmlFor={id} size={size} />
             </div>
         );
     }

--- a/packages/osc-ui/src/components/Checkbox/checkbox.scss
+++ b/packages/osc-ui/src/components/Checkbox/checkbox.scss
@@ -1,22 +1,33 @@
 /* stylelint-disable selector-class-pattern */
 @use "sass:math";
 @use "../../styles/settings" as *;
+@use "../../styles/tools" as *;
 /* stylelint-disable plugin/selector-bem-pattern */
 
 @layer components {
     // Sizes
     $checkbox-width: 1.25;
     $checkbox-height: 1.25;
+    $checkbox-width-xl: 2;
+    $checkbox-height-xl: 2;
 
     .c-checkbox {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: #{$checkbox-width}rem;
-        height: #{$checkbox-height}rem;
         background-color: var(--color-tertiary);
         border: 1px solid var(--color-quinary);
         cursor: pointer;
+
+        &--m {
+            width: #{$checkbox-width}rem;
+            height: #{$checkbox-height}rem;
+        }
+
+        &--xl {
+            width: #{$checkbox-width-xl}rem;
+            height: #{$checkbox-height-xl}rem;
+        }
 
         &__description {
             flex: 1 100%;
@@ -27,10 +38,18 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            width: #{math.div(1, $checkbox-width)}rem;
-            height: #{math.div(1, $checkbox-height)}rem;
             background: var(--color-primary);
             color: var(--color-tertiary);
+
+            &--m {
+                width: #{math.div(1, $checkbox-width)}rem;
+                height: #{math.div(1, $checkbox-height)}rem;
+            }
+
+            &--xl {
+                width: #{math.div($checkbox-width-xl, 1.45)}rem;
+                height: #{math.div($checkbox-height-xl, 1.45)}rem;
+            }
         }
 
         &__group-container {
@@ -68,6 +87,12 @@
                     flex: 1 100%;
                     padding-top: $space-xs;
                     color: var(--color-error);
+                }
+            }
+
+            &--xl {
+                @include mq($mq-mob-l, max) {
+                    align-items: flex-start;
                 }
             }
 

--- a/packages/osc-ui/src/components/Label/Label.tsx
+++ b/packages/osc-ui/src/components/Label/Label.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import type { FC } from 'react';
 import * as RadixLabel from '@radix-ui/react-label';
-import './label.scss';
+import type { FC } from 'react';
+import React from 'react';
 import { useModifier } from '../../hooks/useModifier';
 import { classNames } from '../../utils/classNames';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
+import './label.scss';
 export interface Props {
     onClickHandler?: () => void;
     htmlFor: string;
@@ -12,12 +12,16 @@ export interface Props {
     name: string;
     required?: boolean;
     variants?: string[];
+    size?: 'm' | 'xl';
 }
 
 export const Label: FC<Props> = (props: Props) => {
-    const { hidden, htmlFor, onClickHandler, name, required = false, variants } = props;
+    const { hidden, htmlFor, onClickHandler, name, required = false, size = 'm', variants } = props;
+
     const modifier = useModifier('c-label', variants);
-    const classes = classNames('c-label', modifier);
+    const sizeModifier = useModifier('c-label', size);
+
+    const classes = classNames('c-label', sizeModifier, modifier);
 
     if (hidden) {
         return (

--- a/packages/osc-ui/src/components/Label/label.scss
+++ b/packages/osc-ui/src/components/Label/label.scss
@@ -6,7 +6,6 @@
 @layer components {
     .c-label {
         color: var(--color-neutral-700);
-        font-weight: $fw-reg;
         cursor: pointer;
 
         &__required {
@@ -14,6 +13,15 @@
         }
 
         &--bold {
+            font-weight: $fw-bold;
+        }
+
+        &--m {
+            font-weight: $fw-reg;
+        }
+
+        &--xl {
+            font-size: $fs-l;
             font-weight: $fw-bold;
         }
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds a size modifier to the checkbox and label. Noticed that part of this component
<img width="586" alt="image" src="https://github.com/Open-Study-College/osc/assets/23461173/61294a49-51e1-439d-90fb-5a429f76a461">

Is a big checkbox so I've added some modifier classes to allow us to create checkboxes at this size. Rather than going from m - l I've jumped straight up to xl as that gives us some room for an inbetween size if we ever need one.

## ⛳️ Current behavior (updates)

- Checkboxes are all a standard size

## 🚀 New behavior

- Adds props and modifier classes to checkbox and label

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
