### PR TITLE
Feature/callout secondary

### DIFF
--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, Story } from '@storybook/react';
 import React from 'react';
 import { Button } from '../Button/Button';
+import { Checkbox } from '../Checkbox/Checkbox';
 import { Image } from '../Image/Image';
 import type { CalloutBannerProps } from './CalloutBanner';
 import {
@@ -41,6 +42,35 @@ const Template: Story<CalloutBannerProps> = ({ ...args }) => (
                     </div>
                 </div>
             </CalloutContentGroup>
+        </CalloutBanner>
+    </div>
+);
+
+const TemplateSecondary: Story<CalloutBannerProps> = ({ ...args }) => (
+    <div className="o-container">
+        <CalloutBanner {...args}>
+            <CalloutContentGroup>
+                <Checkbox
+                    id="career-kickstart"
+                    name="Add career kickstart package"
+                    value="Add career kickstart package"
+                    size="xl"
+                />
+            </CalloutContentGroup>
+            <CalloutContentGroup className="t-font-l u-text-bold" willShrink>
+                £29.99
+            </CalloutContentGroup>
+
+            <CalloutFooter asChild>
+                <div className="c-content">
+                    <div className="c-content__inner c-content__inner--left">
+                        <p>
+                            For the smartest way to get your career off the ground.{' '}
+                            <a href="#">Read more</a>
+                        </p>
+                    </div>
+                </div>
+            </CalloutFooter>
         </CalloutBanner>
     </div>
 );
@@ -129,6 +159,12 @@ const HasFooterTemplate: Story<CalloutBannerProps> = ({ ...args }) => (
 
 export const Primary = Template.bind({});
 Primary.args = {};
+
+export const Secondary = TemplateSecondary.bind({});
+Secondary.args = {
+    ...Primary.args,
+    variant: 'secondary',
+};
 
 export const HasButton = TemplateHasButton.bind({});
 HasButton.args = {

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.stories.tsx
@@ -57,16 +57,16 @@ const TemplateSecondary: Story<CalloutBannerProps> = ({ ...args }) => (
                     size="xl"
                 />
             </CalloutContentGroup>
-            <CalloutContentGroup className="t-font-l u-text-bold" willShrink>
+            <CalloutContentGroup className="t-font-l u-text-bold" willShrink isOffset>
                 £29.99
             </CalloutContentGroup>
 
-            <CalloutFooter asChild>
+            <CalloutFooter asChild isOffset>
                 <div className="c-content">
                     <div className="c-content__inner c-content__inner--left">
                         <p>
                             For the smartest way to get your career off the ground.{' '}
-                            <a href="#">Read more</a>
+                            <a href="/">Read more</a>
                         </p>
                     </div>
                 </div>

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -76,18 +76,25 @@ export interface CalloutContentGroupProps extends SharedProps, ComponentPropsWit
      * @default false
      */
     willShrink?: boolean;
+    /**
+     * Offsets the footer to the right
+     * @default false
+     */
+    isOffset?: boolean;
 }
 
 export const CalloutContentGroup = (props: CalloutContentGroupProps) => {
-    const { asChild, children, willShrink = false, className } = props;
+    const { asChild, children, willShrink = false, isOffset = false, className } = props;
     const { variant } = useBannerContext();
 
+    const offsetModifier = useModifier('c-callout-banner__content-group', 'offset');
     const variantModifier = useModifier('c-callout-banner__content-group', variant);
     const flexModifier = useModifier('c-callout-banner__content-group', 'shrink');
 
     const classes = classNames(
         'c-callout-banner__content-group',
         willShrink ? flexModifier : '',
+        isOffset ? offsetModifier : '',
         variantModifier,
         className
     );
@@ -128,7 +135,7 @@ export interface CalloutFooterProps extends SharedProps, ComponentPropsWithoutRe
 }
 
 export const CalloutFooter = (props: CalloutFooterProps) => {
-    const { asChild, children, isOffset, className } = props;
+    const { asChild, children, isOffset = false, className } = props;
     const { variant } = useBannerContext();
 
     const offsetModifier = useModifier('c-callout-banner__footer', 'offset');

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -120,14 +120,25 @@ export interface CalloutFooterProps extends SharedProps, ComponentPropsWithoutRe
      * Merges its props onto its immediate child
      */
     asChild?: boolean;
+    /**
+     * Offsets the footer to the right
+     * @default false
+     */
+    isOffset?: boolean;
 }
 
 export const CalloutFooter = (props: CalloutFooterProps) => {
-    const { asChild, children, className } = props;
+    const { asChild, children, isOffset, className } = props;
     const { variant } = useBannerContext();
 
+    const offsetModifier = useModifier('c-callout-banner__footer', 'offset');
     const variantModifier = useModifier('c-callout-banner__footer', variant);
-    const classes = classNames('c-callout-banner__footer', variantModifier, className);
+    const classes = classNames(
+        'c-callout-banner__footer',
+        variantModifier,
+        isOffset ? offsetModifier : '',
+        className
+    );
 
     const Component = asChild ? Slot : 'div';
 

--- a/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
+++ b/packages/osc-ui/src/components/CalloutBanner/CalloutBanner.tsx
@@ -1,6 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
 import type { ComponentPropsWithoutRef } from 'react';
 import React from 'react';
+import { useModifier } from '../../hooks/useModifier';
 import { classNames } from '../../utils/classNames';
 
 import './callout-banner.scss';
@@ -49,11 +50,25 @@ export interface CalloutContentGroupProps extends SharedProps, ComponentPropsWit
      * Merges its props onto its immediate child
      */
     asChild?: boolean;
+    /**
+     * Sets the flex property to auto
+     * By default it's fixed to 1 so it doesn't shrink, setting this to true will allow it to shrink if needed
+     * @default false
+     */
+    willShrink?: boolean;
 }
 
 export const CalloutContentGroup = (props: CalloutContentGroupProps) => {
-    const { asChild, children, className } = props;
-    const classes = classNames('c-callout-banner__content-group', className);
+    const { asChild, children, willShrink = false, className } = props;
+
+    const flexModifier = useModifier('c-callout-banner__content-group', 'shrink');
+
+    const classes = classNames(
+        'c-callout-banner__content-group',
+        willShrink ? flexModifier : '',
+        className
+    );
+
     const Component = asChild ? Slot : 'div';
 
     return <Component className={classes}>{children}</Component>;

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -16,6 +16,7 @@
     $banner-img-width: 330px; // Set a fixed width so the image doesn't cause the banner to resize when loading
     $banner-border-width: 6px;
     $banner-gradient: var(--color-gradient-quaternary-90);
+    $banner-footer-offset: 44px;
 
     .c-callout-banner {
         display: flex;
@@ -106,6 +107,10 @@
                 @include mq($mq-tab-l) {
                     text-align: right;
                 }
+            }
+
+            &--offset {
+                padding-inline-start: $banner-footer-offset;
             }
         }
 

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -3,36 +3,56 @@
 
 @layer components {
     $banner-bg: var(--color-neutral-300);
+    $banner-bg-secondary: var(--color-tertiary);
     $banner-fg: var(--color-nonary);
+    $banner-fg-secondary: var(--color-secondary);
     $banner-py: $space-xl;
     $banner-py-s: $space-s;
     $banner-px: $space-m;
+    $banner-px-s: $space-s;
     $banner-px-l: $space-xl;
     $banner-content-max-w: 40ch;
     $banner-breakpoint: 1137;
     $banner-img-width: 330px; // Set a fixed width so the image doesn't cause the banner to resize when loading
+    $banner-border-width: 6px;
+    $banner-gradient: var(--color-gradient-quaternary-90);
 
     .c-callout-banner {
         display: flex;
-        flex-direction: column;
         max-width: 100%;
-        padding: $banner-py $banner-px;
-        background-color: $banner-bg;
-        color: $banner-fg;
         margin-inline: auto;
         gap: $space-m;
-
-        @include mq($mq-tab-l) {
-            flex-flow: row wrap;
-            align-items: center;
-            width: fit-content; // make sure banner is constrained to the width of it's children
-            padding: $banner-py-s $banner-px-l;
-        }
 
         /* stylelint-disable-next-line plugin/selector-bem-pattern */
         p,
         li {
             margin-block-end: 0;
+        }
+
+        &--primary {
+            flex-direction: column;
+            padding: $banner-py $banner-px;
+            background-color: $banner-bg;
+            color: $banner-fg;
+
+            @include mq($mq-tab-l) {
+                flex-flow: row wrap;
+                align-items: center;
+                width: fit-content; // make sure banner is constrained to the width of it's children
+                padding: $banner-py-s $banner-px-l;
+            }
+        }
+
+        &--secondary {
+            flex-wrap: wrap;
+            align-items: center;
+            row-gap: 0;
+            padding: $banner-py-s $banner-px-s;
+            background-color: $banner-bg-secondary;
+            border: $banner-border-width solid;
+            color: $banner-fg-secondary;
+            border-image-slice: 1;
+            border-image-source: $banner-gradient;
         }
 
         &__ttl {
@@ -77,12 +97,15 @@
         }
 
         &__footer {
-            margin-block-start: $space-xs;
             flex: 100%;
             font-size: $fs-s;
 
-            @include mq($mq-tab-l) {
-                text-align: right;
+            &--primary {
+                margin-block-start: $space-xs;
+
+                @include mq($mq-tab-l) {
+                    text-align: right;
+                }
             }
         }
 

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -57,9 +57,14 @@
 
         &__content-group {
             flex: 1;
+            margin-block-end: 0;
 
             @include mq($mq-desk-m) {
                 max-width: $banner-content-max-w;
+            }
+
+            &--shrink {
+                flex: 0;
             }
         }
 

--- a/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
+++ b/packages/osc-ui/src/components/CalloutBanner/callout-banner.scss
@@ -16,7 +16,7 @@
     $banner-img-width: 330px; // Set a fixed width so the image doesn't cause the banner to resize when loading
     $banner-border-width: 6px;
     $banner-gradient: var(--color-gradient-quaternary-90);
-    $banner-footer-offset: 44px;
+    $banner-offset: 44px;
 
     .c-callout-banner {
         display: flex;
@@ -45,15 +45,20 @@
         }
 
         &--secondary {
-            flex-wrap: wrap;
-            align-items: center;
-            row-gap: 0;
+            flex-direction: column;
+            gap: $space-2xs;
             padding: $banner-py-s $banner-px-s;
             background-color: $banner-bg-secondary;
             border: $banner-border-width solid;
             color: $banner-fg-secondary;
             border-image-slice: 1;
             border-image-source: $banner-gradient;
+
+            @include mq($mq-mob-m) {
+                flex-flow: row wrap;
+                align-items: center;
+                gap: 0;
+            }
         }
 
         &__ttl {
@@ -80,12 +85,18 @@
             flex: 1;
             margin-block-end: 0;
 
-            @include mq($mq-desk-m) {
-                max-width: $banner-content-max-w;
+            &--primary {
+                @include mq($mq-desk-m) {
+                    max-width: $banner-content-max-w;
+                }
             }
 
             &--shrink {
                 flex: 0;
+            }
+
+            &--offset {
+                padding-inline-start: $banner-offset;
             }
         }
 
@@ -110,7 +121,7 @@
             }
 
             &--offset {
-                padding-inline-start: $banner-footer-offset;
+                padding-inline-start: $banner-offset;
             }
         }
 

--- a/packages/osc-ui/src/components/Content/content.scss
+++ b/packages/osc-ui/src/components/Content/content.scss
@@ -1,4 +1,5 @@
 @import "../../styles/settings";
+@import "../../styles/tools";
 
 @layer components {
     .c-content {
@@ -9,6 +10,10 @@
         flex-grow: 1;
         flex-direction: column;
         width: 100%;
+
+        @include mq($mq-mob, max) {
+            hyphens: auto; // Allow the browser to hyphenate words when needed
+        }
 
         // Ensure the links are underlined unless they are buttons or has been specifically reset
         /* stylelint-disable-next-line plugin/selector-bem-pattern */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #920 

## 📝 Description

Adds a new variant to the callout banner component along with a few new modifiers to adjust the styles to match the add on banner in the Cart page design.

The offset value is a bit of a magic number and only really works with the xl checkbox variant. I think this is _probably_ fine as I can't see anywhere else this style is being used.

## ⛳️ Current behavior (updates)

- Singular variant callout banner

## 🚀 New behavior

- Adds variant prop and primary/secondary modifiers
- Adds context to component so we can pass the variant through
- Adds an offset prop to the content and footer to push things inline when using components such as the checkbox

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
