### PR TITLE
Feature/row

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50288,6 +50288,7 @@
         "@hubspot/api-client": "^8.8.0",
         "@prisma/client": "^4.11.0",
         "@radix-ui/react-icons": "^1.2.0",
+        "@radix-ui/react-slot": "^1.0.1",
         "@react-aria/i18n": "^3.7.0",
         "@react-aria/ssr": "^3.5.0",
         "@remix-run/express": "^1.12.0",

--- a/packages/osc-ecommerce/app/components/Accordion/Accordion.tsx
+++ b/packages/osc-ecommerce/app/components/Accordion/Accordion.tsx
@@ -1,21 +1,30 @@
 import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, Content } from 'osc-ui';
 import type { accordionModule } from '~/types/sanity';
+import { Row } from '../Row';
 
 interface Props {
     module: accordionModule;
+    isFlush?: boolean;
 }
 
 export const AccordionModule = (props: Props) => {
-    const { module } = props;
+    const { module, isFlush } = props;
 
     const defaultIndex = module.accordionItem
         ? module.accordionItem.map((accordionItem) => accordionItem.defaultOpen).indexOf(true)
         : undefined;
 
     const headingLevel = module.accordionHeadingLevels as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    const containerIsFull = module.settings?.container === 'full';
 
     return (
-        <article className="o-container">
+        <Row
+            backgroundColor={module.settings?.backgroundColor}
+            marginBottom={module.settings?.marginBottom}
+            paddingBottom={module.settings?.paddingBottom}
+            paddingTop={module.settings?.paddingTop}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+        >
             {module.content ? (
                 <Content
                     align={module.content?.horizontalAlignment}
@@ -59,6 +68,6 @@ export const AccordionModule = (props: Props) => {
                       })
                     : null}
             </Accordion>
-        </article>
+        </Row>
     );
 };

--- a/packages/osc-ecommerce/app/components/Accordion/Accordion.tsx
+++ b/packages/osc-ecommerce/app/components/Accordion/Accordion.tsx
@@ -15,14 +15,14 @@ export const AccordionModule = (props: Props) => {
         : undefined;
 
     const headingLevel = module.accordionHeadingLevels as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-    const containerIsFull = module.settings?.container === 'full';
+    const containerIsFull = module.rowSettings?.container === 'full';
 
     return (
         <Row
-            backgroundColor={module.settings?.backgroundColor}
-            marginBottom={module.settings?.marginBottom}
-            paddingBottom={module.settings?.paddingBottom}
-            paddingTop={module.settings?.paddingTop}
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
             container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
             {module.content ? (

--- a/packages/osc-ecommerce/app/components/Accordion/Accordion.tsx
+++ b/packages/osc-ecommerce/app/components/Accordion/Accordion.tsx
@@ -25,15 +25,11 @@ export const AccordionModule = (props: Props) => {
             paddingTop={module.rowSettings?.paddingTop}
             container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
-            {module.content ? (
+            {module.content?.body ? (
                 <Content
                     align={module.content?.horizontalAlignment}
-                    backgroundColor={module.content?.backgroundColor}
-                    marginBottom={module.content?.marginBottom}
-                    paddingBottom={module.content?.paddingBottom}
-                    paddingTop={module.content?.paddingTop}
-                    textColor={module.content?.textColor}
                     value={module.content?.body}
+                    buttons={module.content?.buttons}
                 />
             ) : null}
 
@@ -49,17 +45,11 @@ export const AccordionModule = (props: Props) => {
                                       {accordionItem?.heading}
                                   </AccordionHeader>
                                   <AccordionPanel>
-                                      {accordionItem.content ? (
+                                      {accordionItem.content?.body ? (
                                           <Content
                                               align={accordionItem.content?.horizontalAlignment}
-                                              backgroundColor={
-                                                  accordionItem.content?.backgroundColor
-                                              }
-                                              marginBottom={accordionItem.content?.marginBottom}
-                                              paddingBottom={accordionItem.content?.paddingBottom}
-                                              paddingTop={accordionItem.content?.paddingTop}
-                                              textColor={accordionItem.content?.textColor}
                                               value={accordionItem.content?.body}
+                                              buttons={accordionItem.content?.buttons}
                                           />
                                       ) : null}
                                   </AccordionPanel>

--- a/packages/osc-ecommerce/app/components/Cards/Cards.spec.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/Cards.spec.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { mockCardData } from '~/components/Cards/mockCardData';
 import type {
     bioCardModule,
+    cardModule,
     collectionCardModule,
     courseCardModule,
     postCardModule,
@@ -53,7 +54,7 @@ describe('Responsive layout', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <Cards module={mockCardData} />
+                    <Cards module={mockCardData as cardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -78,7 +79,7 @@ describe('Responsive layout', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <Cards module={mockCardData} />
+                    <Cards module={mockCardData as cardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -107,7 +108,7 @@ describe('Responsive layout', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <Cards module={clonedData} />
+                    <Cards module={clonedData as cardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -140,7 +141,7 @@ describe('Controlled layout', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <Cards module={clonedData} />
+                    <Cards module={clonedData as cardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -160,7 +161,7 @@ describe('Controlled layout', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <Cards module={clonedData} />
+                    <Cards module={clonedData as cardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -180,7 +181,7 @@ describe('Controlled layout', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <Cards module={clonedData} />
+                    <Cards module={clonedData as cardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -228,7 +229,7 @@ describe('Card types', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <CourseCard data={courseCard as courseCardModule} />
+                    <CourseCard product={courseCard as unknown as courseCardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -259,7 +260,7 @@ describe('Card types', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <CollectionCard data={collectionCard as collectionCardModule} />
+                    <CollectionCard data={collectionCard as unknown as collectionCardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );
@@ -278,7 +279,7 @@ describe('Card types', () => {
         render(
             <MemoryRouter>
                 <SpritesheetProvider>
-                    <BlogCard data={blogCard as postCardModule} />
+                    <BlogCard data={blogCard as unknown as postCardModule} />
                 </SpritesheetProvider>
             </MemoryRouter>
         );

--- a/packages/osc-ecommerce/app/components/Cards/Cards.spec.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/Cards.spec.tsx
@@ -234,23 +234,25 @@ describe('Card types', () => {
             </MemoryRouter>
         );
 
-        const title = screen.getByRole('heading', {
-            level: 2,
-            name: courseCard?.reference?.store?.title,
-        });
-        const courseOptions = screen.getAllByRole('listitem');
-        const minPrice = screen.getByText(/£469 in full/);
-        const wishlistButton = screen.getByRole('button', {
-            name: 'Save for later',
-        });
+        expect(
+            screen.getByRole('heading', {
+                level: 2,
+                name: courseCard?.reference?.store?.title,
+            })
+        ).toBeInTheDocument();
 
-        expect(title).toBeInTheDocument();
-        expect(courseOptions).toHaveLength(2);
-        expect(minPrice).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem')).toHaveLength(2);
 
-        await user.click(wishlistButton);
+        expect(document.querySelector('.c-card__price-tag')).toHaveTextContent(/£469 in full/);
 
-        expect(wishlistButton).toHaveClass('is-active');
+        // TODO: Add back in with wishlist functionality
+        // const wishlistButton = screen.getByRole('button', {
+        //     name: 'Save for later',
+        // });
+
+        // await user.click(wishlistButton);
+
+        // expect(wishlistButton).toHaveClass('is-active');
     });
 
     test('renders the content of the collection card', () => {

--- a/packages/osc-ecommerce/app/components/Cards/Cards.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/Cards.tsx
@@ -9,6 +9,7 @@ import type {
     staticCardModule,
     TypesOfCard,
 } from '~/types/sanity';
+import { Row } from '../Row';
 import { BioCard } from './BioCard';
 import { BlogCard } from './BlogCard';
 import { CollectionCard } from './CollectionCard';
@@ -18,7 +19,7 @@ import { SimpleCard } from './SimpleCard';
 const Card = (props: { card: TypesOfCard }) => {
     const { card } = props;
 
-    if (!card) return;
+    if (!card) return null;
 
     switch (card._type) {
         case 'card.bio':
@@ -41,8 +42,16 @@ const Card = (props: { card: TypesOfCard }) => {
     }
 };
 
-export const Cards = (props: { module: cardModule }) => {
-    const { module } = props;
+interface CardsProps {
+    module: cardModule;
+    isFlush?: boolean;
+}
+
+export const Cards = (props: CardsProps) => {
+    const { module, isFlush } = props;
+
+    const containerIsFull = module.settings?.container === 'full';
+
     // ! TEMPORARY fix for tokens path not matching dev and prod environments
     // ! Once solution in place we can update this to use design token files instead
     const mq = {
@@ -59,112 +68,17 @@ export const Cards = (props: { module: cardModule }) => {
         setShowOnSmallerThanTab(isSmallerThanTab);
     }, [isSmallerThanTab]);
 
-    const classes = classNames(
-        module?.backgroundColor ? `u-bg-color-${module?.backgroundColor}` : '',
-        module?.marginBottom ? `u-mb-${module?.marginBottom}` : '',
-        module?.paddingTop ? `u-pt-${module?.paddingTop}` : '',
-        module?.paddingBottom ? `u-pb-${module?.paddingBottom}` : ''
-    );
-
     const perView = (perView: number | undefined) => (perView ? perView : 1);
 
     if (module?.layout === 'carousel') {
         return (
-            <article className={classes}>
-                <div className="o-container">
-                    {module.content?.body ? (
-                        <Content
-                            align={module.content.horizontalAlignment}
-                            backgroundColor={
-                                module.content.backgroundColor
-                                    ? module.content.backgroundColor
-                                    : undefined
-                            }
-                            marginBottom={module.content.marginBottom}
-                            paddingBottom={module.content.paddingBottom}
-                            paddingTop={module.content.paddingTop}
-                            value={module.content.body}
-                            buttons={module.content.buttons}
-                        />
-                    ) : null}
-
-                    <Carousel
-                        carouselName={module?.carouselName ? module?.carouselName : ''}
-                        arrows={module?.carouselSettings?.arrows}
-                        dotNav={module?.carouselSettings?.dotNav}
-                        loop={module?.carouselSettings?.loop}
-                        autoplay={module?.carouselSettings?.autoplay}
-                        slidesPerView={perView(module?.carouselSettings?.slidesPerView?.mobile)}
-                        startIndex={
-                            module?.carouselSettings?.startIndex
-                                ? module?.carouselSettings?.startIndex - 1
-                                : 0
-                        } // minus 1 so cms users can start at 1
-                        breakpoints={{
-                            [`(min-width: ${rem(mq['tab'])}rem)`]: {
-                                slides: {
-                                    origin: 'auto',
-                                    perView: perView(
-                                        module?.carouselSettings?.slidesPerView?.tablet
-                                    ),
-                                    spacing: 16,
-                                },
-                            },
-                            [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
-                                slides: {
-                                    origin: 'auto',
-                                    perView: perView(
-                                        module?.carouselSettings?.slidesPerView?.desktop
-                                    ),
-                                    spacing: 16,
-                                },
-                            },
-                        }}
-                        adaptiveHeight
-                    >
-                        {module.card.map((card) => (
-                            <Card card={card} key={card?._key} />
-                        ))}
-                    </Carousel>
-                </div>
-            </article>
-        );
-    }
-
-    if (module.layout === 'island grid') {
-        return (
-            <article className={classes}>
-                <div className="o-container">
-                    {module.content?.body ? (
-                        <Content
-                            align={module.content.horizontalAlignment}
-                            backgroundColor={
-                                module.content.backgroundColor
-                                    ? module.content.backgroundColor
-                                    : undefined
-                            }
-                            marginBottom={module.content.marginBottom}
-                            paddingBottom={module.content.paddingBottom}
-                            paddingTop={module.content.paddingTop}
-                            value={module.content.body}
-                            buttons={module.content.buttons}
-                        />
-                    ) : null}
-
-                    <IslandGrid>
-                        {module.card.map((card) => (
-                            <Card card={card} key={card?._key} />
-                        ))}
-                    </IslandGrid>
-                </div>
-            </article>
-        );
-    }
-
-    // Return grid layout by default
-    return (
-        <article className={classes}>
-            <div className="o-container">
+            <Row
+                backgroundColor={module.settings?.backgroundColor || module?.backgroundColor}
+                marginBottom={module.settings?.marginBottom || module?.marginBottom}
+                paddingBottom={module.settings?.paddingBottom || module?.paddingTop}
+                paddingTop={module.settings?.paddingTop || module?.paddingBottom}
+                container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+            >
                 {module.content?.body ? (
                     <Content
                         align={module.content.horizontalAlignment}
@@ -181,37 +95,131 @@ export const Cards = (props: { module: cardModule }) => {
                     />
                 ) : null}
 
-                {/* Only become a carousel on mobile and small tablets AND when the number of cards is greater than three */}
-                {showOnSmallerThanTab && module?.card.length > 3 ? (
-                    <Carousel
-                        carouselName={module?.carouselName ? module?.carouselName : ''}
-                        slidesPerView={1.2} // Set to 1.2 to peek the next card in the carousel
-                    >
-                        {module.card.map((card) => (
-                            <Card card={card} key={card?._key} />
-                        ))}
-                    </Carousel>
-                ) : (
-                    <ul className="o-grid">
-                        {module.card.map((card) => {
-                            const postCard = card as postCardModule;
-                            const isFullWidth = postCard?.fullWidth;
+                <Carousel
+                    carouselName={module?.carouselName ? module?.carouselName : ''}
+                    arrows={module?.carouselSettings?.arrows}
+                    dotNav={module?.carouselSettings?.dotNav}
+                    loop={module?.carouselSettings?.loop}
+                    autoplay={module?.carouselSettings?.autoplay}
+                    slidesPerView={perView(module?.carouselSettings?.slidesPerView?.mobile)}
+                    startIndex={
+                        module?.carouselSettings?.startIndex
+                            ? module?.carouselSettings?.startIndex - 1
+                            : 0
+                    } // minus 1 so cms users can start at 1
+                    breakpoints={{
+                        [`(min-width: ${rem(mq['tab'])}rem)`]: {
+                            slides: {
+                                origin: 'auto',
+                                perView: perView(module?.carouselSettings?.slidesPerView?.tablet),
+                                spacing: 16,
+                            },
+                        },
+                        [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
+                            slides: {
+                                origin: 'auto',
+                                perView: perView(module?.carouselSettings?.slidesPerView?.desktop),
+                                spacing: 16,
+                            },
+                        },
+                    }}
+                    adaptiveHeight
+                >
+                    {module.card.map((card) => (
+                        <Card card={card} key={card?._key} />
+                    ))}
+                </Carousel>
+            </Row>
+        );
+    }
 
-                            const classes = classNames(
-                                'o-grid__col--12',
-                                isFullWidth ? '' : 'o-grid__col--6@tab',
-                                isFullWidth ? '' : 'o-grid__col--4@desk'
-                            );
+    if (module.layout === 'island grid') {
+        return (
+            <Row
+                backgroundColor={module.settings?.backgroundColor || module?.backgroundColor}
+                marginBottom={module.settings?.marginBottom || module?.marginBottom}
+                paddingBottom={module.settings?.paddingBottom || module?.paddingTop}
+                paddingTop={module.settings?.paddingTop || module?.paddingBottom}
+                container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+            >
+                {module.content?.body ? (
+                    <Content
+                        align={module.content.horizontalAlignment}
+                        backgroundColor={
+                            module.content.backgroundColor
+                                ? module.content.backgroundColor
+                                : undefined
+                        }
+                        marginBottom={module.content.marginBottom}
+                        paddingBottom={module.content.paddingBottom}
+                        paddingTop={module.content.paddingTop}
+                        value={module.content.body}
+                        buttons={module.content.buttons}
+                    />
+                ) : null}
 
-                            return (
-                                <li className={classes} key={card?._key}>
-                                    <Card card={card} />
-                                </li>
-                            );
-                        })}
-                    </ul>
-                )}
-            </div>
-        </article>
+                <IslandGrid>
+                    {module.card.map((card) => (
+                        <Card card={card} key={card?._key} />
+                    ))}
+                </IslandGrid>
+            </Row>
+        );
+    }
+
+    // Return grid layout by default
+    return (
+        <Row
+            backgroundColor={module.settings?.backgroundColor || module?.backgroundColor}
+            marginBottom={module.settings?.marginBottom || module?.marginBottom}
+            paddingBottom={module.settings?.paddingBottom || module?.paddingTop}
+            paddingTop={module.settings?.paddingTop || module?.paddingBottom}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+        >
+            {module.content?.body ? (
+                <Content
+                    align={module.content.horizontalAlignment}
+                    backgroundColor={
+                        module.content.backgroundColor ? module.content.backgroundColor : undefined
+                    }
+                    marginBottom={module.content.marginBottom}
+                    paddingBottom={module.content.paddingBottom}
+                    paddingTop={module.content.paddingTop}
+                    value={module.content.body}
+                    buttons={module.content.buttons}
+                />
+            ) : null}
+
+            {/* Only become a carousel on mobile and small tablets AND when the number of cards is greater than three */}
+            {showOnSmallerThanTab && module?.card.length > 3 ? (
+                <Carousel
+                    carouselName={module?.carouselName ? module?.carouselName : ''}
+                    slidesPerView={1.2} // Set to 1.2 to peek the next card in the carousel
+                >
+                    {module.card.map((card) => (
+                        <Card card={card} key={card?._key} />
+                    ))}
+                </Carousel>
+            ) : (
+                <ul className="o-grid">
+                    {module.card.map((card) => {
+                        const postCard = card as postCardModule;
+                        const isFullWidth = postCard?.fullWidth;
+
+                        const classes = classNames(
+                            'o-grid__col--12',
+                            isFullWidth ? '' : 'o-grid__col--6@tab',
+                            isFullWidth ? '' : 'o-grid__col--4@desk'
+                        );
+
+                        return (
+                            <li className={classes} key={card?._key}>
+                                <Card card={card} />
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </Row>
     );
 };

--- a/packages/osc-ecommerce/app/components/Cards/Cards.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/Cards.tsx
@@ -73,25 +73,17 @@ export const Cards = (props: CardsProps) => {
     if (module?.layout === 'carousel') {
         return (
             <Row
-                backgroundColor={module.rowSettings?.backgroundColor || module?.backgroundColor}
-                marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
-                paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
-                paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
+                backgroundColor={module.rowSettings?.backgroundColor}
+                marginBottom={module.rowSettings?.marginBottom}
+                paddingBottom={module.rowSettings?.paddingBottom}
+                paddingTop={module.rowSettings?.paddingTop}
                 container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
             >
                 {module.content?.body ? (
                     <Content
-                        align={module.content.horizontalAlignment}
-                        backgroundColor={
-                            module.content.backgroundColor
-                                ? module.content.backgroundColor
-                                : undefined
-                        }
-                        marginBottom={module.content.marginBottom}
-                        paddingBottom={module.content.paddingBottom}
-                        paddingTop={module.content.paddingTop}
-                        value={module.content.body}
-                        buttons={module.content.buttons}
+                        align={module.content?.horizontalAlignment}
+                        value={module.content?.body}
+                        buttons={module.content?.buttons}
                     />
                 ) : null}
 
@@ -136,25 +128,17 @@ export const Cards = (props: CardsProps) => {
     if (module.layout === 'island grid') {
         return (
             <Row
-                backgroundColor={module.rowSettings?.backgroundColor || module?.backgroundColor}
-                marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
-                paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
-                paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
+                backgroundColor={module.rowSettings?.backgroundColor}
+                marginBottom={module.rowSettings?.marginBottom}
+                paddingBottom={module.rowSettings?.paddingBottom}
+                paddingTop={module.rowSettings?.paddingTop}
                 container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
             >
                 {module.content?.body ? (
                     <Content
-                        align={module.content.horizontalAlignment}
-                        backgroundColor={
-                            module.content.backgroundColor
-                                ? module.content.backgroundColor
-                                : undefined
-                        }
-                        marginBottom={module.content.marginBottom}
-                        paddingBottom={module.content.paddingBottom}
-                        paddingTop={module.content.paddingTop}
-                        value={module.content.body}
-                        buttons={module.content.buttons}
+                        align={module.content?.horizontalAlignment}
+                        value={module.content?.body}
+                        buttons={module.content?.buttons}
                     />
                 ) : null}
 
@@ -170,23 +154,17 @@ export const Cards = (props: CardsProps) => {
     // Return grid layout by default
     return (
         <Row
-            backgroundColor={module.rowSettings?.backgroundColor || module?.backgroundColor}
-            marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
-            paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
-            paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
             container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
             {module.content?.body ? (
                 <Content
-                    align={module.content.horizontalAlignment}
-                    backgroundColor={
-                        module.content.backgroundColor ? module.content.backgroundColor : undefined
-                    }
-                    marginBottom={module.content.marginBottom}
-                    paddingBottom={module.content.paddingBottom}
-                    paddingTop={module.content.paddingTop}
-                    value={module.content.body}
-                    buttons={module.content.buttons}
+                    align={module.content?.horizontalAlignment}
+                    value={module.content?.body}
+                    buttons={module.content?.buttons}
                 />
             ) : null}
 

--- a/packages/osc-ecommerce/app/components/Cards/Cards.tsx
+++ b/packages/osc-ecommerce/app/components/Cards/Cards.tsx
@@ -50,7 +50,7 @@ interface CardsProps {
 export const Cards = (props: CardsProps) => {
     const { module, isFlush } = props;
 
-    const containerIsFull = module.settings?.container === 'full';
+    const containerIsFull = module.rowSettings?.container === 'full';
 
     // ! TEMPORARY fix for tokens path not matching dev and prod environments
     // ! Once solution in place we can update this to use design token files instead
@@ -73,10 +73,10 @@ export const Cards = (props: CardsProps) => {
     if (module?.layout === 'carousel') {
         return (
             <Row
-                backgroundColor={module.settings?.backgroundColor || module?.backgroundColor}
-                marginBottom={module.settings?.marginBottom || module?.marginBottom}
-                paddingBottom={module.settings?.paddingBottom || module?.paddingTop}
-                paddingTop={module.settings?.paddingTop || module?.paddingBottom}
+                backgroundColor={module.rowSettings?.backgroundColor || module?.backgroundColor}
+                marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
+                paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
+                paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
                 container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
             >
                 {module.content?.body ? (
@@ -136,10 +136,10 @@ export const Cards = (props: CardsProps) => {
     if (module.layout === 'island grid') {
         return (
             <Row
-                backgroundColor={module.settings?.backgroundColor || module?.backgroundColor}
-                marginBottom={module.settings?.marginBottom || module?.marginBottom}
-                paddingBottom={module.settings?.paddingBottom || module?.paddingTop}
-                paddingTop={module.settings?.paddingTop || module?.paddingBottom}
+                backgroundColor={module.rowSettings?.backgroundColor || module?.backgroundColor}
+                marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
+                paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
+                paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
                 container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
             >
                 {module.content?.body ? (
@@ -170,10 +170,10 @@ export const Cards = (props: CardsProps) => {
     // Return grid layout by default
     return (
         <Row
-            backgroundColor={module.settings?.backgroundColor || module?.backgroundColor}
-            marginBottom={module.settings?.marginBottom || module?.marginBottom}
-            paddingBottom={module.settings?.paddingBottom || module?.paddingTop}
-            paddingTop={module.settings?.paddingTop || module?.paddingBottom}
+            backgroundColor={module.rowSettings?.backgroundColor || module?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
+            paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
             container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
             {module.content?.body ? (

--- a/packages/osc-ecommerce/app/components/Cards/mockCardData.ts
+++ b/packages/osc-ecommerce/app/components/Cards/mockCardData.ts
@@ -278,7 +278,11 @@ export const mockCardData = {
     ],
     carouselName: 'List of test cards',
     layout: 'grid',
-    marginBottom: 'milli',
-    paddingBottom: 'beta',
-    paddingTop: 'beta',
+    rowSettings: {
+        backgroundColor: 'neutral-200',
+        marginBottom: '',
+        paddingBottom: '',
+        paddingTop: '',
+        container: 'default',
+    },
 };

--- a/packages/osc-ecommerce/app/components/Carousel/Carousel.tsx
+++ b/packages/osc-ecommerce/app/components/Carousel/Carousel.tsx
@@ -1,5 +1,6 @@
 import { Carousel, Image, rem } from 'osc-ui';
 import type { carouselModule } from '~/types/sanity';
+import { Row } from '../Row';
 
 // ! TEMPORARY fix for tokens path not matching dev and prod environments
 // ! Once solution in place we can update this to use design token files instead
@@ -8,57 +9,72 @@ const mq = {
     'desk-lrg': 1440,
 };
 
-export const CarouselModule = (props: { module: carouselModule }) => {
-    const { carouselName, slides, settings } = props?.module;
+interface CarouselProps {
+    module: carouselModule;
+    isFlush?: boolean;
+}
+
+export const CarouselModule = (props: CarouselProps) => {
+    const { module, isFlush } = props;
+    const { carouselName, slides, settings, rowSettings } = module;
+    const containerIsFull = rowSettings?.container === 'full';
 
     const perView = (perView: number | undefined) => (perView ? perView : 1);
 
     return slides && slides.length > 0 ? (
-        <Carousel
-            carouselName={carouselName ? carouselName : ''}
-            arrows={settings?.arrows}
-            dotNav={settings?.dotNav}
-            loop={settings?.loop}
-            autoplay={settings?.autoplay}
-            slidesPerView={perView(settings?.slidesPerView?.mobile)}
-            startIndex={settings?.startIndex ? settings?.startIndex - 1 : 0} // minus 1 so cms users can start at 1
-            breakpoints={{
-                [`(min-width: ${rem(mq['tab'])}rem)`]: {
-                    slides: {
-                        origin: 'auto',
-                        perView: perView(settings?.slidesPerView?.tablet),
-                        spacing: 16,
-                    },
-                },
-                [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
-                    slides: {
-                        origin: 'auto',
-                        perView: perView(settings?.slidesPerView?.desktop),
-                        spacing: 16,
-                    },
-                },
-            }}
+        <Row
+            backgroundColor={rowSettings?.backgroundColor}
+            marginBottom={rowSettings?.marginBottom}
+            paddingBottom={rowSettings?.paddingBottom}
+            paddingTop={rowSettings?.paddingTop}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
-            {slides.map((slide) =>
-                slide?.image?.src ? (
-                    <Image
-                        key={slide?.image?._key}
-                        src={slide?.image?.src}
-                        width={slide?.image?.width}
-                        height={slide?.image?.height}
-                        alt={slide?.image?.alt}
-                        artDirectedImages={
-                            slide?.image?.responsiveImages
-                                ? slide?.image?.responsiveImages
-                                : undefined
-                        }
-                        overlayColor={slide?.image?.imageStyles?.overlayColor}
-                        isGrayScale={slide?.image?.imageStyles?.grayscale}
-                        hasTransparency={slide?.image?.imageStyles?.opacity}
-                        className="o-img--contain"
-                    />
-                ) : null
-            )}
-        </Carousel>
+            <Carousel
+                carouselName={carouselName ? carouselName : ''}
+                arrows={settings?.arrows}
+                dotNav={settings?.dotNav}
+                loop={settings?.loop}
+                autoplay={settings?.autoplay}
+                slidesPerView={perView(settings?.slidesPerView?.mobile)}
+                startIndex={settings?.startIndex ? settings?.startIndex - 1 : 0} // minus 1 so cms users can start at 1
+                breakpoints={{
+                    [`(min-width: ${rem(mq['tab'])}rem)`]: {
+                        slides: {
+                            origin: 'auto',
+                            perView: perView(settings?.slidesPerView?.tablet),
+                            spacing: 16,
+                        },
+                    },
+                    [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
+                        slides: {
+                            origin: 'auto',
+                            perView: perView(settings?.slidesPerView?.desktop),
+                            spacing: 16,
+                        },
+                    },
+                }}
+            >
+                {slides.map((slide) =>
+                    slide?.image?.src ? (
+                        <Image
+                            key={slide?.image?._key}
+                            src={slide?.image?.src}
+                            width={slide?.image?.width}
+                            height={slide?.image?.height}
+                            alt={slide?.image?.alt}
+                            artDirectedImages={
+                                slide?.image?.responsiveImages
+                                    ? slide?.image?.responsiveImages
+                                    : undefined
+                            }
+                            overlayColor={slide?.image?.imageStyles?.overlayColor}
+                            isGrayScale={slide?.image?.imageStyles?.grayscale}
+                            hasTransparency={slide?.image?.imageStyles?.opacity}
+                            className="o-img--contain"
+                        />
+                    ) : null
+                )}
+            </Carousel>
+        </Row>
     ) : null;
 };

--- a/packages/osc-ecommerce/app/components/Content/Content.tsx
+++ b/packages/osc-ecommerce/app/components/Content/Content.tsx
@@ -1,0 +1,25 @@
+import { Content } from 'osc-ui';
+import type { contentModule } from '~/types/sanity';
+import { Row } from '../Row';
+
+export const ContentModule = (props: { module: contentModule; isFlush?: boolean }) => {
+    const { module, isFlush } = props;
+
+    return module.body ? (
+        <Row
+            backgroundColor={module.backgroundColor}
+            marginBottom={module.marginBottom}
+            paddingBottom={module.paddingBottom}
+            paddingTop={module.paddingTop}
+            container={isFlush || module.fullWidth ? 'o-container--flush o-container--full' : ''}
+            asChild
+        >
+            <Content
+                align={module.horizontalAlignment}
+                value={module.body}
+                fullWidth={module.fullWidth ? module.fullWidth : undefined}
+                buttons={module.buttons}
+            />
+        </Row>
+    ) : null;
+};

--- a/packages/osc-ecommerce/app/components/Content/Content.tsx
+++ b/packages/osc-ecommerce/app/components/Content/Content.tsx
@@ -13,12 +13,10 @@ export const ContentModule = (props: { module: contentModule; isFlush?: boolean 
             paddingBottom={module.rowSettings?.paddingBottom}
             paddingTop={module.rowSettings?.paddingTop}
             container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
-            asChild
         >
             <Content
                 align={module.horizontalAlignment}
                 value={module.body}
-                fullWidth={module.fullWidth ? module.fullWidth : undefined}
                 buttons={module.buttons}
             />
         </Row>

--- a/packages/osc-ecommerce/app/components/Content/Content.tsx
+++ b/packages/osc-ecommerce/app/components/Content/Content.tsx
@@ -4,14 +4,15 @@ import { Row } from '../Row';
 
 export const ContentModule = (props: { module: contentModule; isFlush?: boolean }) => {
     const { module, isFlush } = props;
+    const containerIsFull = module.rowSettings?.container === 'full';
 
     return module.body ? (
         <Row
-            backgroundColor={module.backgroundColor}
-            marginBottom={module.marginBottom}
-            paddingBottom={module.paddingBottom}
-            paddingTop={module.paddingTop}
-            container={isFlush || module.fullWidth ? 'o-container--flush o-container--full' : ''}
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
             asChild
         >
             <Content

--- a/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
+++ b/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
@@ -109,14 +109,10 @@ const Slide = (props: SlideProps) => {
                 className={layoutGrid === '50/40' && itemHasForm ? 'o-grid__col--start-8@tab' : ''}
             >
                 {content?.body ? (
-                    // Fixed in #691
                     <Content
-                        value={content?.body}
                         align={content?.horizontalAlignment}
-                        backgroundColor={
-                            content?.backgroundColor ? content?.backgroundColor : undefined
-                        }
-                        {...content}
+                        value={content?.body}
+                        buttons={content?.buttons}
                     />
                 ) : null}
             </ContentMediaBlock>

--- a/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
+++ b/packages/osc-ecommerce/app/components/ContentMedia/ContentMedia.tsx
@@ -1,40 +1,26 @@
 import mq from 'osc-design-tokens';
 import type { Columns } from 'osc-ui';
-import {
-    Carousel,
-    classNames,
-    Content,
-    ContentMedia,
-    ContentMediaBlock,
-    Image,
-    rem,
-    useSpacing,
-} from 'osc-ui';
+import { Carousel, Content, ContentMedia, ContentMediaBlock, Image, rem } from 'osc-ui';
 import type { contentMediaModule, contentMediaSlide, formModule } from '~/types/sanity';
 import { Forms } from '../Forms/Forms';
+import { Row } from '../Row';
 
 const perView = (perView: number | undefined) => (perView ? perView : 1);
 
 export const ContentMediaModule = (props: { module: contentMediaModule; isFlush?: boolean }) => {
-    const { carouselName, carouselSettings, marginBottom, paddingBottom, paddingTop, slides } =
-        props.module;
+    const { carouselName, carouselSettings, rowSettings, slides } = props.module;
     const { isFlush } = props;
-
-    const marginBottomClass = useSpacing('margin', 'bottom', marginBottom);
-    const paddingTopClass = useSpacing('padding', 'top', paddingTop);
-    const paddingBottomClass = useSpacing('padding', 'bottom', paddingBottom);
-
-    const classes = classNames(
-        'o-container',
-        isFlush ? 'o-container--flush' : '',
-        marginBottomClass,
-        paddingTopClass,
-        paddingBottomClass
-    );
+    const containerIsFull = rowSettings?.container === 'full';
 
     if (slides.length > 1) {
         return (
-            <div className={classes}>
+            <Row
+                backgroundColor={rowSettings?.backgroundColor}
+                marginBottom={rowSettings?.marginBottom}
+                paddingBottom={rowSettings?.paddingBottom}
+                paddingTop={rowSettings?.paddingTop}
+                container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+            >
                 <Carousel
                     carouselName={carouselName ? carouselName : 'content media carousel'}
                     arrows={carouselSettings?.arrows}
@@ -64,13 +50,19 @@ export const ContentMediaModule = (props: { module: contentMediaModule; isFlush?
                         <Slide {...slide} key={slide?._key} />
                     ))}
                 </Carousel>
-            </div>
+            </Row>
         );
     } else {
         return (
-            <div className={classes}>
+            <Row
+                backgroundColor={rowSettings?.backgroundColor}
+                marginBottom={rowSettings?.marginBottom}
+                paddingBottom={rowSettings?.paddingBottom}
+                paddingTop={rowSettings?.paddingTop}
+                container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+            >
                 <Slide {...slides[0]} />
-            </div>
+            </Row>
         );
     }
 };

--- a/packages/osc-ecommerce/app/components/ContentMedia/mockContentMediaData.tsx
+++ b/packages/osc-ecommerce/app/components/ContentMedia/mockContentMediaData.tsx
@@ -5,6 +5,7 @@ export const contentMediaData: contentMediaModule = {
     _type: 'module.contentMedia',
     carouselName: 'Content media carousel',
     carouselSettings: {
+        carouselName: 'Content media carousel',
         _type: 'carouselSettings',
         arrows: false,
         dotNav: true,
@@ -16,17 +17,19 @@ export const contentMediaData: contentMediaModule = {
         },
         startIndex: 1,
     },
-    layout: null,
-    marginBottom: 'l',
-    paddingBottom: null,
-    paddingTop: null,
+    rowSettings: {
+        backgroundColor: undefined,
+        marginBottom: undefined,
+        paddingBottom: undefined,
+        paddingTop: undefined,
+        container: 'default',
+    },
     slides: [
         {
             _key: '9c0a7176365c',
             _type: 'contentMediaSlide',
             content: {
                 _key: null,
-                backgroundColor: null,
                 body: [
                     {
                         _key: '00074647ee36',
@@ -219,11 +222,14 @@ export const contentMediaData: contentMediaModule = {
                         variant: 'secondary',
                     },
                 ],
-                fullWidth: false,
                 horizontalAlignment: 'left',
-                marginBottom: null,
-                paddingBottom: null,
-                paddingTop: null,
+                rowSettings: {
+                    backgroundColor: undefined,
+                    marginBottom: undefined,
+                    paddingBottom: undefined,
+                    paddingTop: undefined,
+                    container: 'default',
+                },
             },
             contentAlignment: 'center',
             layoutDirection: 'content-media',
@@ -231,6 +237,7 @@ export const contentMediaData: contentMediaModule = {
             media: {
                 carouselName: null,
                 carouselSettings: {
+                    carouselName: null,
                     _type: 'carouselSettings',
                     arrows: false,
                     dotNav: true,
@@ -263,7 +270,6 @@ export const contentMediaData: contentMediaModule = {
             _type: 'contentMediaSlide',
             content: {
                 _key: null,
-                backgroundColor: null,
                 body: [
                     {
                         _key: '00074647ee36',
@@ -456,11 +462,14 @@ export const contentMediaData: contentMediaModule = {
                         variant: 'secondary',
                     },
                 ],
-                fullWidth: false,
                 horizontalAlignment: 'left',
-                marginBottom: null,
-                paddingBottom: null,
-                paddingTop: null,
+                rowSettings: {
+                    backgroundColor: undefined,
+                    marginBottom: undefined,
+                    paddingBottom: undefined,
+                    paddingTop: undefined,
+                    container: 'default',
+                },
             },
             contentAlignment: 'center',
             layoutDirection: 'content-media',
@@ -468,6 +477,7 @@ export const contentMediaData: contentMediaModule = {
             media: {
                 carouselName: null,
                 carouselSettings: {
+                    carouselName: null,
                     _type: 'carouselSettings',
                     arrows: false,
                     dotNav: true,
@@ -503,6 +513,7 @@ export const contentMediaDataSingle: contentMediaModule = {
     _type: 'module.contentMedia',
     carouselName: 'Content media test',
     carouselSettings: {
+        carouselName: 'Content media test',
         _type: 'carouselSettings',
         arrows: false,
         dotNav: true,
@@ -514,17 +525,19 @@ export const contentMediaDataSingle: contentMediaModule = {
         },
         startIndex: 1,
     },
-    layout: null,
-    marginBottom: 'l',
-    paddingBottom: null,
-    paddingTop: null,
+    rowSettings: {
+        backgroundColor: undefined,
+        marginBottom: undefined,
+        paddingBottom: undefined,
+        paddingTop: undefined,
+        container: 'default',
+    },
     slides: [
         {
             _key: '9c0a7176365c',
             _type: 'contentMediaSlide',
             content: {
                 _key: null,
-                backgroundColor: null,
                 body: [
                     {
                         _key: '00074647ee36',
@@ -717,11 +730,14 @@ export const contentMediaDataSingle: contentMediaModule = {
                         variant: 'secondary',
                     },
                 ],
-                fullWidth: false,
                 horizontalAlignment: 'left',
-                marginBottom: null,
-                paddingBottom: null,
-                paddingTop: null,
+                rowSettings: {
+                    backgroundColor: undefined,
+                    marginBottom: undefined,
+                    paddingBottom: undefined,
+                    paddingTop: undefined,
+                    container: 'default',
+                },
             },
             contentAlignment: 'center',
             layoutDirection: 'content-media',
@@ -729,6 +745,7 @@ export const contentMediaDataSingle: contentMediaModule = {
             media: {
                 carouselName: null,
                 carouselSettings: {
+                    carouselName: null,
                     _type: 'carouselSettings',
                     arrows: false,
                     dotNav: true,

--- a/packages/osc-ecommerce/app/components/Forms/Forms.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/Forms.tsx
@@ -1,5 +1,5 @@
 import { useFetcher, useLoaderData } from '@remix-run/react';
-import { Alert, classNames, useSpacing } from 'osc-ui';
+import { Alert } from 'osc-ui';
 import type { Dispatch } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import type { z } from 'zod';
@@ -93,9 +93,9 @@ const Form = (props: FormProps) => {
     );
 };
 
-export const Forms = (props: { module: formModule; addContainer?: boolean }) => {
+export const Forms = (props: { module: formModule }) => {
     // Module data coming from Sanity
-    const { module, addContainer = false } = props;
+    const { module } = props;
     // Data coming back when the form has been submitted - e.g. transition state and any server errors
     const fetcher = useFetcher();
     const data = fetcher.data;
@@ -115,10 +115,6 @@ export const Forms = (props: { module: formModule; addContainer?: boolean }) => 
     const { isAdding, isSubmitting } = transitionStates(fetcher);
 
     const formRef = useRef<HTMLFormElement>(null);
-
-    const marginBottomClass = useSpacing('margin', 'bottom', module.marginBottom);
-    const paddingTopClass = useSpacing('padding', 'top', module.paddingTop);
-    const paddingBottomClass = useSpacing('padding', 'bottom', module.paddingBottom);
 
     useEffect(() => {
         // Reset the form when form has finished submitting there is a success response
@@ -150,12 +146,6 @@ export const Forms = (props: { module: formModule; addContainer?: boolean }) => 
         return <Alert status="error">Unable to load form!</Alert>;
     }
 
-    const classes = classNames(
-        addContainer ? 'c-form o-container' : 'c-form',
-        marginBottomClass,
-        paddingTopClass,
-        paddingBottomClass
-    );
     // Get the form data that matches module formId
     const formData = hubspotFormData[module.formId] as HubspotFormData;
 
@@ -163,22 +153,20 @@ export const Forms = (props: { module: formModule; addContainer?: boolean }) => 
     type FlattenedErrors = z.inferFlattenedErrors<typeof schema>;
 
     return (
-        <div className={classes}>
-            <fetcher.Form action="/actions/hubspot" method="post" ref={formRef} noValidate>
-                <Form
-                    form={module}
-                    formErrors={formErrors}
-                    formFieldGroups={formData.formFieldGroups}
-                    isSubmitting={isSubmitting}
-                    key={key}
-                    setValidationErrors={setValidationErrors}
-                    styles={JSON.parse(formData.style)}
-                    submitText={formData.submitText}
-                    successContent={successContent}
-                    themeName={formData.themeName}
-                    validationErrors={validationErrors}
-                />
-            </fetcher.Form>
-        </div>
+        <fetcher.Form action="/actions/hubspot" method="post" ref={formRef} noValidate>
+            <Form
+                form={module}
+                formErrors={formErrors}
+                formFieldGroups={formData.formFieldGroups}
+                isSubmitting={isSubmitting}
+                key={key}
+                setValidationErrors={setValidationErrors}
+                styles={JSON.parse(formData.style)}
+                submitText={formData.submitText}
+                successContent={successContent}
+                themeName={formData.themeName}
+                validationErrors={validationErrors}
+            />
+        </fetcher.Form>
     );
 };

--- a/packages/osc-ecommerce/app/components/Forms/FormsModule.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/FormsModule.tsx
@@ -14,9 +14,9 @@ export const FormsModule = (props: FormsModuleProps) => {
     return (
         <Row
             backgroundColor={module.rowSettings?.backgroundColor}
-            marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
-            paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
-            paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
             container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
             <Forms module={module} />

--- a/packages/osc-ecommerce/app/components/Forms/FormsModule.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/FormsModule.tsx
@@ -1,0 +1,25 @@
+import type { formModule } from '~/types/sanity';
+import { Row } from '../Row';
+import { Forms } from './Forms';
+
+interface FormsModuleProps {
+    module: formModule;
+    isFlush?: boolean;
+}
+
+export const FormsModule = (props: FormsModuleProps) => {
+    const { module, isFlush } = props;
+    const containerIsFull = module.rowSettings?.container === 'full';
+
+    return (
+        <Row
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
+            paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+        >
+            <Forms module={module} />
+        </Row>
+    );
+};

--- a/packages/osc-ecommerce/app/components/Hero/mockHeroData.tsx
+++ b/packages/osc-ecommerce/app/components/Hero/mockHeroData.tsx
@@ -1,11 +1,11 @@
 export const heroCarousel = {
     _type: 'module.hero',
     _key: '4274e830c3e5',
+    carouselName: 'Hero Carousel',
     carouselSettings: {
         _type: 'carouselSettings',
         arrows: false,
         autoplay: 'switch',
-        carouselName: 'Hero Carousel',
         dotNav: true,
         loop: true,
         slidesPerView: {

--- a/packages/osc-ecommerce/app/components/Image/Image.tsx
+++ b/packages/osc-ecommerce/app/components/Image/Image.tsx
@@ -1,0 +1,35 @@
+import { Image } from 'osc-ui';
+import type { imageModule } from '~/types/sanity';
+import { Row } from '../Row';
+
+interface ImageModuleProps {
+    module: imageModule<HTMLImageElement>;
+    isFlush?: boolean;
+}
+
+export const ImageModule = (props: ImageModuleProps) => {
+    const { module, isFlush } = props;
+    const containerIsFull = module.rowSettings?.container === 'full';
+
+    return (
+        <Row
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+        >
+            <Image
+                key={module._key}
+                src={module.src}
+                artDirectedImages={module.responsiveImages ? module.responsiveImages : undefined}
+                alt={module.alt}
+                width={module.width}
+                height={module.height}
+                overlayColor={module?.imageStyles?.overlayColor}
+                isGrayScale={module?.imageStyles?.grayscale}
+                hasTransparency={module?.imageStyles?.opacity}
+            />
+        </Row>
+    );
+};

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -1,5 +1,5 @@
 import type { LinkDescriptor } from '@remix-run/node';
-import { Image, Trustpilot } from 'osc-ui';
+import { Trustpilot } from 'osc-ui';
 import oscUiAccordionStyles from 'osc-ui/dist/src-components-Accordion-accordion.css';
 import alertStyles from 'osc-ui/dist/src-components-Alert-alert.css';
 import buttonStyles from 'osc-ui/dist/src-components-Button-button.css';
@@ -48,6 +48,7 @@ import { ContentModule } from './Content/Content';
 import { ContentMediaModule } from './ContentMedia/ContentMedia';
 import { FormsModule } from './Forms/FormsModule';
 import { Hero } from './Hero/Hero';
+import { ImageModule } from './Image/Image';
 import { RecommendedProducts } from './RecommendedProducts/RecommendedProducts';
 import { TabsModule } from './Tabs/Tabs';
 import { TextGridModule } from './TextGrid/TextGrid';
@@ -250,21 +251,7 @@ export default function Module(props: Props) {
         case 'module.images':
             const moduleImage = module as imageModule<HTMLImageElement>;
 
-            return (
-                <Image
-                    key={moduleImage._key}
-                    src={moduleImage.src}
-                    artDirectedImages={
-                        moduleImage.responsiveImages ? moduleImage.responsiveImages : undefined
-                    }
-                    alt={moduleImage.alt}
-                    width={moduleImage.width}
-                    height={moduleImage.height}
-                    overlayColor={moduleImage?.imageStyles?.overlayColor}
-                    isGrayScale={moduleImage?.imageStyles?.grayscale}
-                    hasTransparency={moduleImage?.imageStyles?.opacity}
-                />
-            );
+            return <ImageModule module={moduleImage} isFlush={isFlush} key={moduleImage._key} />;
 
         case 'module.textGrid':
             const moduleTextGrid = module as textGridModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -270,7 +270,11 @@ export default function Module(props: Props) {
             const moduleTextGrid = module as textGridModule;
 
             return (
-                <TextGridModule data={moduleTextGrid} isFlush={isFlush} key={moduleTextGrid._key} />
+                <TextGridModule
+                    module={moduleTextGrid}
+                    isFlush={isFlush}
+                    key={moduleTextGrid._key}
+                />
             );
 
         case 'module.video':

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -280,7 +280,9 @@ export default function Module(props: Props) {
         case 'module.video':
             const moduleVideo = module as videoModule;
 
-            return <VideoPlayerModule module={moduleVideo} key={moduleVideo._key} />;
+            return (
+                <VideoPlayerModule module={moduleVideo} isFlush={isFlush} key={moduleVideo._key} />
+            );
 
         case 'module.tabs':
             const moduleTabs = module as tabsModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -215,7 +215,7 @@ export default function Module(props: Props) {
 
         case 'module.cards':
             const moduleCard = module as cardModule;
-            return <Cards module={moduleCard} />;
+            return <Cards module={moduleCard} isFlush={isFlush} />;
 
         case 'module.carousel':
             const moduleCarousel = module as carouselModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -220,7 +220,7 @@ export default function Module(props: Props) {
         case 'module.carousel':
             const moduleCarousel = module as carouselModule;
 
-            return <CarouselModule module={moduleCarousel} />;
+            return <CarouselModule module={moduleCarousel} isFlush={isFlush} />;
 
         case 'module.content':
             const moduleContent = module as contentModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -46,7 +46,7 @@ import { Cards } from './Cards/Cards';
 import { CarouselModule } from './Carousel/Carousel';
 import { ContentModule } from './Content/Content';
 import { ContentMediaModule } from './ContentMedia/ContentMedia';
-import { Forms } from './Forms/Forms';
+import { FormsModule } from './Forms/FormsModule';
 import { Hero } from './Hero/Hero';
 import { RecommendedProducts } from './RecommendedProducts/RecommendedProducts';
 import { TabsModule } from './Tabs/Tabs';
@@ -229,7 +229,7 @@ export default function Module(props: Props) {
 
         case 'module.forms':
             const moduleForm = module as formModule;
-            return <Forms addContainer={true} module={moduleForm} key={moduleForm._key} />;
+            return <FormsModule module={moduleForm} isFlush={isFlush} key={moduleForm._key} />;
 
         case 'module.hero':
             const moduleHero = module as heroModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -200,7 +200,13 @@ export default function Module(props: Props) {
         case 'module.accordion':
             const moduleAccordion = module as accordionModule;
 
-            return <AccordionModule module={moduleAccordion} isFlush={isFlush} />;
+            return (
+                <AccordionModule
+                    module={moduleAccordion}
+                    isFlush={isFlush}
+                    key={moduleAccordion._key}
+                />
+            );
 
         case 'module.trustpilot':
             const moduleTrustpilot = module as trustpilotModule;
@@ -216,17 +222,26 @@ export default function Module(props: Props) {
 
         case 'module.cards':
             const moduleCard = module as cardModule;
-            return <Cards module={moduleCard} isFlush={isFlush} />;
+
+            return <Cards module={moduleCard} isFlush={isFlush} key={moduleCard._key} />;
 
         case 'module.carousel':
             const moduleCarousel = module as carouselModule;
 
-            return <CarouselModule module={moduleCarousel} isFlush={isFlush} />;
+            return (
+                <CarouselModule
+                    module={moduleCarousel}
+                    isFlush={isFlush}
+                    key={moduleCarousel._key}
+                />
+            );
 
         case 'module.content':
             const moduleContent = module as contentModule;
 
-            return <ContentModule module={moduleContent} isFlush={isFlush} />;
+            return (
+                <ContentModule module={moduleContent} isFlush={isFlush} key={moduleContent._key} />
+            );
 
         case 'module.forms':
             const moduleForm = module as formModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -281,7 +281,7 @@ export default function Module(props: Props) {
         case 'module.tabs':
             const moduleTabs = module as tabsModule;
 
-            return <TabsModule module={moduleTabs} key={moduleTabs._key} />;
+            return <TabsModule module={moduleTabs} isFlush={isFlush} key={moduleTabs._key} />;
 
         case 'module.recommendedProducts':
             const moduleRecommendedProducts = module as recommendedProductsModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -199,7 +199,7 @@ export default function Module(props: Props) {
         case 'module.accordion':
             const moduleAccordion = module as accordionModule;
 
-            return <AccordionModule module={moduleAccordion} />;
+            return <AccordionModule module={moduleAccordion} isFlush={isFlush} />;
 
         case 'module.trustpilot':
             const moduleTrustpilot = module as trustpilotModule;

--- a/packages/osc-ecommerce/app/components/Module.tsx
+++ b/packages/osc-ecommerce/app/components/Module.tsx
@@ -1,5 +1,5 @@
 import type { LinkDescriptor } from '@remix-run/node';
-import { Content, Image, Trustpilot } from 'osc-ui';
+import { Image, Trustpilot } from 'osc-ui';
 import oscUiAccordionStyles from 'osc-ui/dist/src-components-Accordion-accordion.css';
 import alertStyles from 'osc-ui/dist/src-components-Alert-alert.css';
 import buttonStyles from 'osc-ui/dist/src-components-Button-button.css';
@@ -44,6 +44,7 @@ import { getUniqueObjects } from '~/utils/getUniqueObjects';
 import { AccordionModule } from './Accordion/Accordion';
 import { Cards } from './Cards/Cards';
 import { CarouselModule } from './Carousel/Carousel';
+import { ContentModule } from './Content/Content';
 import { ContentMediaModule } from './ContentMedia/ContentMedia';
 import { Forms } from './Forms/Forms';
 import { Hero } from './Hero/Hero';
@@ -224,30 +225,7 @@ export default function Module(props: Props) {
         case 'module.content':
             const moduleContent = module as contentModule;
 
-            return moduleContent.body ? (
-                <article
-                    className={`o-container ${
-                        isFlush || moduleContent.fullWidth
-                            ? 'o-container--flush o-container--full'
-                            : ''
-                    }`}
-                >
-                    <Content
-                        align={moduleContent.horizontalAlignment}
-                        backgroundColor={
-                            moduleContent.backgroundColor
-                                ? moduleContent.backgroundColor
-                                : undefined
-                        }
-                        marginBottom={moduleContent.marginBottom}
-                        paddingBottom={moduleContent.paddingBottom}
-                        paddingTop={moduleContent.paddingTop}
-                        value={moduleContent.body}
-                        fullWidth={moduleContent.fullWidth ? moduleContent.fullWidth : undefined}
-                        buttons={moduleContent.buttons}
-                    />
-                </article>
-            ) : null;
+            return <ContentModule module={moduleContent} isFlush={isFlush} />;
 
         case 'module.forms':
             const moduleForm = module as formModule;

--- a/packages/osc-ecommerce/app/components/RecommendedProducts/RecommendedProducts.spec.tsx
+++ b/packages/osc-ecommerce/app/components/RecommendedProducts/RecommendedProducts.spec.tsx
@@ -7,10 +7,13 @@ import { mockProductData } from './mockProductData';
 
 const module: recommendedProductsModule = {
     heading: 'You may also like',
-    backgroundColor: 'neutral-300',
-    marginBottom: 'l',
-    paddingTop: 'l',
-    paddingBottom: 'l',
+    rowSettings: {
+        backgroundColor: undefined,
+        marginBottom: 'l',
+        paddingBottom: 'l',
+        paddingTop: 'l',
+        container: 'default',
+    },
     numberOfProducts: 4,
     carouselSettings: {
         carouselName: 'Recommended Products',

--- a/packages/osc-ecommerce/app/components/RecommendedProducts/RecommendedProducts.spec.tsx
+++ b/packages/osc-ecommerce/app/components/RecommendedProducts/RecommendedProducts.spec.tsx
@@ -8,7 +8,7 @@ import { mockProductData } from './mockProductData';
 const module: recommendedProductsModule = {
     heading: 'You may also like',
     rowSettings: {
-        backgroundColor: undefined,
+        backgroundColor: 'neutral-300',
         marginBottom: 'l',
         paddingBottom: 'l',
         paddingTop: 'l',

--- a/packages/osc-ecommerce/app/components/RecommendedProducts/RecommendedProducts.tsx
+++ b/packages/osc-ecommerce/app/components/RecommendedProducts/RecommendedProducts.tsx
@@ -1,73 +1,74 @@
 import { mediaQueries as mq } from 'osc-design-tokens';
-import { Carousel, classNames, rem } from 'osc-ui';
+import { Carousel, rem } from 'osc-ui';
 import { CourseCard } from '~/components/Cards/CourseCard';
 import { useRecommendedProducts } from '~/hooks/useRecommendedProducts';
 import type { recommendedProductsModule } from '~/types/sanity';
+import { Row } from '../Row';
 
-export const RecommendedProducts = (props: { module: recommendedProductsModule }) => {
-    const { module } = props;
+interface RecommendedProductsProps {
+    module: recommendedProductsModule;
+    isFlush?: boolean;
+}
+
+export const RecommendedProducts = (props: RecommendedProductsProps) => {
+    const { module, isFlush } = props;
     const products = useRecommendedProducts();
+
+    const containerIsFull = module.rowSettings?.container === 'full';
 
     if (products && module.numberOfProducts) {
         products.length = module.numberOfProducts;
     }
 
-    const classes = classNames(
-        module?.backgroundColor ? `u-bg-color-${module?.backgroundColor}` : '',
-        module?.marginBottom ? `u-mb-${module.marginBottom}` : '',
-        module?.paddingTop ? `u-pt-${module.paddingTop}` : '',
-        module?.paddingBottom ? `u-pb-${module.paddingBottom}` : ''
-    );
-
     const perView = (perView: number | undefined) => (perView ? perView : 1);
 
     return (
-        <article className={classes}>
-            <div className="o-container">
-                <h2 className="t-font-l u-text-bold u-mb-l">
-                    {module?.heading ? module?.heading : 'You may also like'}
-                </h2>
+        <Row
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+        >
+            <h2 className="t-font-l u-text-bold u-mb-l">
+                {module?.heading ? module?.heading : 'You may also like'}
+            </h2>
 
-                {products && products.length > 0 ? (
-                    <Carousel
-                        carouselName="Recommended Products"
-                        arrows={module?.carouselSettings?.arrows}
-                        dotNav={module?.carouselSettings?.dotNav}
-                        loop={module?.carouselSettings?.loop}
-                        autoplay={module?.carouselSettings?.autoplay}
-                        slidesPerView={perView(module?.carouselSettings?.slidesPerView?.mobile)}
-                        startIndex={
-                            module?.carouselSettings?.startIndex
-                                ? module?.carouselSettings?.startIndex - 1
-                                : 0
-                        } // minus 1 so cms users can start at 1
-                        breakpoints={{
-                            [`(min-width: ${rem(mq['tab'])}rem)`]: {
-                                slides: {
-                                    origin: 'auto',
-                                    perView: perView(
-                                        module?.carouselSettings?.slidesPerView?.tablet
-                                    ),
-                                    spacing: 16,
-                                },
+            {products && products.length > 0 ? (
+                <Carousel
+                    carouselName="Recommended Products"
+                    arrows={module?.carouselSettings?.arrows}
+                    dotNav={module?.carouselSettings?.dotNav}
+                    loop={module?.carouselSettings?.loop}
+                    autoplay={module?.carouselSettings?.autoplay}
+                    slidesPerView={perView(module?.carouselSettings?.slidesPerView?.mobile)}
+                    startIndex={
+                        module?.carouselSettings?.startIndex
+                            ? module?.carouselSettings?.startIndex - 1
+                            : 0
+                    } // minus 1 so cms users can start at 1
+                    breakpoints={{
+                        [`(min-width: ${rem(mq['tab'])}rem)`]: {
+                            slides: {
+                                origin: 'auto',
+                                perView: perView(module?.carouselSettings?.slidesPerView?.tablet),
+                                spacing: 16,
                             },
-                            [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
-                                slides: {
-                                    origin: 'auto',
-                                    perView: perView(
-                                        module?.carouselSettings?.slidesPerView?.desktop
-                                    ),
-                                    spacing: 16,
-                                },
+                        },
+                        [`(min-width: ${rem(mq['desk-lrg'])}rem)`]: {
+                            slides: {
+                                origin: 'auto',
+                                perView: perView(module?.carouselSettings?.slidesPerView?.desktop),
+                                spacing: 16,
                             },
-                        }}
-                    >
-                        {products.map((product) => (
-                            <CourseCard key={product.id} product={product} />
-                        ))}
-                    </Carousel>
-                ) : null}
-            </div>
-        </article>
+                        },
+                    }}
+                >
+                    {products.map((product) => (
+                        <CourseCard key={product.id} product={product} />
+                    ))}
+                </Carousel>
+            ) : null}
+        </Row>
     );
 };

--- a/packages/osc-ecommerce/app/components/Row.tsx
+++ b/packages/osc-ecommerce/app/components/Row.tsx
@@ -59,10 +59,10 @@ export const Row = (props: RowProps) => {
 
     const classes = classNames(
         'o-row',
+        marginBottom ? `o-row--${marginBottom}` : '',
+        paddingTop ? `u-pt-${paddingTop}` : 'u-pt-2xl',
+        paddingBottom ? `u-pb-${paddingBottom}` : 'u-pb-2xl',
         backgroundColor ? `u-bg-color-${backgroundColor}` : '',
-        paddingTop ? `u-pt-${paddingTop}` : '',
-        paddingBottom ? `u-pb-${paddingBottom}` : '',
-        marginBottom ? `u-mb-${marginBottom}` : '',
         className
     );
 

--- a/packages/osc-ecommerce/app/components/Row.tsx
+++ b/packages/osc-ecommerce/app/components/Row.tsx
@@ -1,0 +1,78 @@
+import { Slot } from '@radix-ui/react-slot';
+import type { Maybe } from 'graphql/jsutils/Maybe';
+import { classNames } from 'osc-ui';
+import type { Spacing, Themes } from 'osc-ui/src/types';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+/* -------------------------------------------------------------------------------------------------
+ * Row
+ * A structural element that allows containerisation of objects and components while also
+ * applying vertical rhythym of said components. Grid elements can be used within the row object.
+ * -----------------------------------------------------------------------------------------------*/
+
+interface RowProps extends ComponentPropsWithoutRef<'div'> {
+    /**
+     * Merges its props onto its immediate child
+     */
+    asChild?: boolean;
+    /**
+     * The content of the component
+     */
+    children: ReactNode;
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    className?: string;
+    /**
+     * The background color of the row
+     */
+    backgroundColor?: Maybe<Themes>;
+    /**
+     * The bottom margin of the row
+     */
+    marginBottom?: Maybe<Spacing>;
+    /**
+     * The bottom padding of the row
+     */
+    paddingBottom?: Maybe<Spacing>;
+    /**
+     * The top padding of the row
+     */
+    paddingTop?: Maybe<Spacing>;
+    /**
+     * Control the container size
+     */
+    container?: Maybe<string>;
+}
+
+export const Row = (props: RowProps) => {
+    const {
+        asChild,
+        children,
+        className = '',
+        backgroundColor,
+        marginBottom,
+        paddingBottom,
+        paddingTop,
+        container,
+    } = props;
+
+    const classes = classNames(
+        'o-row',
+        backgroundColor ? `u-bg-color-${backgroundColor}` : '',
+        paddingTop ? `u-pt-${paddingTop}` : '',
+        paddingBottom ? `u-pb-${paddingBottom}` : '',
+        marginBottom ? `u-mb-${marginBottom}` : '',
+        className
+    );
+
+    const containerClasses = classNames('o-container', container ? container : '');
+
+    const Component = asChild ? Slot : 'div';
+
+    return (
+        <article className={classes}>
+            <Component className={containerClasses}>{children}</Component>
+        </article>
+    );
+};

--- a/packages/osc-ecommerce/app/components/Row.tsx
+++ b/packages/osc-ecommerce/app/components/Row.tsx
@@ -7,7 +7,7 @@ import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 /* -------------------------------------------------------------------------------------------------
  * Row
  * A structural element that allows containerisation of objects and components while also
- * applying vertical rhythym of said components. Grid elements can be used within the row object.
+ * applying vertical rhythm of said components. Grid elements can be used within the row object.
  * -----------------------------------------------------------------------------------------------*/
 
 interface RowProps extends ComponentPropsWithoutRef<'div'> {

--- a/packages/osc-ecommerce/app/components/Tabs/Tabs.spec.tsx
+++ b/packages/osc-ecommerce/app/components/Tabs/Tabs.spec.tsx
@@ -10,7 +10,7 @@ const setup = () => {
     return (
         <MemoryRouter>
             <SpritesheetProvider>
-                <TabsModule module={mockTabData as tabsModule} />
+                <TabsModule module={mockTabData as unknown as tabsModule} />
             </SpritesheetProvider>
         </MemoryRouter>
     );

--- a/packages/osc-ecommerce/app/components/Tabs/Tabs.tsx
+++ b/packages/osc-ecommerce/app/components/Tabs/Tabs.tsx
@@ -8,28 +8,26 @@ import {
     TabList,
     TabTrigger,
     Tabs,
-    classNames,
     rem,
     useMediaQuery,
 } from 'osc-ui';
 import { useEffect, useState } from 'react';
 import type { module, tabsModule } from '~/types/sanity';
 import Module from '../Module';
+import { Row } from '../Row';
 
-export const TabsModule = (props: { module: tabsModule }) => {
-    const { module } = props;
+interface TabsModuleProps {
+    module: tabsModule;
+    isFlush?: boolean;
+}
+
+export const TabsModule = (props: TabsModuleProps) => {
+    const { module, isFlush } = props;
+
+    const containerIsFull = module.rowSettings?.container === 'full';
 
     const isGreaterThanMobL = useMediaQuery(`(min-width: ${rem(mq['mob-lrg'])}rem)`);
     const [showOnGreaterThanMobL, setShowOnGreaterThanMobL] = useState<boolean>(false);
-
-    const classes = classNames(
-        'o-container',
-        module?.marginBottom ? `u-mb-${module.marginBottom}` : '',
-        module?.paddingTop ? `u-pt-${module.paddingTop}` : '',
-        module?.paddingRight ? `u-pr-${module.paddingRight}` : '',
-        module?.paddingBottom ? `u-pb-${module.paddingBottom}` : '',
-        module?.paddingLeft ? `u-pl-${module.paddingLeft}` : ''
-    );
 
     // We need this useEffect to set the showOnTab state only when the window object exists
     // Otherwise we will receive an SSR warning telling us the markup differs from the server
@@ -38,7 +36,13 @@ export const TabsModule = (props: { module: tabsModule }) => {
     }, [isGreaterThanMobL]);
 
     return module?.tabItem && module?.tabItem?.length > 0 ? (
-        <div className={classes}>
+        <Row
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
+        >
             {showOnGreaterThanMobL ? (
                 <Tabs defaultValue={module?.tabItem[0]._key}>
                     <TabList>
@@ -71,6 +75,6 @@ export const TabsModule = (props: { module: tabsModule }) => {
                     ))}
                 </Accordion>
             )}
-        </div>
+        </Row>
     ) : null;
 };

--- a/packages/osc-ecommerce/app/components/Tabs/mockTabData.ts
+++ b/packages/osc-ecommerce/app/components/Tabs/mockTabData.ts
@@ -1,11 +1,13 @@
 export const mockTabData = {
     _key: '82737e907e7c',
     _type: 'module.tabs',
-    marginBottom: '6xl',
-    paddingBottom: null,
-    paddingLeft: null,
-    paddingRight: null,
-    paddingTop: null,
+    rowSettings: {
+        backgroundColor: undefined,
+        marginBottom: undefined,
+        paddingBottom: undefined,
+        paddingTop: undefined,
+        container: 'default',
+    },
     tabItem: [
         {
             _key: '04cb18ee7027',

--- a/packages/osc-ecommerce/app/components/TextGrid/TextGrid.tsx
+++ b/packages/osc-ecommerce/app/components/TextGrid/TextGrid.tsx
@@ -15,9 +15,9 @@ export const TextGridModule = (props: TextGridModuleProps) => {
     return (
         <Row
             backgroundColor={module.rowSettings?.backgroundColor}
-            marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
-            paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
-            paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
             container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
             <TextGrid heading={module?.heading} hasInlineHeading={module?.hasInlineHeading}>
@@ -25,16 +25,11 @@ export const TextGridModule = (props: TextGridModuleProps) => {
                     <Fragment key={item?._key}>
                         {item?.icon ? <Icon id={item?.icon} /> : null}
 
-                        {item?.content?.body ? (
+                        {item.content?.body ? (
                             <Content
-                                value={item?.content?.body}
-                                align={item?.content?.horizontalAlignment}
-                                backgroundColor={
-                                    item?.content?.backgroundColor
-                                        ? item?.content?.backgroundColor
-                                        : undefined
-                                }
-                                {...item?.content}
+                                align={item.content?.horizontalAlignment}
+                                value={item.content?.body}
+                                buttons={item.content?.buttons}
                             />
                         ) : null}
                     </Fragment>

--- a/packages/osc-ecommerce/app/components/TextGrid/TextGrid.tsx
+++ b/packages/osc-ecommerce/app/components/TextGrid/TextGrid.tsx
@@ -1,45 +1,45 @@
-import { classNames, Content, Icon, TextGrid, useSpacing } from 'osc-ui';
+import { Content, Icon, TextGrid } from 'osc-ui';
 import { Fragment } from 'react';
 import type { textGridModule } from '~/types/sanity';
+import { Row } from '../Row';
 
-export const TextGridModule = (props: { data: textGridModule; isFlush?: boolean }) => {
-    const { data, isFlush } = props;
-    const marginBottomClass = useSpacing('margin', 'bottom', data?.marginBottom);
-    const paddingTopClass = useSpacing('padding', 'top', data?.paddingTop);
-    const paddingBottomClass = useSpacing('padding', 'bottom', data?.paddingBottom);
+interface TextGridModuleProps {
+    module: textGridModule;
+    isFlush?: boolean;
+}
 
-    const classes = classNames(
-        'o-container',
-        isFlush ? 'o-container--flush' : '',
-        marginBottomClass,
-        paddingTopClass,
-        paddingBottomClass
-    );
+export const TextGridModule = (props: TextGridModuleProps) => {
+    const { module, isFlush } = props;
+    const containerIsFull = module.rowSettings?.container === 'full';
 
     return (
-        <TextGrid
-            heading={data?.heading}
-            hasInlineHeading={data?.hasInlineHeading}
-            className={classes}
+        <Row
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom || module?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom || module?.paddingTop}
+            paddingTop={module.rowSettings?.paddingTop || module?.paddingBottom}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
-            {data?.items?.map((item) => (
-                <Fragment key={item?._key}>
-                    {item?.icon ? <Icon id={item?.icon} /> : null}
+            <TextGrid heading={module?.heading} hasInlineHeading={module?.hasInlineHeading}>
+                {module?.items?.map((item) => (
+                    <Fragment key={item?._key}>
+                        {item?.icon ? <Icon id={item?.icon} /> : null}
 
-                    {item?.content?.body ? (
-                        <Content
-                            value={item?.content?.body}
-                            align={item?.content?.horizontalAlignment}
-                            backgroundColor={
-                                item?.content?.backgroundColor
-                                    ? item?.content?.backgroundColor
-                                    : undefined
-                            }
-                            {...item?.content}
-                        />
-                    ) : null}
-                </Fragment>
-            ))}
-        </TextGrid>
+                        {item?.content?.body ? (
+                            <Content
+                                value={item?.content?.body}
+                                align={item?.content?.horizontalAlignment}
+                                backgroundColor={
+                                    item?.content?.backgroundColor
+                                        ? item?.content?.backgroundColor
+                                        : undefined
+                                }
+                                {...item?.content}
+                            />
+                        ) : null}
+                    </Fragment>
+                ))}
+            </TextGrid>
+        </Row>
     );
 };

--- a/packages/osc-ecommerce/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/osc-ecommerce/app/components/VideoPlayer/VideoPlayer.tsx
@@ -47,14 +47,11 @@ export const VideoPlayerModule = (props: Props) => {
                 }
                 iconPath={spritesheet}
             >
-                {module?.content?.body ? (
+                {module.content?.body ? (
                     <Content
-                        align={module?.content?.horizontalAlignment}
-                        backgroundColor={module?.content?.backgroundColor}
-                        marginBottom={module?.content?.marginBottom}
-                        paddingBottom={module?.content?.paddingBottom}
-                        paddingTop={module?.content?.paddingTop}
-                        value={module?.content?.body}
+                        align={module.content?.horizontalAlignment}
+                        value={module.content?.body}
+                        buttons={module.content?.buttons}
                     />
                 ) : null}
             </VideoPlayer>

--- a/packages/osc-ecommerce/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/osc-ecommerce/app/components/VideoPlayer/VideoPlayer.tsx
@@ -1,52 +1,63 @@
 import { Content, Image, VideoPlayer } from 'osc-ui';
 import spritesheet from 'osc-ui/dist/spritesheet.svg';
 import type { videoModule } from '~/types/sanity';
+import { Row } from '../Row';
 
 interface Props {
     module: videoModule;
+    isFlush?: boolean;
 }
 
 export const VideoPlayerModule = (props: Props) => {
-    const { module } = props;
+    const { module, isFlush } = props;
+    const containerIsFull = module.rowSettings?.container === 'full';
 
     return (
-        <VideoPlayer
-            key={module._key}
-            url={module?.videoUrl}
-            variant={module?.videoType}
-            autoplay={module?.videoSettings?.autoplay}
-            loop={module?.videoSettings?.loop}
-            preserveContent={module?.videoSettings?.preserveContent}
-            previewImage={
-                module?.videoImage?.src ? (
-                    <Image
-                        src={module?.videoImage?.src}
-                        artDirectedImages={
-                            module?.videoImage?.responsiveImages
-                                ? module?.videoImage?.responsiveImages
-                                : undefined
-                        }
-                        alt={module?.videoImage?.alt}
-                        width={module?.videoImage?.width}
-                        height={module?.videoImage?.height}
-                        overlayColor={module?.videoImage?.imageStyles?.overlayColor}
-                        isGrayScale={module?.videoImage?.imageStyles?.grayscale}
-                        hasTransparency={module?.videoImage?.imageStyles?.opacity}
-                    />
-                ) : undefined
-            }
-            iconPath={spritesheet}
+        <Row
+            backgroundColor={module.rowSettings?.backgroundColor}
+            marginBottom={module.rowSettings?.marginBottom}
+            paddingBottom={module.rowSettings?.paddingBottom}
+            paddingTop={module.rowSettings?.paddingTop}
+            container={isFlush || containerIsFull ? 'o-container--flush o-container--full' : ''}
         >
-            {module?.content?.body ? (
-                <Content
-                    align={module?.content?.horizontalAlignment}
-                    backgroundColor={module?.content?.backgroundColor}
-                    marginBottom={module?.content?.marginBottom}
-                    paddingBottom={module?.content?.paddingBottom}
-                    paddingTop={module?.content?.paddingTop}
-                    value={module?.content?.body}
-                />
-            ) : null}
-        </VideoPlayer>
+            <VideoPlayer
+                key={module._key}
+                url={module?.videoUrl}
+                variant={module?.videoType}
+                autoplay={module?.videoSettings?.autoplay}
+                loop={module?.videoSettings?.loop}
+                preserveContent={module?.videoSettings?.preserveContent}
+                previewImage={
+                    module?.videoImage?.src ? (
+                        <Image
+                            src={module?.videoImage?.src}
+                            artDirectedImages={
+                                module?.videoImage?.responsiveImages
+                                    ? module?.videoImage?.responsiveImages
+                                    : undefined
+                            }
+                            alt={module?.videoImage?.alt}
+                            width={module?.videoImage?.width}
+                            height={module?.videoImage?.height}
+                            overlayColor={module?.videoImage?.imageStyles?.overlayColor}
+                            isGrayScale={module?.videoImage?.imageStyles?.grayscale}
+                            hasTransparency={module?.videoImage?.imageStyles?.opacity}
+                        />
+                    ) : undefined
+                }
+                iconPath={spritesheet}
+            >
+                {module?.content?.body ? (
+                    <Content
+                        align={module?.content?.horizontalAlignment}
+                        backgroundColor={module?.content?.backgroundColor}
+                        marginBottom={module?.content?.marginBottom}
+                        paddingBottom={module?.content?.paddingBottom}
+                        paddingTop={module?.content?.paddingTop}
+                        value={module?.content?.body}
+                    />
+                ) : null}
+            </VideoPlayer>
+        </Row>
     );
 };

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/accordion.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/accordion.ts
@@ -1,5 +1,6 @@
 import groq from 'groq';
 import { MODULE_CONTENT } from './content';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_ACCORDION = groq`
     _key,
@@ -16,5 +17,6 @@ export const MODULE_ACCORDION = groq`
     },
     content {
         ${MODULE_CONTENT}
-    }
+    },
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/card.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/card.ts
@@ -3,6 +3,7 @@ import { PATHS } from '~/constants';
 import { LINK_EXTERNAL } from '../linkExternal';
 import { LINK_INTERNAL } from '../linkInternal';
 import { MODULE_IMAGES } from './images';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_CARDS = groq`
     ...,
@@ -86,6 +87,6 @@ export const MODULE_CARDS = groq`
             showSubHeading,
             subHeading
         },
-    }
-
+    },
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/carousel.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/carousel.ts
@@ -1,5 +1,6 @@
 import groq from 'groq';
 import { MODULE_IMAGES } from './images';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_CAROUSEL = groq`
     _key,
@@ -10,5 +11,6 @@ export const MODULE_CAROUSEL = groq`
             ${MODULE_IMAGES}
         }
     },
-    settings
+    settings,
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/content.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/content.ts
@@ -2,16 +2,11 @@ import groq from 'groq';
 import { IMAGE } from '../image';
 import { LINK_EXTERNAL } from '../linkExternal';
 import { LINK_INTERNAL } from '../linkInternal';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_CONTENT = groq`
     _key,
-    backgroundColor,
     horizontalAlignment,
-    marginBottom,
-    paddingBottom,
-    paddingTop,
-    paddingLeft,
-    paddingRight,
     fullWidth,
     body[] {
         ...,
@@ -37,5 +32,6 @@ export const MODULE_CONTENT = groq`
         (type == "external") => {
             ${LINK_EXTERNAL}
         }
-    }
+    },
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/contentMedia.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/contentMedia.ts
@@ -1,6 +1,7 @@
 import groq from 'groq';
 import { MODULE_CONTENT } from './content';
 import { MODULE_IMAGES } from './images';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_CONTENT_MEDIA = groq`
     _key,
@@ -41,5 +42,6 @@ export const MODULE_CONTENT_MEDIA = groq`
                 },
             }
         }
-    }
+    },
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/forms.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/forms.ts
@@ -1,4 +1,5 @@
 import groq from 'groq';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_FORMS = groq`
     _key,
@@ -8,4 +9,5 @@ export const MODULE_FORMS = groq`
     marginBottom,
     paddingBottom,
     paddingTop,
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/images.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/images.ts
@@ -1,4 +1,5 @@
 import groq from 'groq';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_IMAGES = groq`
     _key,
@@ -14,5 +15,6 @@ export const MODULE_IMAGES = groq`
         "width": image.width,
         "height": image.height,
     },
-    "imageStyles": image.imageStyles
+    "imageStyles": image.imageStyles,
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/recommendedProducts.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/recommendedProducts.ts
@@ -1,13 +1,11 @@
 import groq from 'groq';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_RECOMMENDED_PRODUCTS = groq`
     _key,
     _type,
-    backgroundColor,
-    paddingBottom,
-    paddingTop,
-    marginBottom,
     heading,
     numberOfProducts,
-    carouselSettings
+    carouselSettings,
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/rowSettings.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/rowSettings.ts
@@ -1,0 +1,12 @@
+import groq from 'groq';
+
+export const ROW_SETTINGS = groq`
+    settings {
+        _type,
+        backgroundColor,
+        paddingBottom,
+        paddingTop,
+        marginBottom,
+        container
+    }
+`;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/rowSettings.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/rowSettings.ts
@@ -1,7 +1,7 @@
 import groq from 'groq';
 
 export const ROW_SETTINGS = groq`
-    settings {
+    rowSettings {
         _type,
         backgroundColor,
         paddingBottom,

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/tabs.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/tabs.ts
@@ -1,5 +1,6 @@
 import groq from 'groq';
 import { CHILD_MODULES } from '../childModules';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_TABS = groq`
     _key,
@@ -8,8 +9,6 @@ export const MODULE_TABS = groq`
     marginBottom,
     paddingBottom,
     paddingTop,
-    paddingLeft,
-    paddingRight,
     tabItem[] {
         _type,
         _key,
@@ -18,5 +17,6 @@ export const MODULE_TABS = groq`
             _type,
             ${CHILD_MODULES}
         }
-    }
+    },
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/textGrid.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/textGrid.ts
@@ -1,5 +1,6 @@
 import groq from 'groq';
 import { MODULE_CONTENT } from './content';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_TEXT_GRID = groq`
     _key,
@@ -15,5 +16,6 @@ export const MODULE_TEXT_GRID = groq`
             ${MODULE_CONTENT}
         },
         icon,
-    }
+    },
+    ${ROW_SETTINGS},
 `;

--- a/packages/osc-ecommerce/app/queries/sanity/fragments/modules/video.ts
+++ b/packages/osc-ecommerce/app/queries/sanity/fragments/modules/video.ts
@@ -1,4 +1,5 @@
 import groq from 'groq';
+import { ROW_SETTINGS } from './rowSettings';
 
 export const MODULE_VIDEO = groq`
     _key,
@@ -20,5 +21,6 @@ export const MODULE_VIDEO = groq`
     videoSettings,
     videoType,
     videoUrl,
-    content
+    content,
+    ${ROW_SETTINGS}
 `;

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -328,9 +328,19 @@ export interface textGridModule extends module {
     }[];
     heading?: string;
     hasInlineHeading?: boolean;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     marginBottom: Spacing;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     paddingBottom: Spacing;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     paddingTop: Spacing;
+    rowSettings: rowSettings;
 }
 
 export interface tabsModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -159,6 +159,11 @@ export interface videoModule extends module {
 
 export interface bioCardModule extends module {
     reference?: {
+        _createdAt: string;
+        _id: string;
+        _rev: string;
+        _type: 'team';
+        _updatedAt: string;
         bio?: PortableTextBlock[];
         image?: {
             alt: string;
@@ -174,7 +179,7 @@ export interface courseCardModule extends module, ProductType {
         _createdAt: string;
         _id: string;
         _rev: string;
-        _type: string;
+        _type: 'product';
         _updatedAt: string;
         store?: shopifyProduct;
     };
@@ -182,6 +187,11 @@ export interface courseCardModule extends module, ProductType {
 
 export interface collectionCardModule extends module {
     reference: {
+        _createdAt: string;
+        _id: string;
+        _rev: string;
+        _type: 'collection';
+        _updatedAt: string;
         store?: shopifyCollection;
         theme?: {
             color?: string;
@@ -196,6 +206,11 @@ export interface postCardModule extends module {
     fullWidth?: boolean;
     backgroundColor?: string;
     reference: {
+        _createdAt: string;
+        _id: string;
+        _rev: string;
+        _type: 'post';
+        _updatedAt: string;
         theme?: {
             color?: string;
         };
@@ -242,22 +257,6 @@ export type TypesOfCard =
     | staticCardModule;
 
 export interface cardModule extends module {
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    backgroundColor?: Themes;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    marginBottom?: Spacing;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingBottom?: Spacing;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingTop?: Spacing;
     layout: string;
     carouselName?: Maybe<string>;
     carouselSettings?: carouselModuleSettings;
@@ -325,34 +324,10 @@ export interface textGridModule extends module {
     }[];
     heading?: string;
     hasInlineHeading?: boolean;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    marginBottom: Spacing;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingBottom: Spacing;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingTop: Spacing;
     rowSettings: rowSettings;
 }
 
 export interface tabsModule extends module {
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    marginBottom?: Maybe<Spacing>;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingBottom?: Maybe<Spacing>;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingTop?: Maybe<Spacing>;
     tabItem: {
         _key: string;
         _type: string;
@@ -561,18 +536,6 @@ export interface SanityActionNavSettings {
 export interface formModule extends module {
     formId: string;
     formName: string;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    marginBottom?: Maybe<Spacing>;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingBottom?: Maybe<Spacing>;
-    /**
-     * @deprecated in favour of rowSettings
-     */
-    paddingTop?: Maybe<Spacing>;
     rowSettings: rowSettings;
 }
 

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -348,13 +348,10 @@ export interface tabsModule extends module {
 }
 
 export interface recommendedProductsModule extends module {
-    marginBottom?: Maybe<Spacing>;
-    paddingBottom?: Maybe<Spacing>;
-    paddingTop?: Maybe<Spacing>;
-    backgroundColor?: Themes | string;
     numberOfProducts: number;
     heading?: string;
     carouselSettings?: carouselModuleSettings;
+    rowSettings: rowSettings;
 }
 
 export interface SanitySEO {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -56,6 +56,14 @@ export interface module {
     _key?: Maybe<string>;
 }
 
+export interface rowSettings extends module {
+    backgroundColor?: Maybe<Themes>;
+    marginBottom?: Maybe<Spacing>;
+    paddingBottom?: Maybe<Spacing>;
+    paddingTop?: Maybe<Spacing>;
+    container?: Maybe<'default' | 'full'>;
+}
+
 export interface buttonModule extends module {
     _key: string;
     _type: string;
@@ -136,6 +144,7 @@ export interface accordionModule extends module {
         heading: string;
     }[];
     content?: contentModule;
+    settings: rowSettings;
 }
 
 export interface videoModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -334,17 +334,25 @@ export interface textGridModule extends module {
 }
 
 export interface tabsModule extends module {
+    /**
+     * @deprecated in favour of rowSettings
+     */
     marginBottom?: Maybe<Spacing>;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     paddingBottom?: Maybe<Spacing>;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     paddingTop?: Maybe<Spacing>;
-    paddingLeft: Maybe<Spacing>;
-    paddingRight: Maybe<Spacing>;
     tabItem: {
         _key: string;
         _type: string;
         modules: module[] | contentModule[];
         title: string;
     }[];
+    rowSettings: rowSettings;
 }
 
 export interface recommendedProductsModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -132,6 +132,7 @@ export interface contentMediaModule extends module {
     paddingBottom?: Maybe<Spacing>;
     paddingTop?: Maybe<Spacing>;
     slides: contentMediaSlide[];
+    rowSettings: rowSettings;
 }
 
 export interface accordionModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -94,16 +94,11 @@ export interface buttonModule extends module {
 }
 
 export interface contentModule extends module {
-    backgroundColor?: Maybe<Themes>;
     horizontalAlignment?: 'left' | 'centre' | 'right';
-    marginBottom?: Maybe<Spacing>;
-    paddingBottom?: Maybe<Spacing>;
-    paddingTop?: Maybe<Spacing>;
-    paddingLeft: Maybe<Spacing>;
-    paddingRight: Maybe<Spacing>;
     fullWidth?: Maybe<boolean>;
     body?: PortableTextBlock[];
     buttons?: buttonModule[];
+    rowSettings: rowSettings;
 }
 
 export interface contentMediaSlide extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -158,6 +158,7 @@ export interface videoModule extends module {
     };
     videoImage?: imageModule<HTMLImageElement>;
     content?: contentModule;
+    rowSettings: rowSettings;
 }
 
 export interface bioCardModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -244,15 +244,28 @@ export type TypesOfCard =
     | staticCardModule;
 
 export interface cardModule extends module {
-    backgroundColor?: Themes | string;
-    marginBottom?: Spacing | string;
-    paddingBottom?: Spacing | string;
-    paddingTop?: Spacing | string;
+    /**
+     * @deprecated in favour of rowSettings
+     */
+    backgroundColor?: Themes;
+    /**
+     * @deprecated in favour of rowSettings
+     */
+    marginBottom?: Spacing;
+    /**
+     * @deprecated in favour of rowSettings
+     */
+    paddingBottom?: Spacing;
+    /**
+     * @deprecated in favour of rowSettings
+     */
+    paddingTop?: Spacing;
     layout: string;
     carouselName?: Maybe<string>;
     carouselSettings?: carouselModuleSettings;
     content?: contentModule;
     card: TypesOfCard[];
+    settings?: rowSettings;
 }
 
 export interface mediaTextModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -49,6 +49,7 @@ export interface imageModule<T> extends SanityImage<T> {
         grayscale?: boolean;
         opacity?: boolean;
     };
+    rowSettings?: rowSettings;
 }
 
 export interface module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -144,7 +144,7 @@ export interface accordionModule extends module {
         heading: string;
     }[];
     content?: contentModule;
-    settings: rowSettings;
+    rowSettings: rowSettings;
 }
 
 export interface videoModule extends module {
@@ -265,7 +265,7 @@ export interface cardModule extends module {
     carouselSettings?: carouselModuleSettings;
     content?: contentModule;
     card: TypesOfCard[];
-    settings?: rowSettings;
+    rowSettings?: rowSettings;
 }
 
 export interface mediaTextModule extends module {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -549,9 +549,19 @@ export interface SanityActionNavSettings {
 export interface formModule extends module {
     formId: string;
     formName: string;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     marginBottom?: Maybe<Spacing>;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     paddingBottom?: Maybe<Spacing>;
+    /**
+     * @deprecated in favour of rowSettings
+     */
     paddingTop?: Maybe<Spacing>;
+    rowSettings: rowSettings;
 }
 
 export interface PreviewProps {

--- a/packages/osc-ecommerce/app/types/sanity.ts
+++ b/packages/osc-ecommerce/app/types/sanity.ts
@@ -265,7 +265,7 @@ export interface cardModule extends module {
     carouselSettings?: carouselModuleSettings;
     content?: contentModule;
     card: TypesOfCard[];
-    rowSettings?: rowSettings;
+    rowSettings: rowSettings;
 }
 
 export interface mediaTextModule extends module {
@@ -287,6 +287,7 @@ export interface carouselModule extends module {
         image?: imageModule<HTMLImageElement>;
     }[];
     settings?: carouselModuleSettings;
+    rowSettings: rowSettings;
 }
 
 export interface carouselModuleSettings extends module {

--- a/packages/osc-ecommerce/package.json
+++ b/packages/osc-ecommerce/package.json
@@ -33,6 +33,7 @@
     "@hubspot/api-client": "^8.8.0",
     "@prisma/client": "^4.11.0",
     "@radix-ui/react-icons": "^1.2.0",
+    "@radix-ui/react-slot": "^1.0.1",
     "@react-aria/i18n": "^3.7.0",
     "@react-aria/ssr": "^3.5.0",
     "@remix-run/express": "^1.12.0",

--- a/packages/osc-studio/schemas/objects/module/accordion.ts
+++ b/packages/osc-studio/schemas/objects/module/accordion.ts
@@ -14,8 +14,8 @@ export default defineType({
     icon: StackCompactIcon,
     groups: [
         {
-            name: 'settings',
-            title: 'Settings',
+            name: 'row',
+            title: 'Row',
         },
         {
             name: 'content',
@@ -29,10 +29,10 @@ export default defineType({
     ],
     fields: [
         defineField({
-            name: 'settings',
+            name: 'rowSettings',
             title: 'Settings',
-            type: 'moduleSettings',
-            group: 'settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
         defineField({
             name: 'content',

--- a/packages/osc-studio/schemas/objects/module/accordion.ts
+++ b/packages/osc-studio/schemas/objects/module/accordion.ts
@@ -14,6 +14,10 @@ export default defineType({
     icon: StackCompactIcon,
     groups: [
         {
+            name: 'settings',
+            title: 'Settings',
+        },
+        {
             name: 'content',
             title: 'Content',
             default: true,
@@ -24,6 +28,12 @@ export default defineType({
         },
     ],
     fields: [
+        defineField({
+            name: 'settings',
+            title: 'Settings',
+            type: 'moduleSettings',
+            group: 'settings',
+        }),
         defineField({
             name: 'content',
             title: 'Content',

--- a/packages/osc-studio/schemas/objects/module/cards.ts
+++ b/packages/osc-studio/schemas/objects/module/cards.ts
@@ -1,8 +1,6 @@
 import { ThLargeIcon } from '@sanity/icons';
 import pluralize from 'pluralize';
 import { defineField, defineType } from 'sanity';
-import { ColorPicker } from '../../../components/inputs/ColorPicker';
-import { SPACING } from '../../../constants';
 
 const CARDS = [
     { type: 'card.bio' },
@@ -23,13 +21,13 @@ export default defineType({
     icon: ThLargeIcon,
     groups: [
         {
-            default: true,
-            name: 'spacing',
-            title: 'Spacing',
+            name: 'settings',
+            title: 'Settings',
         },
         {
             name: 'content',
             title: 'Content',
+            default: true,
         },
         {
             name: 'cards',
@@ -38,43 +36,16 @@ export default defineType({
     ],
     fields: [
         defineField({
+            name: 'settings',
+            title: 'Settings',
+            type: 'moduleSettings',
+            group: 'settings',
+        }),
+        defineField({
             name: 'content',
             title: 'Content',
             type: 'module.content',
             group: 'content',
-        }),
-        defineField({
-            name: 'marginBottom',
-            title: 'Push Region',
-            type: 'string',
-            description: 'Spacing you would like between this region and the next.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingTop',
-            title: 'Inner Padding Top',
-            type: 'string',
-            description: 'Inner padding at the top of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingBottom',
-            title: 'Inner Padding Bottom',
-            type: 'string',
-            description: 'Inner padding at the bottom of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
         }),
         defineField({
             name: 'layout',
@@ -115,15 +86,6 @@ export default defineType({
             type: 'carouselSettings',
             group: 'cards',
             hidden: ({ parent }) => !shouldShow(parent),
-        }),
-        defineField({
-            name: 'backgroundColor',
-            title: 'Background Colour',
-            type: 'string',
-            components: {
-                input: ColorPicker,
-            },
-            group: 'cards',
         }),
         defineField({
             name: 'card',

--- a/packages/osc-studio/schemas/objects/module/cards.ts
+++ b/packages/osc-studio/schemas/objects/module/cards.ts
@@ -21,8 +21,8 @@ export default defineType({
     icon: ThLargeIcon,
     groups: [
         {
-            name: 'settings',
-            title: 'Settings',
+            name: 'row',
+            title: 'Row',
         },
         {
             name: 'content',
@@ -36,10 +36,10 @@ export default defineType({
     ],
     fields: [
         defineField({
-            name: 'settings',
+            name: 'rowSettings',
             title: 'Settings',
-            type: 'moduleSettings',
-            group: 'settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
         defineField({
             name: 'content',

--- a/packages/osc-studio/schemas/objects/module/carousel.ts
+++ b/packages/osc-studio/schemas/objects/module/carousel.ts
@@ -9,6 +9,10 @@ export default defineType({
     icon: StarIcon,
     groups: [
         {
+            name: 'row',
+            title: 'Row',
+        },
+        {
             name: 'settings',
             title: 'Settings',
         },
@@ -40,6 +44,12 @@ export default defineType({
             title: 'Settings',
             type: 'carouselSettings',
             group: 'settings',
+        }),
+        defineField({
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
     ],
     preview: {

--- a/packages/osc-studio/schemas/objects/module/content.ts
+++ b/packages/osc-studio/schemas/objects/module/content.ts
@@ -1,7 +1,5 @@
 import { EditIcon } from '@sanity/icons';
 import { defineField, defineType } from 'sanity';
-import { ColorPicker } from '../../../components/inputs/ColorPicker';
-import { SPACING } from '../../../constants';
 
 export default defineType({
     name: 'module.content',
@@ -10,8 +8,8 @@ export default defineType({
     icon: EditIcon,
     groups: [
         {
-            name: 'spacing',
-            title: 'Spacing',
+            name: 'row',
+            title: 'Row',
         },
         {
             name: 'content',
@@ -21,59 +19,10 @@ export default defineType({
     ],
     fields: [
         defineField({
-            name: 'marginBottom',
-            title: 'Push Region',
-            type: 'string',
-            description: 'Spacing you would like between this region and the next.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingTop',
-            title: 'Inner Padding Top',
-            type: 'string',
-            description: 'Inner padding at the top of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingBottom',
-            title: 'Inner Padding Bottom',
-            type: 'string',
-            description: 'Inner padding at the bottom of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingLeft',
-            title: 'Inner Padding Left',
-            type: 'string',
-            description: 'Inner padding at the left of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingRight',
-            title: 'Inner Padding Right',
-            type: 'string',
-            description: 'Inner padding at the right of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
         defineField({
             name: 'horizontalAlignment',
@@ -88,23 +37,6 @@ export default defineType({
             },
             initialValue: 'left',
             group: 'content',
-        }),
-        defineField({
-            name: 'backgroundColor',
-            title: 'Background Colour',
-            type: 'string',
-            components: {
-                input: ColorPicker,
-            },
-            group: 'content',
-        }),
-        defineField({
-            name: 'fullWidth',
-            title: 'Full Width',
-            type: 'boolean',
-            description: 'Whether the content should fill the width of the container.',
-            group: 'content',
-            initialValue: false,
         }),
         defineField({
             name: 'body',

--- a/packages/osc-studio/schemas/objects/module/contentMedia.ts
+++ b/packages/osc-studio/schemas/objects/module/contentMedia.ts
@@ -1,7 +1,6 @@
 import { MasterDetailIcon } from '@sanity/icons';
 import pluralize from 'pluralize';
 import { defineField, defineType } from 'sanity';
-import { SPACING } from '../../../constants';
 
 const shouldShow = (parent: { slides: {}[] }) => {
     return parent?.slides?.length > 1;
@@ -14,8 +13,8 @@ export default defineType({
     icon: MasterDetailIcon,
     groups: [
         {
-            name: 'spacing',
-            title: 'Spacing',
+            name: 'row',
+            title: 'Row',
         },
         {
             name: 'slides',
@@ -25,44 +24,17 @@ export default defineType({
     ],
     fields: [
         defineField({
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
+        }),
+        defineField({
             name: 'slides',
             title: 'Slides',
             type: 'array',
             of: [{ type: 'contentMediaSlide' }],
             group: 'slides',
-        }),
-        defineField({
-            name: 'marginBottom',
-            title: 'Push Region',
-            type: 'string',
-            description: 'Spacing you would like between this region and the next.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingTop',
-            title: 'Inner Padding Top',
-            type: 'string',
-            description: 'Inner padding at the top of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingBottom',
-            title: 'Inner Padding Bottom',
-            type: 'string',
-            description: 'Inner padding at the bottom of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
         }),
         defineField({
             // To make the name validation only apply when the field is visible we need to move it out of the settings object

--- a/packages/osc-studio/schemas/objects/module/forms.ts
+++ b/packages/osc-studio/schemas/objects/module/forms.ts
@@ -1,6 +1,5 @@
 import { DocumentIcon } from '@sanity/icons';
 import { defineField, defineType } from 'sanity';
-import { SPACING } from '../../../constants';
 
 // TODO - Update so that these are pulled in dynamically on a get request to Hubspot form API. Looks like a proxy needs setting up in order to do this.
 const forms = [
@@ -17,12 +16,13 @@ export default defineType({
     icon: DocumentIcon,
     groups: [
         {
-            name: 'forms',
-            title: 'Form',
+            name: 'row',
+            title: 'Row',
         },
         {
-            name: 'spacing',
-            title: 'Spacing',
+            name: 'forms',
+            title: 'Form',
+            default: true,
         },
     ],
     fields: [
@@ -41,37 +41,10 @@ export default defineType({
             group: 'forms',
         }),
         defineField({
-            name: 'marginBottom',
-            title: 'Push Region',
-            type: 'string',
-            description: 'Spacing you would like between this region and the next.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingTop',
-            title: 'Inner Padding Top',
-            type: 'string',
-            description: 'Inner padding at the top of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingBottom',
-            title: 'Inner Padding Bottom',
-            type: 'string',
-            description: 'Inner padding at the bottom of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
     ],
     preview: {

--- a/packages/osc-studio/schemas/objects/module/images.tsx
+++ b/packages/osc-studio/schemas/objects/module/images.tsx
@@ -6,12 +6,30 @@ export default defineType({
     title: 'Image',
     type: 'object',
     icon: ImageIcon,
+    groups: [
+        {
+            name: 'row',
+            title: 'Row',
+        },
+        {
+            name: 'image',
+            title: 'Image',
+            default: true,
+        },
+    ],
     fields: [
+        defineField({
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
+        }),
         // Modules (Images)
         defineField({
             name: 'image',
             title: 'Image',
             type: 'image.desktop',
+            group: 'image',
         }),
     ],
     preview: {

--- a/packages/osc-studio/schemas/objects/module/recommendedProducts.ts
+++ b/packages/osc-studio/schemas/objects/module/recommendedProducts.ts
@@ -1,7 +1,5 @@
 import { TagIcon } from '@sanity/icons';
 import { defineField, defineType } from 'sanity';
-import { ColorPicker } from '../../../components/inputs/ColorPicker';
-import { SPACING } from '../../../constants';
 
 export default defineType({
     name: 'module.recommendedProducts',
@@ -10,8 +8,8 @@ export default defineType({
     icon: TagIcon,
     groups: [
         {
-            name: 'spacing',
-            title: 'Spacing',
+            name: 'row',
+            title: 'Row',
         },
         {
             name: 'products',
@@ -21,55 +19,16 @@ export default defineType({
     ],
     fields: [
         defineField({
-            name: 'marginBottom',
-            title: 'Push Region',
-            type: 'string',
-            description: 'Spacing you would like between this region and the next.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingTop',
-            title: 'Inner Padding Top',
-            type: 'string',
-            description: 'Inner padding at the top of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            initialValue: '5xl',
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingBottom',
-            title: 'Inner Padding Bottom',
-            type: 'string',
-            description: 'Inner padding at the bottom of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            initialValue: '4xl',
-            group: 'spacing',
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
         defineField({
             name: 'heading',
             title: 'Heading',
             type: 'string',
             initialValue: 'You may also like',
-            group: 'products',
-        }),
-        defineField({
-            name: 'backgroundColor',
-            title: 'Background Colour',
-            type: 'string',
-            components: {
-                input: ColorPicker,
-            },
-            initialValue: 'neutral-300',
             group: 'products',
         }),
         defineField({

--- a/packages/osc-studio/schemas/objects/module/tabs.ts
+++ b/packages/osc-studio/schemas/objects/module/tabs.ts
@@ -1,7 +1,6 @@
 import { BlockElementIcon } from '@sanity/icons';
 import pluralize from 'pluralize';
 import { defineField, defineType } from 'sanity';
-import { SPACING } from '../../../constants';
 
 export default defineType({
     name: 'module.tabs',
@@ -10,8 +9,8 @@ export default defineType({
     icon: BlockElementIcon,
     groups: [
         {
-            name: 'spacing',
-            title: 'Spacing',
+            name: 'row',
+            title: 'Row',
         },
         {
             name: 'tabs',
@@ -21,59 +20,10 @@ export default defineType({
     ],
     fields: [
         defineField({
-            name: 'marginBottom',
-            title: 'Push Region',
-            type: 'string',
-            description: 'Spacing you would like between this region and the next.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingTop',
-            title: 'Inner Padding Top',
-            type: 'string',
-            description: 'Inner padding at the top of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingBottom',
-            title: 'Inner Padding Bottom',
-            type: 'string',
-            description: 'Inner padding at the bottom of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingLeft',
-            title: 'Inner Padding Left',
-            type: 'string',
-            description: 'Inner padding at the left of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingRight',
-            title: 'Inner Padding Right',
-            type: 'string',
-            description: 'Inner padding at the right of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
         defineField({
             name: 'tabItem',

--- a/packages/osc-studio/schemas/objects/module/textGrid.ts
+++ b/packages/osc-studio/schemas/objects/module/textGrid.ts
@@ -1,6 +1,5 @@
 import { GridIcon } from '@radix-ui/react-icons';
 import { defineField, defineType } from 'sanity';
-import { SPACING } from '../../../constants';
 
 export default defineType({
     name: 'module.textGrid',
@@ -9,8 +8,8 @@ export default defineType({
     icon: GridIcon,
     groups: [
         {
-            name: 'spacing',
-            title: 'Spacing',
+            name: 'row',
+            title: 'Row',
         },
         {
             name: 'content',
@@ -20,37 +19,10 @@ export default defineType({
     ],
     fields: [
         defineField({
-            name: 'marginBottom',
-            title: 'Push Region',
-            type: 'string',
-            description: 'Spacing you would like between this region and the next.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingTop',
-            title: 'Inner Padding Top',
-            type: 'string',
-            description: 'Inner padding at the top of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
-        }),
-        defineField({
-            name: 'paddingBottom',
-            title: 'Inner Padding Bottom',
-            type: 'string',
-            description: 'Inner padding at the bottom of the region.',
-            options: {
-                list: SPACING,
-                layout: 'dropdown',
-            },
-            group: 'spacing',
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
         }),
         defineField({
             name: 'heading',

--- a/packages/osc-studio/schemas/objects/module/video.tsx
+++ b/packages/osc-studio/schemas/objects/module/video.tsx
@@ -8,6 +8,10 @@ export default defineType({
     icon: VideoIcon,
     groups: [
         {
+            name: 'row',
+            title: 'Row',
+        },
+        {
             default: true,
             name: 'video',
             title: 'Video',
@@ -18,6 +22,12 @@ export default defineType({
         },
     ],
     fields: [
+        defineField({
+            name: 'rowSettings',
+            title: 'Settings',
+            type: 'rowSettings',
+            group: 'row',
+        }),
         defineField({
             name: 'videoType',
             title: 'Video Type',

--- a/packages/osc-studio/schemas/objects/rowSettings.ts
+++ b/packages/osc-studio/schemas/objects/rowSettings.ts
@@ -70,6 +70,7 @@ export default defineType({
             title: 'Container',
             type: 'string',
             description: 'Sets the width of the component',
+            initialValue: 'default',
             group: 'container',
             options: {
                 list: ['default', 'full'],

--- a/packages/osc-studio/schemas/objects/rowSettings.ts
+++ b/packages/osc-studio/schemas/objects/rowSettings.ts
@@ -6,6 +6,8 @@ export default defineType({
     name: 'rowSettings',
     title: 'Settings',
     type: 'object',
+    description:
+        'Settings for the row. Note: These settings will only apply to the top level module.',
     groups: [
         {
             name: 'spacing',

--- a/packages/osc-studio/schemas/objects/rowSettings.ts
+++ b/packages/osc-studio/schemas/objects/rowSettings.ts
@@ -1,0 +1,81 @@
+import { defineField, defineType } from 'sanity';
+import { ColorPicker } from '../../components/inputs/ColorPicker';
+import { SPACING } from '../../constants';
+
+export default defineType({
+    name: 'moduleSettings',
+    title: 'Settings',
+    type: 'object',
+    groups: [
+        {
+            name: 'spacing',
+            title: 'Spacing',
+            default: true,
+        },
+        {
+            name: 'background',
+            title: 'Background',
+        },
+        {
+            name: 'container',
+            title: 'Container',
+        },
+    ],
+    fields: [
+        defineField({
+            name: 'marginBottom',
+            title: 'Push Region',
+            type: 'string',
+            description: 'Spacing you would like between this region and the next.',
+            initialValue: 'l',
+            options: {
+                list: SPACING,
+                layout: 'dropdown',
+            },
+            group: 'spacing',
+        }),
+        defineField({
+            name: 'paddingTop',
+            title: 'Inner Padding Top',
+            type: 'string',
+            description: 'Inner padding at the top of the region.',
+            options: {
+                list: SPACING,
+                layout: 'dropdown',
+            },
+            group: 'spacing',
+        }),
+        defineField({
+            name: 'paddingBottom',
+            title: 'Inner Padding Bottom',
+            type: 'string',
+            description: 'Inner padding at the bottom of the region.',
+            options: {
+                list: SPACING,
+                layout: 'dropdown',
+            },
+            group: 'spacing',
+        }),
+        defineField({
+            name: 'backgroundColor',
+            title: 'Background Colour',
+            type: 'string',
+            components: {
+                input: ColorPicker,
+            },
+            group: 'background',
+        }),
+        defineField({
+            name: 'container',
+            title: 'Container',
+            type: 'string',
+            description: 'Sets the width of the component',
+            group: 'container',
+            options: {
+                list: ['default', 'full'],
+                layout: 'radio',
+                direction: 'horizontal',
+            },
+        }),
+    ],
+});

--- a/packages/osc-studio/schemas/objects/rowSettings.ts
+++ b/packages/osc-studio/schemas/objects/rowSettings.ts
@@ -29,7 +29,6 @@ export default defineType({
             title: 'Push Region',
             type: 'string',
             description: 'Spacing you would like between this region and the next.',
-            initialValue: 'l',
             options: {
                 list: SPACING,
                 layout: 'dropdown',
@@ -41,6 +40,7 @@ export default defineType({
             title: 'Inner Padding Top',
             type: 'string',
             description: 'Inner padding at the top of the region.',
+            initialValue: '2xl',
             options: {
                 list: SPACING,
                 layout: 'dropdown',
@@ -52,6 +52,7 @@ export default defineType({
             title: 'Inner Padding Bottom',
             type: 'string',
             description: 'Inner padding at the bottom of the region.',
+            initialValue: '2xl',
             options: {
                 list: SPACING,
                 layout: 'dropdown',

--- a/packages/osc-studio/schemas/objects/rowSettings.ts
+++ b/packages/osc-studio/schemas/objects/rowSettings.ts
@@ -3,7 +3,7 @@ import { ColorPicker } from '../../components/inputs/ColorPicker';
 import { SPACING } from '../../constants';
 
 export default defineType({
-    name: 'moduleSettings',
+    name: 'rowSettings',
     title: 'Settings',
     type: 'object',
     groups: [

--- a/packages/osc-studio/schemas/schema.ts
+++ b/packages/osc-studio/schemas/schema.ts
@@ -70,6 +70,7 @@ import placeholderString from './objects/placeholderString';
 import productOption from './objects/productOption';
 import ProductWithVariant from './objects/productWithVariant';
 import proxyString from './objects/proxyString';
+import moduleSettings from './objects/rowSettings';
 import seoHome from './objects/seo/home';
 import seoPage from './objects/seo/page';
 import seoShopify from './objects/seo/shopify';
@@ -112,6 +113,7 @@ export const schemaTypes: SchemaTypeDefinition[] = [
     bodyNoHeadings,
 
     // Objects
+    moduleSettings,
     accordionItem,
     tabItem,
     carouselSettings,

--- a/packages/osc-ui/src/components/Content/Content.spec.tsx
+++ b/packages/osc-ui/src/components/Content/Content.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render } from 'test-utils';
 import { Content } from './Content';
 import { textContent, textContentHasButtons } from './textContent';
-// TODO: sb - test background color -- think we need theme setup in storybook?
+
 test('renders the correct elements', () => {
     render(<Content value={textContent.body} />);
 
@@ -57,24 +57,6 @@ test('renders a custom classname', () => {
     render(<Content value={textContent.body} className="test-class" />);
     const content = document.querySelector('.c-content');
     expect(content).toHaveClass('test-class');
-});
-
-test('renders the correct padding class', () => {
-    const { rerender } = render(
-        <Content value={textContent.body} paddingTop={10} paddingBottom={10} />
-    );
-    const content = document.querySelector('.c-content');
-    expect(content).toHaveClass('u-pt-10 u-pb-10');
-
-    rerender(<Content value={textContent.body} paddingTop={50} paddingBottom={110} />);
-
-    expect(content).toHaveClass('u-pt-50 u-pb-110');
-});
-
-test('renders the correct margin class', () => {
-    render(<Content value={textContent.body} marginBottom={10} />);
-    const content = document.querySelector('.c-content');
-    expect(content).toHaveClass('u-mb-10');
 });
 
 test('renders the correct buttons', () => {

--- a/packages/osc-ui/src/components/Content/Content.stories.tsx
+++ b/packages/osc-ui/src/components/Content/Content.stories.tsx
@@ -7,7 +7,6 @@ import {
     textContentFonts,
     textContentHasButtons,
     textContentSizes,
-    textContentWithBackgroundColor,
     textContentWithTextColor,
 } from './textContent';
 
@@ -43,23 +42,8 @@ export default {
                 },
             },
         },
-        backgroundColor: {
-            description: 'Sets the background colour of the content',
-        },
         className: {
             description: 'Custom class',
-        },
-        marginBottom: {
-            description: 'Sets the bottom margin of the content',
-            control: 'select',
-        },
-        paddingBottom: {
-            description: 'Sets the bottom padding of the content',
-            control: 'select',
-        },
-        paddingTop: {
-            description: 'Sets the top padding of the content',
-            control: 'select',
         },
         textColor: {
             description: 'Sets the text colour of the content',
@@ -77,14 +61,6 @@ Primary.args = {
 export const TextColour = Template.bind({});
 TextColour.args = {
     value: textContentWithTextColor.body,
-};
-
-export const BackgroundColour = Template.bind({});
-BackgroundColour.args = {
-    backgroundColor: textContentWithBackgroundColor.backgroundColor,
-    value: textContentWithBackgroundColor.body,
-    paddingTop: textContentWithBackgroundColor.paddingTop,
-    paddingBottom: textContentWithBackgroundColor.paddingBottom,
 };
 
 export const TextSizes = Template.bind({});

--- a/packages/osc-ui/src/components/Content/Content.tsx
+++ b/packages/osc-ui/src/components/Content/Content.tsx
@@ -4,8 +4,6 @@ import type { PortableTextBlock } from '@portabletext/types';
 import { Link } from '@remix-run/react';
 import { colors, fluidScale as sizes, typography } from 'osc-design-tokens';
 import React from 'react';
-import { useSpacing } from '../../hooks/useSpacing';
-import type { Maybe, Spacing } from '../../types';
 import { classNames } from '../../utils/classNames';
 import { Button, ButtonGroup, CopyButton } from '../Button/Button';
 import { Icon } from '../Icon/Icon';
@@ -43,16 +41,9 @@ export interface ButtonProps {
 
 export interface Props {
     align?: 'left' | 'centre' | 'right';
-    backgroundColor?: Maybe<string>;
     className?: string;
-    marginBottom?: Maybe<Spacing>;
-    paddingBottom?: Maybe<Spacing>;
-    paddingTop?: Maybe<Spacing>;
-    paddingLeft?: Maybe<Spacing>;
-    paddingRight?: Maybe<Spacing>;
     value: PortableTextBlock[];
     buttons?: ButtonProps[];
-    fullWidth?: Maybe<boolean>;
 }
 
 // Create the decorator markup
@@ -143,43 +134,16 @@ const portableTextComponents: PortableTextComponents = {
 };
 
 export const Content = (props: Props) => {
-    const {
-        align = 'left',
-        fullWidth = false,
-        backgroundColor,
-        className,
-        marginBottom,
-        paddingTop,
-        paddingBottom,
-        paddingLeft,
-        paddingRight,
-        value,
-        buttons,
-    } = props;
+    const { align = 'left', className, value, buttons } = props;
 
     // ? Perhaps better to simply apply the class and pass them as a value from Sanity?
     const alignClass = align ? `c-content__inner--${align}` : '';
-    const fullWidthClass = fullWidth ? 'c-content__inner--full' : '';
-    const marginBottomClass = useSpacing('margin', 'bottom', marginBottom);
-    const paddingTopClass = useSpacing('padding', 'top', paddingTop);
-    const paddingBottomClass = useSpacing('padding', 'bottom', paddingBottom);
-    const paddingLeftClass = useSpacing('padding', 'left', paddingLeft);
-    const paddingRightClass = useSpacing('padding', 'right', paddingRight);
 
-    const classes = classNames(
-        'c-content',
-        paddingTopClass,
-        paddingBottomClass,
-        marginBottomClass,
-        paddingLeftClass,
-        paddingRightClass,
-        backgroundColor && `u-bg-color-${backgroundColor}`,
-        className
-    );
+    const classes = classNames('c-content', className);
 
     return (
         <div className={classes ? classes : null}>
-            <div className={`c-content__inner ${alignClass} ${fullWidthClass}`}>
+            <div className={`c-content__inner ${alignClass}`}>
                 <ReactPortableText value={value} components={portableTextComponents} />
 
                 {buttons && buttons.length > 0 ? (

--- a/packages/osc-ui/src/components/Content/textContent.ts
+++ b/packages/osc-ui/src/components/Content/textContent.ts
@@ -1,12 +1,7 @@
 import type { PortableTextBlock } from '@portabletext/types';
-import type { Spacing, Themes } from '../../types';
 import type { ButtonProps } from './Content';
 
 interface TextContent {
-    backgroundColor?: Themes;
-    paddingTop?: Spacing;
-    paddingBottom?: Spacing;
-    marginBottom?: Spacing;
     body: PortableTextBlock[];
     buttons?: ButtonProps[];
 }

--- a/packages/osc-ui/src/components/Hero/Hero.stories.tsx
+++ b/packages/osc-ui/src/components/Hero/Hero.stories.tsx
@@ -74,7 +74,7 @@ const SecondaryTemplate: Story<HeroProps> = ({ ...args }) => (
 
             <HeroContent>
                 <div className="c-content">
-                    <div className="c-content__inner c-content__inner--centre">
+                    <div className="c-content__inner">
                         <p className="t-font-l u-color-tertiary">
                             Get £75 off when you spend over £400 on your enrolment
                         </p>
@@ -172,7 +172,7 @@ const CarouselTemplate: Story<HeroProps> = () => (
 
                 <HeroContent>
                     <div className="c-content">
-                        <div className="c-content__inner c-content__inner--centre">
+                        <div className="c-content__inner">
                             <p className="t-font-l">
                                 Download our <strong>new 2023 prospectus</strong> today
                             </p>
@@ -192,7 +192,7 @@ const CarouselTemplate: Story<HeroProps> = () => (
 
                 <HeroContent>
                     <div className="c-content">
-                        <div className="c-content__inner c-content__inner--centre">
+                        <div className="c-content__inner">
                             <p className="t-font-l u-color-tertiary">
                                 Get £75 off when you spend over £400 on your enrolment
                             </p>

--- a/packages/osc-ui/src/components/Hero/hero.scss
+++ b/packages/osc-ui/src/components/Hero/hero.scss
@@ -189,6 +189,7 @@
                     align-items: center;
                     justify-content: center;
                     gap: $space-2xs;
+                    max-width: 100%;
 
                     @include mq($mq-tab-m) {
                         flex-direction: row;

--- a/packages/osc-ui/src/styles/components/_forms.scss
+++ b/packages/osc-ui/src/styles/components/_forms.scss
@@ -9,6 +9,7 @@
             position: relative;
             max-width: 100%;
             padding: var(--space-scale-2xl);
+            background: var(--color-tertiary);
             box-shadow: $shadow-l, $shadow-s;
 
             &--newsletter-form {

--- a/packages/osc-ui/src/styles/objects/_row.scss
+++ b/packages/osc-ui/src/styles/objects/_row.scss
@@ -17,7 +17,7 @@
     display: flex;
     flex-flow: row wrap;
     width: 100%;
-    margin: 0 auto $space-m;
+    margin: 0 auto $space-l;
     background-size: cover;
 
     // content-visibility: auto;

--- a/packages/osc-ui/src/styles/objects/_row.scss
+++ b/packages/osc-ui/src/styles/objects/_row.scss
@@ -3,7 +3,7 @@
 /* ============================
 // $ROW WRAPPER
 // A structural element that allows containerisation of objects and components while also
-// applying vertical rhythym of said components. Grid elements can be used within the row object.
+// applying vertical rhythm of said components. Grid elements can be used within the row object.
 */
 
 /* ============================

--- a/packages/osc-ui/src/styles/objects/_row.scss
+++ b/packages/osc-ui/src/styles/objects/_row.scss
@@ -17,7 +17,7 @@
     display: flex;
     flex-flow: row wrap;
     width: 100%;
-    margin: 0 auto $space-l;
+    margin: 0 auto;
     background-size: cover;
 
     // content-visibility: auto;

--- a/packages/osc-ui/src/types.ts
+++ b/packages/osc-ui/src/types.ts
@@ -18,7 +18,15 @@ export type Themes =
     | 'octonary'
     | 'nonary'
     | 'denary'
-    | 'duodenary';
+    | 'duodenary'
+    | 'neutral-0'
+    | 'neutral-100'
+    | 'neutral-200'
+    | 'neutral-300'
+    | 'neutral-400'
+    | 'neutral-500'
+    | 'neutral-600'
+    | 'neutral-700';
 
 export type Variants = 'outline' | 'subtle';
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

- Closes #867 

## 📝 Description

I've added a `Row` component which wraps around all of our modules and a `rowSettings` schema to modules in Sanity. This will let us apply styles etc. around our component, allowing us to add full width backgrounds, change container sizes etc.

The design has a lot of varied spacings but I've set the default paddings to be `2xl` this will allow cms users to not worry too much when building pages and this seemed like the best compromise.

There is a limitation within Sanity where we can't hide the `Row` settings when a component is nested within another, for example the `Accordion` as the `Content` component nested within it, but we don't want to allow the row styles to impact the styles of the component. In cases like this I've added a description to the row to say it won't work when nested. It would be better to make it readonly or hide it but unfortunately Sanity doesn't give you enough context in their conditional fields to do this.

Sorry this has turned into a 59 file change PR. The majority of it is replacing settings with the Sanity `rowSettings` and adding the `Row` to the components, which adds up to quite a few files now 😅 

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

- Wraps all components in ecommerce with `Row`
- Adds `rowSettings` to module schemas

## 💣 Is this a breaking change (Yes/No): Yes

The `marginBottom`, `paddingBottom`, `paddingTop` etc. will now be part of the `rowSettings` object rather than being stored directly on the module.

## 📝 Additional Information

This should solve everything in #867 I moved the form stuff out of that ticket and into #936 