### PR TITLE
Bugfix/text input

### DIFF
--- a/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { useState } from 'react';
+import { Button } from '../Button/Button';
 import { SpritesheetProvider } from '../Icon/Icon';
 import { TextInput } from './TextInput';
 import { textInputSchema } from './mockSchema';
@@ -186,4 +187,41 @@ test('should change focus to second input when using the tab key', async () => {
     await user.tab();
 
     expect(input2).toHaveFocus();
+});
+
+const ValueControlledInput = () => {
+    const [inputValue, setInputValue] = useState('');
+
+    return (
+        <div>
+            <TextInput
+                id="name"
+                label="Name"
+                name="name"
+                type="text"
+                variants={['tertiary']}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+            />
+
+            <Button size="sm" onClick={() => setInputValue('')}>
+                Reset
+            </Button>
+        </div>
+    );
+};
+
+test('should clear the input value when the reset button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ValueControlledInput />);
+
+    const input1 = screen.getByRole('textbox', { name: 'Name' });
+    await user.type(input1, 'test');
+
+    expect(input1).toHaveValue('test');
+
+    const resetButton = screen.getByRole('button', { name: 'Reset' });
+    await user.click(resetButton);
+
+    expect(input1).toHaveValue('');
 });

--- a/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, Story } from '@storybook/react';
 import React, { useEffect, useRef, useState } from 'react';
 
-import { textInputSchema } from './mockSchema';
+import { Button } from '../Button/Button';
 import { TextInput } from './TextInput';
+import { textInputSchema } from './mockSchema';
 
 export default {
     title: 'osc-ui/TextInput',
@@ -120,11 +121,42 @@ const ValidationTemplate: Story = () => {
     );
 };
 
+const ControlledInputTemplate = () => {
+    const [inputValue, setInputValue] = useState('');
+
+    return (
+        <div
+            style={{
+                margin: '1em',
+                width: '300px',
+                display: 'flex',
+                flexDirection: 'row',
+                gap: '1em',
+            }}
+        >
+            <TextInput
+                id="name"
+                label="Name"
+                name="name"
+                type="text"
+                variants={['tertiary']}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+            />
+
+            <Button size="sm" onClick={() => setInputValue('')}>
+                Reset
+            </Button>
+        </div>
+    );
+};
+
 export const Primary = Template.bind({});
 export const Secondary = Template.bind({});
 export const Tertiary = Template.bind({});
 export const Quaternary = Template.bind({});
 export const Validation = ValidationTemplate.bind({});
+export const ControlledInput = ControlledInputTemplate.bind({});
 
 Primary.args = {
     items: [

--- a/packages/osc-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/osc-ui/src/components/TextInput/TextInput.tsx
@@ -91,6 +91,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
         type = 'text',
         variants,
         className,
+        value: _value,
         ...rest
     } = props;
     const [value, setValue] = useState(defaultValue ? defaultValue : '');
@@ -139,6 +140,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
                     onChange={(event) => setValue(event.currentTarget.value)}
                     ref={forwardedRef}
                     type={type}
+                    value={_value || value}
                     {...rest}
                 />
                 <Label
@@ -147,7 +149,7 @@ export const TextInput = forwardRef<HTMLInputElement, Props>((props: Props, forw
                     htmlFor={id}
                     name={label}
                     required={required}
-                    variants={value ? ['filled'] : null}
+                    variants={_value || value ? ['filled'] : null}
                 />
                 {icon ? <Icon className={iconClasses} id={icon.id} /> : null}
                 {errors && errors.length > 0 ? <InputError errors={errors} id={id} /> : null}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds a `value` prop and sets the the `TextInput` component to be controlled internally so that the `c-label--filled` class is correctly applied when controlling the input with external state.

## ⛳️ Current behavior (updates)

Currently when you blur or try to clear the state of a controlled input (tertiary variant) then the label drops back down but the input value persists, which leads to this obscured looking text.

https://github.com/Open-Study-College/osc/assets/23461173/f0bca1f5-763e-4d7c-9fed-52c74944c48d

## 🚀 New behavior

By passing a `_value` prop through to the inner component we can use that in conjunction with the inner `value` prop to control whether the `filled` variant gets set or not while also being able to control the state outside of the component.

https://github.com/Open-Study-College/osc/assets/23461173/290d7924-c2dd-4840-a833-7dec9fbc77dc

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
