### PR TITLE
Feature/product cart pending states

### DIFF
--- a/packages/osc-ecommerce/app/components/Cart/CartTotal.tsx
+++ b/packages/osc-ecommerce/app/components/Cart/CartTotal.tsx
@@ -44,6 +44,7 @@ export const CartTotal = (props: CartTotalProps) => {
                     {totalAmount?.amount ? (
                         <LineItemPrice asChild>
                             <Price
+                                size="sm"
                                 compareAtPrice={
                                     hasCartDiscount ? (
                                         <Money data={subtotalAmount} as="span" />

--- a/packages/osc-ecommerce/app/components/Cart/DiscountBox/DiscountBox.tsx
+++ b/packages/osc-ecommerce/app/components/Cart/DiscountBox/DiscountBox.tsx
@@ -109,7 +109,6 @@ export const DiscountBox = (props: DiscountBoxProps) => {
                             variant="primary"
                             size="sm"
                             isLoading={pendingFetcher}
-                            loadingText=""
                             isDisabled={pendingFetcher || !inputValue ? true : false}
                             tabIndex={active ? 0 : -1}
                         >

--- a/packages/osc-ecommerce/app/components/Cart/DiscountBox/DiscountBox.tsx
+++ b/packages/osc-ecommerce/app/components/Cart/DiscountBox/DiscountBox.tsx
@@ -108,6 +108,8 @@ export const DiscountBox = (props: DiscountBoxProps) => {
                         <Button
                             variant="primary"
                             size="sm"
+                            isLoading={pendingFetcher}
+                            loadingText=""
                             isDisabled={pendingFetcher || !inputValue ? true : false}
                             tabIndex={active ? 0 : -1}
                         >

--- a/packages/osc-ecommerce/app/components/Cart/Layout.tsx
+++ b/packages/osc-ecommerce/app/components/Cart/Layout.tsx
@@ -188,7 +188,6 @@ export const CartLayout = () => {
                                         isFull
                                         isDisabled={linesArePending || discountCodeIsPending}
                                         isLoading={linesArePending || discountCodeIsPending}
-                                        loadingText=""
                                     >
                                         Enrol now
                                     </Button>

--- a/packages/osc-ecommerce/app/components/Cart/Layout.tsx
+++ b/packages/osc-ecommerce/app/components/Cart/Layout.tsx
@@ -187,6 +187,8 @@ export const CartLayout = () => {
                                         href={cart.checkoutUrl}
                                         isFull
                                         isDisabled={linesArePending || discountCodeIsPending}
+                                        isLoading={linesArePending || discountCodeIsPending}
+                                        loadingText=""
                                     >
                                         Enrol now
                                     </Button>

--- a/packages/osc-ecommerce/app/components/Cart/LineItem.tsx
+++ b/packages/osc-ecommerce/app/components/Cart/LineItem.tsx
@@ -43,8 +43,6 @@ const CartLineItemPrice = (props: CartLineItemPriceProps) => {
 
     if (!line?.cost?.amountPerQuantity || !line?.cost?.totalAmount) return null;
 
-    console.log(line);
-
     const { amountPerQuantity, totalAmount } = line?.cost;
 
     const isOnSale =

--- a/packages/osc-ecommerce/app/components/Forms/CartActions/RemoveFromCart.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/CartActions/RemoveFromCart.tsx
@@ -19,7 +19,13 @@ export const RemoveFromCart = (props: RemoveFromCartProps) => {
             <input type="hidden" name="cartAction" value={CartAction.REMOVE_FROM_CART} />
             <input type="hidden" name="linesIds" value={JSON.stringify(lineIds)} />
 
-            <Button variant="quaternary" isDisabled={isPending} className="u-text-underline">
+            <Button
+                variant="quaternary"
+                isDisabled={isPending}
+                isLoading={isPending}
+                loadingText="Remove"
+                className="u-text-underline"
+            >
                 Remove
             </Button>
         </fetcher.Form>

--- a/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
+++ b/packages/osc-ecommerce/app/components/Forms/ProductForm/ProductForm.tsx
@@ -161,7 +161,6 @@ export const ProductForm = forwardRef<ElementRef<'div'>, ProductFormProps>(
                 <ButtonGroup direction="column">
                     {!isOutOfStock ? (
                         <AddToCart
-                            isDisabled={transitionIsNotIdle}
                             lines={[
                                 {
                                     merchandiseId: selectedVariant.id,

--- a/packages/osc-ui/src/components/Button/Button.spec.tsx
+++ b/packages/osc-ui/src/components/Button/Button.spec.tsx
@@ -15,7 +15,7 @@ describe('default button', () => {
         };
 
         return (
-            <Button onClick={handleClick} isLoading={loading}>
+            <Button onClick={handleClick} isLoading={loading} loadingText="Loading">
                 Click me
             </Button>
         );

--- a/packages/osc-ui/src/components/Button/Button.tsx
+++ b/packages/osc-ui/src/components/Button/Button.tsx
@@ -137,7 +137,6 @@ export const Button = forwardRef<typeof HTMLElement, ButtonProps>(
             target,
             ...attr
         } = props;
-
         const sizeModifier = useModifier('c-btn', size);
         const variantModifier = useModifier('c-btn', variant);
         const classes = classNames(
@@ -164,14 +163,17 @@ export const Button = forwardRef<typeof HTMLElement, ButtonProps>(
 
         const isBlank = target === '_blank' ? true : false;
 
+        // IF there is loading text then add the spinner in a relative position to the right of it
+        // ELSE there is no loading text absolutely position the spinner in the middle of the button and visually hide the children
         const buttonInner = isLoading ? (
             <span className="c-btn__inner">
                 {loadingText && loadingText}{' '}
-                <span className="c-btn-loader">
+                <span className={`c-btn-loader ${!loadingText ? 'c-btn-loader--absolute' : ''}`}>
                     <span className="c-btn-loader__dot"></span>
                     <span className="c-btn-loader__dot"></span>
                     <span className="c-btn-loader__dot"></span>
                 </span>
+                {!loadingText && <span className="u-vis-hidden">{children}</span>}
             </span>
         ) : (
             <span className="c-btn__inner">{children}</span>

--- a/packages/osc-ui/src/components/Button/Button.tsx
+++ b/packages/osc-ui/src/components/Button/Button.tsx
@@ -94,7 +94,6 @@ export interface SharedButtonProps {
     isInversed?: boolean;
     /**
      * 'Sets the loading text of the button, used in conjunction with `isLoading`'
-     * @default Loading
      */
     loadingText?: string;
     /**
@@ -131,7 +130,7 @@ export const Button = forwardRef<typeof HTMLElement, ButtonProps>(
             isPill,
             isInversed,
             isFull,
-            loadingText = 'Loading',
+            loadingText,
             size = 'md',
             variant = 'primary',
             target,

--- a/packages/osc-ui/src/components/Button/button.scss
+++ b/packages/osc-ui/src/components/Button/button.scss
@@ -538,7 +538,12 @@
     // *----------------------------------*/
     .c-btn-loader {
         display: flex;
+        align-items: center;
         gap: 0.25em;
+
+        &--absolute {
+            position: absolute;
+        }
 
         &__dot {
             width: 2px;

--- a/packages/osc-ui/src/styles/utilities/_anim.scss
+++ b/packages/osc-ui/src/styles/utilities/_anim.scss
@@ -66,8 +66,8 @@
                 linear-gradient(
                     90deg,
                     rgba(#fff, 0) 0,
-                    rgba(#fff, 0.2) 20%,
-                    rgba(#fff, 0.5) 60%,
+                    rgba(#fff, 0.3) 20%,
+                    rgba(#fff, 0.6) 60%,
                     rgba(#fff, 0)
                 );
             transform: translateX(-100%);

--- a/packages/osc-ui/src/styles/utilities/_util.scss
+++ b/packages/osc-ui/src/styles/utilities/_util.scss
@@ -196,6 +196,12 @@ $osc-config: (
         values: (
             "auto": auto
         )
+    ),
+    visibility: (
+        prefix: "vis",
+        values: (
+            hidden
+        )
     )
 );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Attempts to make the pending states of the cart clearer to the user when they are updating the contents.
I've added a spinner to the buttons within the cart, so when they are in a pending state they will show a spinner as well as the shimmer. The opacity of the shimmer has been reduced to make it less subtle.

I've not added a spinner to the button in the product form as when the minicart gets added the `AddToCart` form will become a fetcher and I plan to use some optimistic UI here to add the item to the minicart before the transition has finished. Having a spinner on here when the cart opens will likely lead to the form looking out of sync. If it turns out the optimistic UI isn't the best behaviour then I'll add the spinner as part of that work.

I noticed that the discounted text size was larger than the total on mobile devices so have added a small fix for this in here also.

## ⛳️ Current behavior (updates)

N/a

## 🚀 New behavior

- Adds a condition to the Button to absolutely position the spinner when there is no loading text, this stops the button from changing size as the spinner is much smaller than the text
- Adds spinners to cart buttons when cart is in a pending state
- Makes shimmer animation less transparent
- Tidies up a left over console log and duplicated prop

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
