### PR TITLE
fix: pass the query through as the value for the TextInput

### DIFF
--- a/packages/osc-ecommerce/app/components/InstantSearch/Components/SearchBox.tsx
+++ b/packages/osc-ecommerce/app/components/InstantSearch/Components/SearchBox.tsx
@@ -12,7 +12,7 @@ export const SearchBox = (props: UseSearchBoxProps) => {
         []
     );
 
-    const { refine } = useSearchBox({ ...props, queryHook });
+    const { refine, query } = useSearchBox({ ...props, queryHook });
 
     const ref = useRef<HTMLInputElement>(null);
 
@@ -35,6 +35,7 @@ export const SearchBox = (props: UseSearchBoxProps) => {
                 type="search"
                 onChange={(e: ChangeEvent<HTMLInputElement>) => refine(e.target.value)}
                 ref={ref}
+                value={query}
             />
         </form>
     );


### PR DESCRIPTION
Closes #1118 

## 📝 Description

There is no value when you type into the Searchbox on the InstantSearch page - http://localhost:2000/search

## ⛳️ Current behavior (updates)

As above

## 🚀 New behavior

Enables values to by typed into the Searchbox

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
