### PR TITLE
Feature/sticky header

### DIFF
--- a/packages/osc-ecommerce/app/components/Header/Header.tsx
+++ b/packages/osc-ecommerce/app/components/Header/Header.tsx
@@ -31,7 +31,7 @@ export const SiteHeader = (props: SiteHeaderProps) => {
     }, [menuIsOpen]);
 
     return (
-        <Header>
+        <Header isSticky>
             <Burger
                 id="mob-menu-trigger"
                 label="Open mobile menu"

--- a/packages/osc-ui/src/components/Drawer/drawer.scss
+++ b/packages/osc-ui/src/components/Drawer/drawer.scss
@@ -79,16 +79,6 @@
                         @if $dir == right or $dir == left {
                             top: $drawer-offset;
                             width: calc(100% - #{$drawer-trigger-height});
-
-                            // WHEN the viewport is the combined size of the offset and the max-height
-                            // then reset the offset value
-                            @include mq(
-                                strip-unit($drawer-max-height) + strip-unit($drawer-offset),
-                                max,
-                                height
-                            ) {
-                                top: calc($drawer-offset / 2);
-                            }
                         }
                     }
 
@@ -257,16 +247,6 @@
 
                         &#{$self}--offset {
                             top: $drawer-offset;
-
-                            // WHEN the viewport is the combined size of the offset and the max-height
-                            // then reset the offset value
-                            @include mq(
-                                strip-unit($drawer-max-height) + strip-unit($drawer-offset),
-                                max,
-                                height
-                            ) {
-                                top: calc($drawer-offset / 2);
-                            }
                         }
                     }
 
@@ -290,18 +270,6 @@
                     @if $dir == right or $dir == left {
                         transform: if($dir == right, rotate(90deg), rotate(270deg)); /* [2] */
                         transform-origin: if($dir == right, top left, top right); /* [3] */
-
-                        &#{$self}--offset {
-                            // WHEN the viewport is the combined size of the offset and the max-height
-                            // then reset the offset value
-                            @include mq(
-                                strip-unit($drawer-max-height) + strip-unit($drawer-offset),
-                                max,
-                                height
-                            ) {
-                                top: calc($drawer-offset / 2);
-                            }
-                        }
 
                         /* stylelint-disable-next-line selector-class-pattern, plugin/selector-bem-pattern */
                         > .c-btn__inner {

--- a/packages/osc-ui/src/components/Header/Header.spec.tsx
+++ b/packages/osc-ui/src/components/Header/Header.spec.tsx
@@ -41,6 +41,17 @@ describe('header', () => {
         // Will be 0 as we aren't rendering a proper DOM
         expect(header).toHaveStyle('--header-height: 0px;');
     });
+
+    test('sets the c-header--sticky class when isSticky prop is true', () => {
+        render(
+            <Header isSticky={true}>
+                <Logo />
+            </Header>
+        );
+
+        const header = screen.getByRole('banner');
+        expect(header).toHaveClass('c-header--sticky');
+    });
 });
 
 describe('headerNav', () => {

--- a/packages/osc-ui/src/components/Header/Header.spec.tsx
+++ b/packages/osc-ui/src/components/Header/Header.spec.tsx
@@ -44,13 +44,24 @@ describe('header', () => {
 
     test('sets the c-header--sticky class when isSticky prop is true', () => {
         render(
-            <Header isSticky={true}>
+            <Header isSticky>
                 <Logo />
             </Header>
         );
 
         const header = screen.getByRole('banner');
         expect(header).toHaveClass('c-header--sticky');
+    });
+
+    test('sets inline height when isSticky prop is true', () => {
+        render(
+            <Header isSticky>
+                <Logo />
+            </Header>
+        );
+
+        const header = screen.getByRole('banner');
+        expect(header).toHaveStyle('height: var(--header-height);');
     });
 });
 

--- a/packages/osc-ui/src/components/Header/Header.spec.tsx
+++ b/packages/osc-ui/src/components/Header/Header.spec.tsx
@@ -116,7 +116,7 @@ describe('headerNav', () => {
         );
 
         expect(headerNav).not.toHaveStyle('overflow-y: auto;');
-        expect(document.body).toHaveStyle('overflow-y: auto;');
+        expect(document.body).not.toHaveStyle('overflow-y: hidden;');
     });
 });
 

--- a/packages/osc-ui/src/components/Header/Header.tsx
+++ b/packages/osc-ui/src/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import { useMediaQuery } from '../../hooks/useMediaQuery';
 import { classNames } from '../../utils/classNames';
 import { rem } from '../../utils/rem';
 
+import { useModifier } from '../../hooks/useModifier';
 import './header.scss';
 
 export interface SharedNavProps {
@@ -23,13 +24,21 @@ export interface SharedNavProps {
 /* -------------------------------------------------------------------------------------------------
  * Header
  * -----------------------------------------------------------------------------------------------*/
-export interface HeaderProps extends SharedNavProps, HTMLAttributes<HTMLDivElement> {}
+export interface HeaderProps extends SharedNavProps, HTMLAttributes<HTMLDivElement> {
+    /**
+     * Sets the header to be sticky
+     * @default false
+     */
+    isSticky?: boolean;
+}
 
 export const Header = forwardRef<ElementRef<'header'>, HeaderProps>((props, forwardedRef) => {
-    const { className, children, ...attr } = props;
+    const { className, children, isSticky, ...attr } = props;
     const ref = useRef<HTMLDivElement>(null);
     const headerHeight = useHeight(ref);
-    const classes = classNames('c-header', 'o-container', className);
+
+    const stickyModifier = useModifier('c-header', isSticky && 'sticky');
+    const classes = classNames('c-header', 'o-container', stickyModifier, className);
 
     return (
         <header

--- a/packages/osc-ui/src/components/Header/Header.tsx
+++ b/packages/osc-ui/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import { classNames } from '../../utils/classNames';
 import { rem } from '../../utils/rem';
 
 import { useModifier } from '../../hooks/useModifier';
+import { useScroll } from '../../hooks/useScroll';
 import './header.scss';
 
 export interface SharedNavProps {
@@ -36,9 +37,18 @@ export const Header = forwardRef<ElementRef<'header'>, HeaderProps>((props, forw
     const { className, children, isSticky, ...attr } = props;
     const ref = useRef<HTMLDivElement>(null);
     const headerHeight = useHeight(ref);
+    const scrollPos = useScroll();
+
+    const scrollOffset = 10;
+    const hasTraveledPastOffset = scrollPos > scrollOffset;
 
     const stickyModifier = useModifier('c-header', isSticky && 'sticky');
-    const classes = classNames('c-header', stickyModifier, className);
+    const classes = classNames(
+        'c-header',
+        stickyModifier,
+        isSticky && hasTraveledPastOffset && 'is-scrolled',
+        className
+    );
 
     return (
         <header

--- a/packages/osc-ui/src/components/Header/Header.tsx
+++ b/packages/osc-ui/src/components/Header/Header.tsx
@@ -59,9 +59,13 @@ export const Header = forwardRef<ElementRef<'header'>, HeaderProps>((props, forw
                 ...attr.style,
                 // Set the header height as state so we can use it to help position things such as the nav
                 ['--header-height' as string]: `${headerHeight}px`,
+                // Set a fixed height for the header, this helps us avoid flickering when changing the height when scrolling
+                height: isSticky && headerHeight ? `var(--header-height)` : '',
             }}
         >
-            <div className="c-header__inner o-container">{children}</div>
+            <div className="u-bg-color-tertiary">
+                <div className="c-header__inner o-container">{children}</div>
+            </div>
         </header>
     );
 });

--- a/packages/osc-ui/src/components/Header/Header.tsx
+++ b/packages/osc-ui/src/components/Header/Header.tsx
@@ -38,7 +38,7 @@ export const Header = forwardRef<ElementRef<'header'>, HeaderProps>((props, forw
     const headerHeight = useHeight(ref);
 
     const stickyModifier = useModifier('c-header', isSticky && 'sticky');
-    const classes = classNames('c-header', 'o-container', stickyModifier, className);
+    const classes = classNames('c-header', stickyModifier, className);
 
     return (
         <header
@@ -51,7 +51,7 @@ export const Header = forwardRef<ElementRef<'header'>, HeaderProps>((props, forw
                 ['--header-height' as string]: `${headerHeight}px`,
             }}
         >
-            {children}
+            <div className="c-header__inner o-container">{children}</div>
         </header>
     );
 });

--- a/packages/osc-ui/src/components/Header/header.scss
+++ b/packages/osc-ui/src/components/Header/header.scss
@@ -9,23 +9,27 @@
     .c-header {
         $self: &;
 
-        position: relative;
-        display: grid;
-        align-items: center;
-        grid-template-columns: repeat(3, auto);
-        padding-block: $space-xl;
+        background-color: var(--color-tertiary);
 
         @include z-index("header");
-
-        @include mq($mq-desk) {
-            grid-template-columns: repeat(2, auto);
-            grid-template-rows: repeat(2, 1fr);
-            gap: $space-2xs;
-        }
 
         &--sticky {
             position: sticky;
             top: 0;
+        }
+
+        &__inner {
+            position: relative;
+            padding-block: $space-xl;
+            display: grid;
+            align-items: center;
+            grid-template-columns: repeat(3, auto);
+
+            @include mq($mq-desk) {
+                grid-template-columns: repeat(2, auto);
+                grid-template-rows: repeat(2, 1fr);
+                gap: $space-2xs;
+            }
         }
 
         &__logo {

--- a/packages/osc-ui/src/components/Header/header.scss
+++ b/packages/osc-ui/src/components/Header/header.scss
@@ -23,6 +23,11 @@
             gap: $space-2xs;
         }
 
+        &--sticky {
+            position: sticky;
+            top: 0;
+        }
+
         &__logo {
             margin-inline: auto;
             grid-column: 2 / 3;

--- a/packages/osc-ui/src/components/Header/header.scss
+++ b/packages/osc-ui/src/components/Header/header.scss
@@ -5,11 +5,20 @@
 @layer components {
     $logo-size-s: 192px;
     $logo-size-l: 277px;
+    $header-height: var(--header-height, 0);
+    $header-padding: $space-xl;
+    $header-padding-s: $space-s;
+
+    // Calculate the difference of the padding between the header and the nav
+    // Multiply by two as we need to account for the top and bottom padding
+    // As we're using dynamic sizes we're adding 1px to make up for the decimal value
+    $header-padding-diff: calc((calc(#{$header-padding} - #{$header-padding-s}) * 2) + 1px);
 
     .c-header {
         $self: &;
 
-        background-color: var(--color-tertiary);
+        position: relative;
+        pointer-events: none;
 
         @include z-index("header");
 
@@ -20,15 +29,30 @@
 
         &__inner {
             position: relative;
-            padding-block: $space-xl;
             display: grid;
             align-items: center;
+            transition: padding-block $timing $ease-out-sine;
+            padding-block: $header-padding;
             grid-template-columns: repeat(3, auto);
+            pointer-events: auto;
 
             @include mq($mq-desk) {
                 grid-template-columns: repeat(2, auto);
                 grid-template-rows: repeat(2, 1fr);
                 gap: $space-2xs;
+            }
+
+            .is-scrolled & {
+                @include mq($mq-desk) {
+                    padding-block: $header-padding-s;
+                }
+
+                /* stylelint-disable-next-line selector-class-pattern */
+                .c-nav__content[data-level="0"] {
+                    @include mq($mq-desk) {
+                        top: calc($header-height - $header-padding-diff);
+                    }
+                }
             }
         }
 
@@ -64,7 +88,7 @@
      */
         &__nav {
             position: fixed; /* [1] */
-            top: var(--header-height, 0);
+            top: $header-height;
             right: 0;
             bottom: 0;
             left: 0;
@@ -99,12 +123,13 @@
                 }
             }
 
-            /* stylelint-disable-next-line selector-class-pattern */
+            /* stylelint-disable-next-line selector-class-pattern, no-descending-specificity */
             .c-nav__content[data-level="0"] {
                 left: 0;
+                transition: top $timing $ease-out-sine;
 
                 @include mq($mq-desk) {
-                    top: var(--header-height, 0);
+                    top: $header-height;
                 }
             }
         }

--- a/packages/osc-ui/src/hooks/useScroll.ts
+++ b/packages/osc-ui/src/hooks/useScroll.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Gets the distance scrolled from the top of the page.
+ *
+ * @returns Number of pixels scrolled from the top of the page
+ */
+export const useScroll = () => {
+    const [scrollPosY, setScrollPosY] = useState<number>(0);
+
+    useEffect(() => {
+        let ticking = false;
+
+        const handleScroll = () => {
+            if (!ticking) {
+                window.requestAnimationFrame(() => {
+                    setScrollPosY(window.scrollY);
+
+                    ticking = false;
+                });
+
+                ticking = true;
+            }
+        };
+
+        document.addEventListener('scroll', handleScroll);
+
+        return () => {
+            document.removeEventListener('scroll', handleScroll);
+        };
+    }, []);
+
+    return scrollPosY;
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds support for a sticky header. I've restructured the component slightly to now include a `header__inner` element which houses the grid layout and most of the styling for the header. This is needed to prevent some flickering that was occurring if we just resize the header directly. Instead I'm setting a fixed height on the header and resizing the inner element.

## ⛳️ Current behavior (updates)

- Header is relatively positioned and scrolls with the rest of the page

## 🚀 New behavior

- Adds a `useScroll` hook which allows us to track the scroll position of the window
- Adds `isSticky` prop to the `<Header>`
- Restructures the `<Header>` with a `header__inner` element to prevent flickering resize issue when resizing the parent on scroll

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
