### PR TITLE
Feature/algolia instantsearch sync urls v2

### DIFF
--- a/packages/osc-ecommerce/app/components/InstantSearch/Components/Searchbox.tsx
+++ b/packages/osc-ecommerce/app/components/InstantSearch/Components/Searchbox.tsx
@@ -1,1 +1,0 @@
-                value={query}

--- a/packages/osc-ecommerce/app/components/InstantSearch/Components/Searchbox.tsx
+++ b/packages/osc-ecommerce/app/components/InstantSearch/Components/Searchbox.tsx
@@ -1,0 +1,1 @@
+                value={query}

--- a/packages/osc-ecommerce/app/components/InstantSearch/Widgets/Refinements/RefinementSlider.tsx
+++ b/packages/osc-ecommerce/app/components/InstantSearch/Widgets/Refinements/RefinementSlider.tsx
@@ -25,7 +25,8 @@ interface RangeSliderProps extends UseRangeSliderProps {
 export const RefinementSlider = (props: RangeSliderProps) => {
     const { accordionItem = false, accordionValue, prefix, title } = props;
     // TODO: send range slider event
-    const { range, refine } = useRangeSlider(props);
+    const { range, refine, start } = useRangeSlider(props);
+
     const [minValue, setMinValue] = useState<number>();
     const [maxValue, setMaxValue] = useState<number>();
     const [value, setValue] = useState<number[]>([]);
@@ -41,6 +42,31 @@ export const RefinementSlider = (props: RangeSliderProps) => {
         setMaxValue(range?.max);
         setValue([range?.min, range?.max]);
     }, [range, minValue, maxValue]);
+
+    useEffect(() => {
+        if (typeof range?.min !== 'number' || typeof range?.max !== 'number') return;
+
+        // Check whether numbers are finite (the defaults are '-Infinity/Infinity' respectively)
+        const START = Number.isFinite(start[0]) && start[0];
+        const END = Number.isFinite(start[1]) && start[1];
+
+        // If END is defined but larger than the max range then set range max.
+        if (END && (END as number) > range.max) {
+            return setValue([START || range.min, range.max]);
+        }
+
+        // Set value in accordance to which values have been set
+        if (START && !END) {
+            return setValue([START, range.max]);
+        }
+        if (!START && END) {
+            return setValue([range.min, END]);
+        }
+        if (START && END) {
+            return setValue([START, END]);
+        }
+        setValue([range?.min, range?.max]);
+    }, [range, start]);
 
     if (typeof range?.min !== 'number' || typeof range?.max !== 'number') return null;
 

--- a/packages/osc-ecommerce/app/components/InstantSearch/Widgets/Refinements/SortBy.tsx
+++ b/packages/osc-ecommerce/app/components/InstantSearch/Widgets/Refinements/SortBy.tsx
@@ -10,7 +10,7 @@ interface SortByProps {
 
 export function SortBy(props: SortByProps) {
     const { items } = props;
-    const { options, refine } = useSortBy({ items });
+    const { options, refine, currentRefinement } = useSortBy({ items });
 
     const handleCheckboxChange = (event: string) => refine(event);
 
@@ -21,6 +21,7 @@ export function SortBy(props: SortByProps) {
             name={'sortBy_select'}
             setExternalValue={handleCheckboxChange}
             groupVariants={['inline', 'tertiary']}
+            value={currentRefinement}
         >
             {options.map((item, index) => {
                 return (

--- a/packages/osc-ecommerce/app/components/InstantSearch/data.ts
+++ b/packages/osc-ecommerce/app/components/InstantSearch/data.ts
@@ -41,7 +41,6 @@ export const REFINEMENT_DATA: RefinementData[] = [
         accordionValue: 'price',
         attribute: 'price',
         prefix: '£',
-        start: [100, 200],
         type: 'slider',
         title: 'Price',
     },

--- a/packages/osc-ecommerce/app/components/InstantSearch/utils/getRefinementWidget.tsx
+++ b/packages/osc-ecommerce/app/components/InstantSearch/utils/getRefinementWidget.tsx
@@ -23,7 +23,6 @@ export const getRefinementWidget = (refinement: RefinementData, index: number) =
                     accordionValue={refinement?.accordionValue}
                     attribute={refinement.attribute}
                     prefix={refinement.prefix}
-                    start={refinement.start}
                     title={refinement.title}
                 />
             );

--- a/packages/osc-ecommerce/app/components/InstantSearch/utils/search-routing.ts
+++ b/packages/osc-ecommerce/app/components/InstantSearch/utils/search-routing.ts
@@ -27,7 +27,7 @@ const router = (serverUrl: string) => {
             const urlParts = location.href.match(/^(.*?)\/search/);
             const baseUrl = `${urlParts ? urlParts[1] : ''}/`;
             const queryParameters: Partial<QueryParameters> = {};
-            console.log('RS', qsModule);
+
             if (routeState.query) {
                 queryParameters.query = encodeURIComponent(routeState.query as string);
             }
@@ -37,7 +37,6 @@ const router = (serverUrl: string) => {
                         .filter((q) => q)
                         .map(encodeURIComponent);
                 } else {
-                    console.log('routeState.price', routeState.price);
                     queryParameters.price = (routeState.price as string)
                         .split(':')
                         .map((value) => {

--- a/packages/osc-ecommerce/app/components/InstantSearch/utils/search-routing.ts
+++ b/packages/osc-ecommerce/app/components/InstantSearch/utils/search-routing.ts
@@ -1,0 +1,121 @@
+import { history } from 'instantsearch.js/es/lib/routers';
+import type { UiState } from 'instantsearch.js';
+import { SORTING_INDEXES } from '../data';
+
+interface QueryParameters {
+    award: string[];
+    awarding_body: string[];
+    query: string;
+    price: string[];
+    study_method: string[];
+    sortBy: string;
+}
+
+const router = (serverUrl: string) => {
+    return history({
+        getLocation: () => {
+            return typeof document === 'undefined'
+                ? (new URL(serverUrl!) as unknown as Location)
+                : window.location;
+        },
+        windowTitle({ query }) {
+            const queryTitle = query ? `Results for "${query}"` : 'Search';
+            return queryTitle;
+        },
+
+        createURL({ qsModule, routeState, location }) {
+            const urlParts = location.href.match(/^(.*?)\/search/);
+            const baseUrl = `${urlParts ? urlParts[1] : ''}/`;
+            const queryParameters: Partial<QueryParameters> = {};
+            console.log('RS', qsModule);
+            if (routeState.query) {
+                queryParameters.query = encodeURIComponent(routeState.query as string);
+            }
+            if (routeState.price && (routeState.price as []).length > 0) {
+                if (Array.isArray(routeState.price)) {
+                    queryParameters.price = (routeState.price as string[])
+                        .filter((q) => q)
+                        .map(encodeURIComponent);
+                } else {
+                    console.log('routeState.price', routeState.price);
+                    queryParameters.price = (routeState.price as string)
+                        .split(':')
+                        .map((value) => {
+                            return value;
+                        })
+                        .map(encodeURIComponent);
+                }
+            }
+
+            if (routeState.award) {
+                queryParameters.award = (routeState.award as string[]).map(encodeURIComponent);
+            }
+            if (routeState.awarding_body) {
+                queryParameters.awarding_body = (routeState.awarding_body as string[]).map(
+                    encodeURIComponent
+                );
+            }
+            if (routeState.study_method) {
+                queryParameters.study_method = (routeState.study_method as string[]).map(
+                    encodeURIComponent
+                );
+            }
+            if (routeState.sortBy) {
+                const index = SORTING_INDEXES.find((index) => index.value === routeState.sortBy);
+                if (index) {
+                    queryParameters.sortBy = encodeURIComponent(index.label);
+                }
+            }
+            const queryString = qsModule.stringify(queryParameters, {
+                addQueryPrefix: true,
+                arrayFormat: 'repeat',
+            });
+
+            return `${baseUrl}search/${queryString}`;
+        },
+
+        parseURL({ qsModule, location }) {
+            const {
+                award = [],
+                awarding_body = [],
+                query = '',
+                price = [],
+                sortBy = '',
+                study_method = [],
+            } = qsModule.parse(location.search.slice(1));
+
+            // `qs` does not return an array when there's a single value.
+            const allAwards = Array.isArray(award)
+                ? (award as string[])
+                : ([award].filter(Boolean) as string[]);
+            const awardingBodies = Array.isArray(awarding_body)
+                ? (awarding_body as string[])
+                : ([awarding_body].filter(Boolean) as string[]);
+            const studyMethods = Array.isArray(study_method)
+                ? (study_method as string[])
+                : ([study_method].filter(Boolean) as string[]);
+            const prices = Array.isArray(price)
+                ? (price as string[])
+                : ([price].filter(Boolean) as string[]);
+
+            const res = {
+                award: allAwards.map(decodeURIComponent),
+                awarding_body: awardingBodies.map(decodeURIComponent),
+                query: decodeURIComponent(query as string),
+                study_method: studyMethods.map(decodeURIComponent),
+                sortBy: SORTING_INDEXES.find(
+                    (index) => index.label === decodeURIComponent(sortBy as string)
+                )?.value,
+                price: prices.map(decodeURIComponent),
+            } as UiState;
+
+            return res;
+        },
+    });
+};
+
+const searchRouting = {
+    router: (serverUrl: string) => router(serverUrl),
+};
+
+export default searchRouting;

--- a/packages/osc-ecommerce/app/components/InstantSearch/utils/search-routing.ts
+++ b/packages/osc-ecommerce/app/components/InstantSearch/utils/search-routing.ts
@@ -1,6 +1,7 @@
 import { history } from 'instantsearch.js/es/lib/routers';
 import type { UiState } from 'instantsearch.js';
 import { SORTING_INDEXES } from '../data';
+import type QueryString from 'qs';
 
 interface QueryParameters {
     award: string[];
@@ -83,19 +84,19 @@ const router = (serverUrl: string) => {
                 study_method = [],
             } = qsModule.parse(location.search.slice(1));
 
+            /**
+             * Ensures return value is an array
+             */
+            const asArray = (
+                value: string | string[] | QueryString.ParsedQs | QueryString.ParsedQs[]
+            ) =>
+                Array.isArray(value) ? (value as string[]) : ([value].filter(Boolean) as string[]);
+
             // `qs` does not return an array when there's a single value.
-            const allAwards = Array.isArray(award)
-                ? (award as string[])
-                : ([award].filter(Boolean) as string[]);
-            const awardingBodies = Array.isArray(awarding_body)
-                ? (awarding_body as string[])
-                : ([awarding_body].filter(Boolean) as string[]);
-            const studyMethods = Array.isArray(study_method)
-                ? (study_method as string[])
-                : ([study_method].filter(Boolean) as string[]);
-            const prices = Array.isArray(price)
-                ? (price as string[])
-                : ([price].filter(Boolean) as string[]);
+            const allAwards = asArray(award);
+            const awardingBodies = asArray(awarding_body);
+            const studyMethods = asArray(study_method);
+            const prices = asArray(price);
 
             const res = {
                 award: allAwards.map(decodeURIComponent),

--- a/packages/osc-ecommerce/remix.config.js
+++ b/packages/osc-ecommerce/remix.config.js
@@ -9,6 +9,7 @@ module.exports = {
     devServerPort: 8002,
     serverDependenciesToBundle: [
         'instantsearch.js/es/connectors',
+        'instantsearch.js/es/lib/routers',
         /^osc-ui\/dist\/.*\.svg$/, // match svg files in dist folder, this prevents the unhandled token error being thrown
     ],
     future: {

--- a/packages/osc-ui/src/components/Slider/Slider.tsx
+++ b/packages/osc-ui/src/components/Slider/Slider.tsx
@@ -43,7 +43,7 @@ export const Slider = forwardRef<ElementRef<typeof SliderPrimitive.Root>, Slider
         const { className, name, prefix, setExternalValue, variants, ...rest } = props;
         const [value, setValue] = useState<number[]>();
 
-        const sliderValues = value || props.value || props.defaultValue;
+        const sliderValues = props.value || value || props.defaultValue;
 
         const modifier = useModifier('c-slider', variants);
         const sliderClasses = classNames(`c-slider`, modifier, className);


### PR DESCRIPTION
Closes #202 

## 📝 Description

Enables the url search params to be built and shared as a user refines their search results. It also enables the usage of forward/backward navigation to step through each step of refinement. 

You can read more here - https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/react-hooks/

## ⛳️ Current behavior (updates)

Instantsearch just refines results but does not update the URL.

## 🚀 New behavior

The URL will get updated each time the user does any kind of search refinement.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


