### PR TITLE
feat: added validation from order

### DIFF
--- a/packages/osc-api-auth/src/resolvers/resolver.ts
+++ b/packages/osc-api-auth/src/resolvers/resolver.ts
@@ -85,5 +85,11 @@ export const resolvers = {
         ) => {
             return social.createUserSocial(input, user!.id);
         },
+        validateFromorder: async (_: undefined, { magicKeyToken }: magicKeyArgs) => {
+            return account.validateFromOrder(magicKeyToken);
+        },
+        updatePasswordFromOrder: async (_: undefined, { input }: completeResetPasswordArgs) => {
+            return account.UpdatePasswordFromOrder(input);
+        },
     },
 };

--- a/packages/osc-api-auth/src/schemas/schema.ts
+++ b/packages/osc-api-auth/src/schemas/schema.ts
@@ -196,5 +196,7 @@ export const typeDefs = gql`
         socialLoginCreate(input: socialLoginCreateInput): Boolean
         validateTutor(magicKeyToken: String!): [CourseTutor]
         completeTutorCreate(input: completeTutorCreate!): User
+        validateFromOrder(magicKeyToken: String!): User
+        updatePasswordFromOrder(input: passwordResetInput!): User
     }
 `;

--- a/packages/osc-api-auth/src/types/arguments.ts
+++ b/packages/osc-api-auth/src/types/arguments.ts
@@ -75,6 +75,11 @@ export type passwordResetInput = {
     readonly password: string;
 };
 
+export type passwordUpdateInput = {
+    readonly userId: number;
+    readonly password: string;
+};
+
 export type ResetRequestArgs = {
     readonly email: string;
 };

--- a/packages/osc-api-auth/src/types/functions.ts
+++ b/packages/osc-api-auth/src/types/functions.ts
@@ -11,6 +11,7 @@ import type {
     createTutorInput,
     completeTutorCreate,
     createUserSocialInput,
+    passwordUpdateInput,
 } from './arguments';
 import type { PermissionsProps } from './interfaces';
 
@@ -41,6 +42,8 @@ export type VerifyFn = (magicKeyToken: string) => Promise<number | false>;
 export type VerifyLinkFn = (magicKeyToken: string) => Promise<User | Error | null>;
 export type ResetRequestFn = (email: string) => Promise<Boolean | Error>;
 export type PasswordResetFn = (input: passwordResetInput) => Promise<User | Error>;
+export type UpdatePasswordFn = (input: passwordUpdateInput) => Promise<User | Error>;
+export type UpdatePasswordFromOrderFn = (input: passwordResetInput) => Promise<User | Error>;
 
 export type UserProfileFn = (userId: number) => Promise<{
     avatar: UserAvatar | null;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #882 
Closes #883  <!-- Github issue # here -->

## 📝 Description

After a user has created an order they are sent a magic link.
This magic link is used to return back user data and then the user can create/update their password

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

Mutation
- validateFromOrder - send a magic key token and receive user details
- updatePasswordFromOrder - send magic link and password to complete creation of a user

Consolidated the updatePassword functionality into a separate function to remove repeated code

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
